### PR TITLE
Add install video to Getting Started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Behind the scenes Claude uses ButterCut Skills and a little Ruby library to gene
 
 ## Getting Started
 
+[![ButterCut Install Video](https://img.youtube.com/vi/BCMQzg-HiTw/0.jpg)](https://www.youtube.com/watch?v=BCMQzg-HiTw)
+
+*Click to watch the ButterCut install video on YouTube*
+
 **Clone ButterCut:**
 ```bash
 git clone https://github.com/barefootford/buttercut.git && cd buttercut


### PR DESCRIPTION
## Summary
- Adds YouTube video embed for ButterCut installation walkthrough at the top of Getting Started section
- Uses clickable thumbnail format consistent with existing demo video

## Test plan
- [x] Verify thumbnail displays correctly on GitHub
- [x] Verify link opens the correct YouTube video

🤖 Generated with [Claude Code](https://claude.com/claude-code)