### PR TITLE
Add support for DaVinci Resolve via fcp7 xml

### DIFF
--- a/.claude/skills/roughcut/SKILL.md
+++ b/.claude/skills/roughcut/SKILL.md
@@ -127,10 +127,25 @@ Using the user's preferences as your guide, consider:
 - Confirm the narrative flow makes sense
 - Trust your judgment - you're the editor making something watchable
 
-### 5. Export to Final Cut Pro XML
-- After creating the YAML rough cut, immediately export to FCPXML format
-- Always use `.fcpxml` extension, not xml.
-- Run the export script:
+### 5. Export to Video Editor XML
+
+**Ask User for Editor Preference:**
+- Use the AskUserQuestion tool to ask which video editor they want to use
+- Provide three options:
+  - **Final Cut Pro X**: Uses FCPXML 1.8 format (`.fcpxml` extension)
+  - **Adobe Premiere Pro**: Uses xmeml version 5 format (`.xml` extension)
+  - **DaVinci Resolve**: Uses xmeml version 5 format (`.xml` extension)
+
+**Export Based on Editor Choice:**
+- After creating the YAML rough cut, immediately export to the appropriate format
+- Run the export script with the editor parameter:
 ```bash
-./.claude/skills/roughcut/export_to_fcpxml.rb libraries/[library-name]/roughcuts/[roughcut_name]_datetime1.yaml libraries/[library-name]/roughcuts/[roughcut_name]_datetime1.fcpxml
+# For Final Cut Pro X:
+./.claude/skills/roughcut/export_to_fcpxml.rb libraries/[library-name]/roughcuts/[roughcut_name]_datetime1.yaml libraries/[library-name]/roughcuts/[roughcut_name]_datetime1.fcpxml fcpx
+
+# For Adobe Premiere Pro:
+./.claude/skills/roughcut/export_to_fcpxml.rb libraries/[library-name]/roughcuts/[roughcut_name]_datetime1.yaml libraries/[library-name]/roughcuts/[roughcut_name]_datetime1.xml premiere
+
+# For DaVinci Resolve:
+./.claude/skills/roughcut/export_to_fcpxml.rb libraries/[library-name]/roughcuts/[roughcut_name]_datetime1.yaml libraries/[library-name]/roughcuts/[roughcut_name]_datetime1.xml resolve
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ The project has two main components:
 
 Currently supports:
 - **Final Cut Pro X** (FCPXML 1.8 format)
-- **Final Cut Pro 7 / Adobe Premiere Pro** (xmeml version 5)
+- **Adobe Premiere Pro** (xmeml version 5)
+- **DaVinci Resolve** (xmeml version 5)
 
 ## Core Workflow
 
@@ -75,7 +76,7 @@ Each library has a `library.yaml` file that serves as your persistent memory and
 - `lib/buttercut.rb` - Factory class that creates editor-specific generators
 - `lib/buttercut/editor_base.rb` - Shared validation, metadata extraction, and timeline math
 - `lib/buttercut/fcpx.rb` - Final Cut Pro X implementation (FCPXML 1.8)
-- `lib/buttercut/fcp7.rb` - Final Cut Pro 7 / Premiere implementation (xmeml v5)
+- `lib/buttercut/fcp7.rb` - Final Cut Pro 7 / Premiere / DaVinci Resolve implementation (xmeml v5)
 - `.claude/skills/` - Claude Code skills for AI-powered workflow
 - `spec/` - RSpec test suite
 - `templates/` - Library and project templates

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 *Click to watch the ButterCut demo on YouTube*
 
 ## Edit video with Claude Code
-ButterCut analyzes footage and builds roughcuts or sequences for Final Cut Pro and Adobe Premiere.
+ButterCut analyzes footage and builds roughcuts or sequences for Final Cut Pro, Adobe Premiere, and DaVinci Resolve.
 
 Two pieces work together to make this go: ButterCut, The Ruby gem. And ButterCut, the Claude Code Skills.
 
@@ -99,7 +99,7 @@ whisperx --help
 | Editor Symbol | Format | Typical Import Target |
 | ------------- | ------ | --------------------- |
 | `:fcpx`       | FCPXML 1.8 | Final Cut Pro X |
-| `:fcp7`       | xmeml version 5 | Final Cut Pro 7 / Adobe Premiere Pro |
+| `:fcp7`       | xmeml version 5 | Final Cut Pro 7 / Adobe Premiere Pro / DaVinci Resolve |
 
 ## Usage
 
@@ -151,12 +151,19 @@ Claude: [Asks 3 preference questions]
 You: "Start with presentations (5 sec clips), then interviews,
       then my closing reflection. 3-5 minutes, conversational pacing."
 
+Claude: [Asks which video editor you want to use]
+        - Final Cut Pro X
+        - Adobe Premiere Pro
+        - DaVinci Resolve
+
+You: "Final Cut Pro X"
+
 Claude: [Creates roughcut with editorial decisions]
         ✓ Combined visual transcripts
         ✓ Selected 29 clips (4:32 total)
         ✓ Exported to FCPXML
 
-Result: Ready-to-import Final Cut Pro timeline at:
+Result: Ready-to-import timeline at:
         libraries/[library]/roughcuts/[name]_[datetime].fcpxml
 ```
 
@@ -178,8 +185,7 @@ videos = [
 fcpx_generator = ButterCut.new(videos, editor: :fcpx)
 fcpx_generator.save('timeline.fcpxml')
 
-# Final Cut Pro 7 / Adobe Premiere timeline
-# This opened up correctly for me, but this isn't really tested yet.
+# Final Cut Pro 7 / Adobe Premiere / DaVinci Resolve timeline
 fcp7_generator = ButterCut.new(videos, editor: :fcp7)
 fcp7_generator.save('timeline.xml')
 ```


### PR DESCRIPTION
DaVinci Resolve seems happy to open up both FCP7 and FCPX files. I'm guessing FCP7 will feel a bit more native (no magnetic timeline) to Resolve so going to guide ButterCut to generate FCP7 xml files for Resolve users. 

This closes #7 