### PR TITLE
Simplify library.yaml transcript fields, improve timestamp precision (v0.3.0)

### DIFF
--- a/.claude/skills/analyze-video/SKILL.md
+++ b/.claude/skills/analyze-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze-video
-description: Adds visual descriptions to transcripts by extracting and analyzing video frames with ffmpeg. Creates visual transcript with periodic visual descriptions of the video clip. Use when all files have audio transcripts present (transcript_path) but but don't yet have visual transcripts created (visual_transcript_path).
+description: Adds visual descriptions to transcripts by extracting and analyzing video frames with ffmpeg. Creates visual transcript with periodic visual descriptions of the video clip. Use when all files have audio transcripts present (transcript) but don't yet have visual transcripts created (visual_transcript).
 ---
 
 # Skill: Analyze Video

--- a/.claude/skills/roughcut/SKILL.md
+++ b/.claude/skills/roughcut/SKILL.md
@@ -20,8 +20,8 @@ Before launching the roughcut agent, verify all transcripts are complete:
 
 2. **Verify visual transcripts:**
    Read `libraries/[library-name]/library.yaml` and check that every video entry has both:
-   - `transcript_path` populated (audio transcript)
-   - `visual_transcript_path` populated (visual descriptions)
+   - `transcript` populated (audio transcript filename)
+   - `visual_transcript` populated (visual descriptions filename)
 
    If any visual transcripts are missing:
    - Inform user that transcript processing must be completed first

--- a/.claude/skills/roughcut/agent_instructions.md
+++ b/.claude/skills/roughcut/agent_instructions.md
@@ -95,14 +95,14 @@ cp templates/roughcut_template.yaml "libraries/[library-name]/roughcuts/[roughcu
 
 **Build clips based on user's request:**
 - Use the user's stated goals to guide editorial decisions
-- Convert timestamps from seconds to `HH:MM:SS` format (round to nearest second)
+- Convert timestamps from seconds to `HH:MM:SS.ss` format (hundredths of second precision)
 - Reference video files using `source_file` from the combined JSON
 
 **CRITICAL - Timecode Logic:**
 - `in_point`: Start time of FIRST segment you want
 - `out_point`: End time of LAST segment you want
-- Use `start` and `end` from segments
-- Example: segment at 2.849s-29.63s → in_point: `00:00:02`, out_point: `00:00:29`
+- Use `start` and `end` from segments directly (preserve sub-second precision)
+- Example: segment at 2.849s-29.63s → in_point: `00:00:02.85`, out_point: `00:00:29.63`
 
 **CRITICAL - Required Fields:**
 Each clip needs:
@@ -111,7 +111,7 @@ Each clip needs:
 
 **Metadata:**
 - `created_date`: `YYYY-MM-DD HH:MM:SS`
-- `total_duration`: Sum of all clips in `HH:MM:SS` format
+- `total_duration`: Sum of all clips in `HH:MM:SS.ss` format
 
 ### 5. Export to Video Editor
 

--- a/.claude/skills/roughcut/export_to_fcpxml.rb
+++ b/.claude/skills/roughcut/export_to_fcpxml.rb
@@ -4,9 +4,11 @@
 require 'yaml'
 
 def timecode_to_seconds(timecode)
-  # Convert HH:MM:SS to seconds
-  parts = timecode.split(':').map(&:to_i)
-  hours, minutes, seconds = parts
+  # Convert HH:MM:SS or HH:MM:SS.s to seconds (supports decimal seconds)
+  parts = timecode.split(':')
+  hours = parts[0].to_i
+  minutes = parts[1].to_i
+  seconds = parts[2].to_f  # to_f handles both "03" and "03.5"
   hours * 3600 + minutes * 60 + seconds
 end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to ButterCut will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-12-01
+
+### Changed
+- **BREAKING**: Simplified library.yaml transcript fields
+  - `transcript_path` → `transcript` (filename only, not full path)
+  - `visual_transcript_path` → `visual_transcript` (filename only, not full path)
+  - Transcripts are always stored in `libraries/[library-name]/transcripts/`
+  - Reduces library.yaml size by ~45% for large libraries
+- **Hundredths-of-second timestamp precision** in roughcuts
+  - Timestamps now use `HH:MM:SS.ss` format instead of `HH:MM:SS`
+  - Preserves timing within ~10ms of WhisperX transcript data
+  - Prevents clipping words at edit points
+
+### Removed
+- `file_size_mb` field from library.yaml (not used for editorial decisions)
+
+### Migration
+```bash
+# Back up your libraries first (creates ZIP in /backups/)
+ruby .claude/skills/backup-library/backup_libraries.rb
+
+# Migrate library.yaml files to new field names
+ruby scripts/001_migrate_0.2_to_0.3.rb --all
+```
+
 ## [0.2.0] - 2025-11-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ You are an AI video editor assistant working with a software engineer. You gener
 3. **Edit** → Use `roughcut` skill to create timeline scripts from transcripts
    - **Rough cuts**: Multi-minute edits for full videos (typically 3-15+ minutes)
    - **Sequences**: 30-60 second clips that user will build to be imported into a larger video (created using the same roughcut skill with shorter target duration)
-   - **PREREQUISITE:** Check library.yaml to verify all videos have visual_transcript_path populated
+   - **PREREQUISITE:** Check library.yaml to verify all videos have visual_transcript populated
 4. **Backup** → Use `backup-library` skill to create compressed archives of all libraries
    - Creates timestamped ZIP backup of entire libraries directory
    - Backups are stored in `/backups/` and excluded from git
@@ -98,9 +98,9 @@ Note: A single `/tmp/` directory at the root is used for all temporary files. Cr
 Duplicate `templates/library_template.yaml` to create `libraries/[library-name]/library.yaml`:
 
 For each video file:
-1. Use `ffprobe` to get duration and file size
-2. Add entry to library.yaml with empty `transcript_path` and `visual_transcript_path`
-3. Empty paths mean "todo", valid paths mean "done"
+1. Use `ffprobe` to get duration
+2. Add entry to library.yaml with empty `transcript` and `visual_transcript`
+3. Empty fields mean "todo", valid filenames mean "done"
 
 The `language` field stores the language code for all videos in this library.
 
@@ -113,15 +113,15 @@ After library setup completes, **automatically start analyzing all footage**:
 1. Inform user: "Library setup complete. Found [N] videos ([total size]). Starting footage analysis..."
 2. Read library.yaml to get language code and find videos needing transcription
 3. Launch `transcribe-audio` agents (can run in parallel for multiple videos)
-4. As each agent completes, update library.yaml with `transcript_path`
+4. As each agent completes, update library.yaml with `transcript` (filename only, not full path)
 5. After all audio transcripts complete, launch `analyze-video` agents (can run in parallel)
-6. As each agent completes, update library.yaml with `visual_transcript_path`
+6. As each agent completes, update library.yaml with `visual_transcript` (filename only, not full path)
 7. Analyze ALL videos before offering to create rough cuts
 8. **After all analysis completes, automatically create a backup** using the `backup-library` skill
 
 **Terminology:**
 - User-facing: Call it "footage analysis" or "analyzing footage"
-- Internal/file names: Use "transcription" (library.yaml, transcript_path, etc.)
+- Internal/file names: Use "transcription" (library.yaml, transcript, etc.)
 
 **If user requests rough cut before analysis completes:**
 - Warn: "I can create a rough cut now, but I'll do a better job after analyzing all the footage. Continue anyway?"
@@ -156,9 +156,11 @@ When processing multiple videos, use parallel agents for maximum throughput:
 
 Each library has a `library.yaml` file that serves as your persistent memory and the SOURCE OF TRUTH. This file contains all library metadata, footage descriptions, transcription status, and key learnings. Always read this file when working on a library and you need guidance for how/where to save files.
 
+**If library structure seems wrong, check CHANGELOG.md.** The library.yaml format has evolved over versions. If you encounter unexpected field names (like `transcript_path` instead of `transcript`), read CHANGELOG.md to understand breaking changes and available migration scripts.
+
 **Use actual filenames.** Never use generic labels like "Video 1" or "Clip A" - always reference actual filenames like "DJI_20250423171212_0210_D.mov" for clear traceability.
 
-**Visual transcripts are mandatory.** Before creating any rough cut or sequence, verify ALL videos have both audio and visual transcripts. Check `library.yaml` - every video entry must have a `visual_transcript_path` with a file path (not empty or null or ""). Visual descriptions are essential for shot selection, pacing decisions, and B-roll placement.
+**Visual transcripts are mandatory.** Before creating any rough cut or sequence, verify ALL videos have both audio and visual transcripts. Check `library.yaml` - every video entry must have a `visual_transcript` with a filename (not empty or null or ""). Transcripts are stored in `libraries/[library-name]/transcripts/`. Visual descriptions are essential for shot selection, pacing decisions, and B-roll placement.
 
 **Be curious and ask questions.** Occasionally ask users questions about their libraries and footage to better understand context, creative intent, and preferences. When you receive answers, add this information to the `user_context` key in the library.yaml file. This builds institutional knowledge that improves future rough cut and sequence decisions and helps maintain continuity across editing sessions.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buttercut (0.2.0)
+    buttercut (0.3.0)
       nokogiri (~> 1.13)
       rubyzip (~> 2.3)
 

--- a/lib/buttercut/version.rb
+++ b/lib/buttercut/version.rb
@@ -1,3 +1,3 @@
 class ButterCut
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/scripts/001_migrate_0.2_to_0.3.rb
+++ b/scripts/001_migrate_0.2_to_0.3.rb
@@ -1,0 +1,90 @@
+#!/usr/bin/env ruby
+# Migration script: Convert full transcript paths to filenames in library.yaml
+#
+# Before:
+#   transcript_path: "/Users/.../transcripts/video.json"
+#   visual_transcript_path: "/Users/.../transcripts/visual_video.json"
+#
+# After:
+#   transcript: "video.json"
+#   visual_transcript: "visual_video.json"
+#
+# Usage: ruby scripts/migrate_library_yaml.rb [library_name]
+#        ruby scripts/migrate_library_yaml.rb --all
+
+require 'yaml'
+require 'fileutils'
+
+def migrate_library(library_path)
+  unless File.exist?(library_path)
+    puts "  ✗ Not found: #{library_path}"
+    return false
+  end
+
+  content = File.read(library_path)
+  data = YAML.load(content, permitted_classes: [Date, Time, Symbol])
+
+  return false unless data['videos']
+
+  changes = 0
+  data['videos'].each do |video|
+    # Migrate transcript_path -> transcript
+    if video['transcript_path']
+      video['transcript'] = File.basename(video['transcript_path'])
+      video.delete('transcript_path')
+      changes += 1
+    end
+
+    # Migrate visual_transcript_path -> visual_transcript
+    if video['visual_transcript_path']
+      video['visual_transcript'] = File.basename(video['visual_transcript_path'])
+      video.delete('visual_transcript_path')
+      changes += 1
+    end
+
+    # Remove file_size_mb (no longer needed)
+    if video['file_size_mb']
+      video.delete('file_size_mb')
+      changes += 1
+    end
+  end
+
+  if changes > 0
+    # Write migrated file
+    File.write(library_path, data.to_yaml)
+    puts "  ✓ Migrated #{changes} fields"
+    true
+  else
+    puts "  - No changes needed"
+    false
+  end
+end
+
+def find_libraries
+  Dir.glob("libraries/*/library.yaml")
+end
+
+# Main
+if ARGV.empty?
+  puts "Usage: ruby scripts/migrate_library_yaml.rb [library_name]"
+  puts "       ruby scripts/migrate_library_yaml.rb --all"
+  exit 1
+end
+
+if ARGV[0] == '--all'
+  libraries = find_libraries
+  puts "Migrating #{libraries.length} libraries...\n\n"
+
+  libraries.each do |lib_path|
+    lib_name = lib_path.split('/')[1]
+    puts "#{lib_name}:"
+    migrate_library(lib_path)
+  end
+else
+  library_name = ARGV[0]
+  library_path = "libraries/#{library_name}/library.yaml"
+  puts "#{library_name}:"
+  migrate_library(library_path)
+end
+
+puts "\nMigration complete."

--- a/templates/library_template.yaml
+++ b/templates/library_template.yaml
@@ -16,6 +16,5 @@ footage_summary: "No footage analyzed yet."
 videos:
   - path: /full/path/to/video_file.mp4
     duration: "00:05:32"
-    file_size_mb: 245
-    transcript_path: # path to saved transcript
-    visual_transcript_path: # path to saved transcript that has been annotated with visual video frame descriptions
+    transcript: # filename only (stored in libraries/[library-name]/transcripts/)
+    visual_transcript: # filename only (visual_*.json with frame descriptions)

--- a/templates/roughcut_template.yaml
+++ b/templates/roughcut_template.yaml
@@ -25,14 +25,14 @@ footage_coverage: |
 clips:
   # Example clip structure (replace with actual selections)
   - source_file: "DJI_20250423171212_0210_D.mov"  # filename only, path comes from library.yaml
-    in_point: "00:00:03"      # Start time in HH:MM:SS format
-    out_point: "00:00:28"      # End time in HH:MM:SS format
+    in_point: "00:00:02.92"     # Start time in HH:MM:SS.ss format (hundredths precision)
+    out_point: "00:00:28.35"    # End time in HH:MM:SS.ss format
     dialogue: "In order to tell this one, I've got to zoom back about 10, 12, 13 years ago to when I barely just moved to San Francisco"
     visual_description: "[Man with mustache speaking directly to camera in medium-close shot. Outdoor urban SF street setting with residential buildings in background. Tan corduroy jacket. Handheld camera.]"
 
   - source_file: "DJI_20250423174726_0238_D.mov"
-    in_point: "00:00:00"
-    out_point: "00:00:05"
+    in_point: "00:00:00.00"
+    out_point: "00:00:05.24"
     dialogue: ""
     visual_description: "[POV from inside San Francisco Muni bus looking out window at passing street. Yellow safety handrails visible. Transit journey B-roll.]"
 


### PR DESCRIPTION
Simplify library.yaml format and improves timestamp precision in rough cuts:

- **Breaking change**: Simplified transcript fields in library.yaml from full paths to filenames only
  - `transcript_path` → `transcript` 
  - `visual_transcript_path` → `visual_transcript`
  - remove file_size_mb from library.yaml. wasn't used, agents don't read files directly, we already have duration which is more helpful.
  - Reduces library.yaml file size by almost 50 percent
  - All transcripts stored in `libraries/[library-name]/transcripts/` by convention, so we don't need the full path like we do for media.

- **Timestamp precision**: Added hundredths-of-second precision to rough cut timestamps. This makes segment audio editing much, much better. 
  - Format changed from `HH:MM:SS` to `HH:MM:SS.ss`
  - Preserves timing within ~10ms of WhisperX transcript data
  - Prevents clipping words at edit points

## Migration

Users upgrading from 0.2.0 should:

1. Back up existing libraries: `ruby .claude/skills/backup-library/backup_libraries.rb`
2. Run migration script: `ruby scripts/migrate_library_yaml.rb --all`

## Changes

- Updated library.yaml template and all skill documentation
- Added migration script for existing libraries
- Updated FCPXML export to handle decimal seconds
- Version bump to 0.3.0
- Updated CHANGELOG.md with migration instructions