### PR TITLE
Add Claude Code settings and fix analyze-video tmp paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "Skill(backup-library)",
+      "Skill(release)",
+      "Skill(update-buttercut)",
+      "Skill(setup)",
+      "Skill(transcribe-audio)",
+      "Skill(roughcut)",
+      "Skill(analyze-video)",
+      "Read(libraries/**)",
+      "Edit(libraries/**)",
+      "Write(libraries/**)",
+      "Read(templates/**)",
+      "Read(.claude/**)",
+      "Bash(ffprobe:*)",
+      "Bash(ffmpeg:*)",
+      "Bash(whisperx:*)",
+      "Bash(ruby:.claude/**)",
+      "Bash(mkdir:libraries/**)",
+      "Bash(mkdir:tmp/**)",
+      "Bash(rm:tmp/**)",
+      "Bash(ls:*)",
+      "Bash(zip:*)",
+      "Bash(cp:libraries/**)",
+      "Bash(unzip:backups/**)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/skills/analyze-video/SKILL.md
+++ b/.claude/skills/analyze-video/SKILL.md
@@ -24,13 +24,13 @@ ruby .claude/skills/analyze-video/prepare_visual_script.rb libraries/[library]/t
 
 ### 2. Extract Frames (Binary Search)
 
-Create frame directory: `mkdir -p /tmp/frames/[video_name]`
+Create frame directory: `mkdir -p tmp/frames/[video_name]`
 
 **Videos ≤30s:** Extract one frame at 2s
 **Videos >30s:** Extract start (2s), middle (duration/2), end (duration-2s)
 
 ```bash
-ffmpeg -ss 00:00:02 -i video.mov -vframes 1 -vf "scale=1280:-1" /tmp/frames/[video_name]/start.jpg
+ffmpeg -ss 00:00:02 -i video.mov -vframes 1 -vf "scale=1280:-1" tmp/frames/[video_name]/start.jpg
 ```
 
 **Subdivide when:** Footage start, middle and end have different subjects, setting or angle changes
@@ -41,7 +41,7 @@ ffmpeg -ss 00:00:02 -i video.mov -vframes 1 -vf "scale=1280:-1" /tmp/frames/[vid
 
 Read the visual video json file that you created earlier.
 
-**Read the JPG frames** from `/tmp/frames/[video_name]/` using Read tool, then **Edit** `visual_video.json`:
+**Read the JPG frames** from `tmp/frames/[video_name]/` using Read tool, then **Edit** `visual_video.json`:
 
 Do these incrementally. You don't need to create a program or script to do this, just incrementally edit the json whenever you read new frames.
 
@@ -76,7 +76,7 @@ Do these incrementally. You don't need to create a program or script to do this,
 ### 4. Cleanup & Return
 
 ```bash
-rm -rf /tmp/frames/[video_name]
+rm -rf tmp/frames/[video_name]
 ```
 
 Return structured response:


### PR DESCRIPTION
## Summary

- Add `.claude/settings.json` with project-level permissions to reduce approval prompts for common workflow operations
- Fix analyze-video skill to use project `tmp/` directory instead of system `/tmp/` for frame extraction

## Changes

**settings.json** - Auto-allows:
- All ButterCut skills
- Read/edit/write operations for `libraries/**` and `templates/**`
- Media tools: `ffprobe`, `ffmpeg`, `whisperx`
- Ruby scripts in `.claude/**`
- Directory operations for `libraries/**` and `tmp/**`
- Copy within libraries, unzip from backups

**analyze-video/SKILL.md** - Changed frame extraction paths from `/tmp/frames/` to `tmp/frames/` to keep temp files within project directory.

## Test plan

- [x] Verify settings.json is loaded by Claude Code on new sessions
- [x] Run analyze-video skill and confirm frames go to `tmp/frames/`
- [x] Confirm no approval prompts for allowed operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)