### PR TITLE
Update Gemfile.lock for v0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    buttercut (0.3.0)
+    buttercut (0.4.0)
       nokogiri (~> 1.13)
       rubyzip (~> 2.3)
 


### PR DESCRIPTION
Updates Gemfile.lock to reflect the 0.4.0 version bump.