### PR TITLE
Add hundredths-of-second timestamp precision to roughcuts

### DIFF
--- a/.claude/skills/roughcut/agent_instructions.md
+++ b/.claude/skills/roughcut/agent_instructions.md
@@ -95,14 +95,14 @@ cp templates/roughcut_template.yaml "libraries/[library-name]/roughcuts/[roughcu
 
 **Build clips based on user's request:**
 - Use the user's stated goals to guide editorial decisions
-- Convert timestamps from seconds to `HH:MM:SS` format (round to nearest second)
+- Convert timestamps from seconds to `HH:MM:SS.ss` format (hundredths of second precision)
 - Reference video files using `source_file` from the combined JSON
 
 **CRITICAL - Timecode Logic:**
 - `in_point`: Start time of FIRST segment you want
 - `out_point`: End time of LAST segment you want
-- Use `start` and `end` from segments
-- Example: segment at 2.849s-29.63s → in_point: `00:00:02`, out_point: `00:00:29`
+- Use `start` and `end` from segments directly (preserve sub-second precision)
+- Example: segment at 2.849s-29.63s → in_point: `00:00:02.85`, out_point: `00:00:29.63`
 
 **CRITICAL - Required Fields:**
 Each clip needs:
@@ -111,7 +111,7 @@ Each clip needs:
 
 **Metadata:**
 - `created_date`: `YYYY-MM-DD HH:MM:SS`
-- `total_duration`: Sum of all clips in `HH:MM:SS` format
+- `total_duration`: Sum of all clips in `HH:MM:SS.ss` format
 
 ### 5. Export to Video Editor
 

--- a/.claude/skills/roughcut/export_to_fcpxml.rb
+++ b/.claude/skills/roughcut/export_to_fcpxml.rb
@@ -4,9 +4,11 @@
 require 'yaml'
 
 def timecode_to_seconds(timecode)
-  # Convert HH:MM:SS to seconds
-  parts = timecode.split(':').map(&:to_i)
-  hours, minutes, seconds = parts
+  # Convert HH:MM:SS or HH:MM:SS.s to seconds (supports decimal seconds)
+  parts = timecode.split(':')
+  hours = parts[0].to_i
+  minutes = parts[1].to_i
+  seconds = parts[2].to_f  # to_f handles both "03" and "03.5"
   hours * 3600 + minutes * 60 + seconds
 end
 

--- a/templates/roughcut_template.yaml
+++ b/templates/roughcut_template.yaml
@@ -25,14 +25,14 @@ footage_coverage: |
 clips:
   # Example clip structure (replace with actual selections)
   - source_file: "DJI_20250423171212_0210_D.mov"  # filename only, path comes from library.yaml
-    in_point: "00:00:03"      # Start time in HH:MM:SS format
-    out_point: "00:00:28"      # End time in HH:MM:SS format
+    in_point: "00:00:02.92"     # Start time in HH:MM:SS.ss format (hundredths precision)
+    out_point: "00:00:28.35"    # End time in HH:MM:SS.ss format
     dialogue: "In order to tell this one, I've got to zoom back about 10, 12, 13 years ago to when I barely just moved to San Francisco"
     visual_description: "[Man with mustache speaking directly to camera in medium-close shot. Outdoor urban SF street setting with residential buildings in background. Tan corduroy jacket. Handheld camera.]"
 
   - source_file: "DJI_20250423174726_0238_D.mov"
-    in_point: "00:00:00"
-    out_point: "00:00:05"
+    in_point: "00:00:00.00"
+    out_point: "00:00:05.24"
     dialogue: ""
     visual_description: "[POV from inside San Francisco Muni bus looking out window at passing street. Yellow safety handrails visible. Transit journey B-roll.]"
 


### PR DESCRIPTION
Previously timestamps were rounded to whole seconds (HH:MM:SS), losing up to 500ms of precision per cut point. Now uses HH:MM:SS.ss format which preserves timing within ~10ms of WhisperX transcript data.

Practically, this just means much, much smoother editing of segments (still work to do to cut segments up to word by word cuts) with more coherent dialogue.

Changes:
- export_to_fcpxml.rb: Parse decimal seconds with .to_f
- agent_instructions.md: Specify HH:MM:SS.ss format
- roughcut_template.yaml: Update examples with hundredths
