### PR TITLE
Create clip summarizes as part of library generation

### DIFF
--- a/.claude/skills/analyze-video/SKILL.md
+++ b/.claude/skills/analyze-video/SKILL.md
@@ -3,95 +3,28 @@ name: analyze-video
 description: Adds visual descriptions to transcripts by extracting and analyzing video frames with ffmpeg. Creates visual transcript with periodic visual descriptions of the video clip. Use when all files have audio transcripts present (transcript) but don't yet have visual transcripts created (visual_transcript).
 ---
 
-# Skill: Analyze Video
+# Skill: Analyze Video (parent brief)
 
-Add visual descriptions to audio transcripts by extracting JPG frames with ffmpeg and analyzing them. **Never read video files directly** - extract frames first.
+Adds visual descriptions to a video's audio transcript by extracting JPG frames with ffmpeg and analyzing them.
+
+`SKILL.md` is the parent's dispatch brief. The sub-agent's working prompt lives in `agent_prompt.md` — inline its contents when launching the Task agent. Don't pass `SKILL.md`.
 
 ## Prerequisites
 
-Videos must have audio transcripts. Run **transcribe-audio** skill first if needed.
+Each video must already have an audio transcript. Run `transcribe-audio` first if any are missing.
 
-## Workflow
+## Parallelism
 
-### 1. Inputs from the parent
+Launch at most **8 in parallel**. ffmpeg frame extraction is a brief CPU burst at the start; the rest of the runtime is LLM API calls. 8 is a comfortable middle ground that won't saturate older machines.
 
-This skill runs as a sub-agent. Do NOT read `library.yaml` or `settings.yaml` — the parent has that context and passes everything inline in your prompt. Expect these inputs:
+## Inputs to gather and pass inline
 
 - `video_path` — absolute path to the video file
 - `audio_transcript_path` — absolute path to the prepared audio transcript JSON
 - `visual_transcript_path` — absolute path to write the visual transcript JSON
 
-### 2. Copy & Clean Audio Transcript
+After the agent returns, update `library.yaml` with `visual_transcript: <filename>.json`.
 
-Don't read the audio transcript, just copy it and then prepare it by using the prepare_visual_script.rb file. This removes word-level timing data and prettifies the JSON for easier editing:
+## Next step
 
-```bash
-cp <audio_transcript_path> <visual_transcript_path>
-ruby .claude/skills/analyze-video/prepare_visual_script.rb <visual_transcript_path>
-```
-
-### 3. Extract Frames (Binary Search)
-
-Create frame directory: `mkdir -p tmp/frames/[video_name]`
-
-**Videos ≤30s:** Extract one frame at 2s
-**Videos >30s:** Extract start (2s), middle (duration/2), end (duration-2s)
-
-```bash
-ffmpeg -ss 00:00:02 -i video.mov -vframes 1 -vf "scale=1280:-1" tmp/frames/[video_name]/start.jpg
-```
-
-**Subdivide when:** Footage start, middle and end have different subjects, setting or angle changes
-**Stop when:** The footage no longer seems to be changing or only has minor changes
-**Never sample** more frequently than once per 30 seconds
-
-### 4. Add Visual Descriptions
-
-Read the visual video json file that you created earlier.
-
-**Read the JPG frames** from `tmp/frames/[video_name]/` using Read tool, then **Edit** the file at `<visual_transcript_path>`:
-
-Do these incrementally. You don't need to create a program or script to do this, just incrementally edit the json whenever you read new frames.
-
-**Dialogue segments - add `visual` field:**
-```json
-{
-  "start": 2.917,
-  "end": 7.586,
-  "text": "Hey, good afternoon everybody.",
-  "visual": "Man in red shirt speaking to camera in medium shot. Home office with bookshelf. Natural lighting.",
-  "words": [...]
-}
-```
-
-**B-roll segments - insert new entries:**
-```json
-{
-  "start": 35.474,
-  "end": 56.162,
-  "text": "",
-  "visual": "Green bicycle parked in front of building. Urban street with trees.",
-  "b_roll": true,
-  "words": []
-}
-```
-
-**Guidelines:**
-- Descriptions should be 3 sentences max.
-- First segment: detailed (subject, setting, shot type, lighting, camera style)
-- Continuing shots: brief if similar, otherwise can be up to 3 sentences if drastically different.
-
-### 5. Cleanup & Return
-
-```bash
-rm -rf tmp/frames/[video_name]
-```
-
-Return structured response:
-```
-✓ [video_filename.mov] analyzed successfully
-  Visual transcript: <visual_transcript_path>
-  Video path: <video_path>
-```
-
-**DO NOT update library.yaml** - parent agent handles this to avoid race conditions in parallel execution.
+Once all videos have visual transcripts, dispatch `summarize-video` (Haiku model) to produce summaries.

--- a/.claude/skills/analyze-video/agent_prompt.md
+++ b/.claude/skills/analyze-video/agent_prompt.md
@@ -1,0 +1,84 @@
+# Analyze Video (sub-agent prompt)
+
+You are a sub-agent. Add visual descriptions to one video's audio transcript by extracting JPG frames with ffmpeg and analyzing them. **Never read the video file directly** — extract frames first.
+
+## Inputs (passed inline by the parent)
+
+- `video_path` — absolute path to the video file
+- `audio_transcript_path` — absolute path to the prepared audio transcript JSON
+- `visual_transcript_path` — absolute path to write the visual transcript JSON
+
+Do NOT read `library.yaml` or `settings.yaml`.
+
+## 1. Copy & clean audio transcript
+
+Don't read the audio transcript — just copy it, then prepare it via `prepare_visual_script.rb`. This removes word-level timing data and prettifies the JSON for easier editing:
+
+```bash
+cp <audio_transcript_path> <visual_transcript_path>
+ruby .claude/skills/analyze-video/prepare_visual_script.rb <visual_transcript_path>
+```
+
+## 2. Extract frames (binary search)
+
+Create frame directory: `mkdir -p tmp/frames/[video_name]`
+
+**Videos ≤30s:** extract one frame at 2s
+**Videos >30s:** extract start (2s), middle (duration/2), end (duration-2s)
+
+```bash
+ffmpeg -ss 00:00:02 -i video.mov -vframes 1 -vf "scale=1280:-1" tmp/frames/[video_name]/start.jpg
+```
+
+**Subdivide when:** start, middle, and end have different subjects, settings, or angle changes
+**Stop when:** the footage no longer seems to be changing or only has minor changes
+**Never sample** more frequently than once per 30 seconds
+
+## 3. Add visual descriptions
+
+Read the visual transcript JSON you created in step 1.
+
+**Read the JPG frames** from `tmp/frames/[video_name]/` using the Read tool, then **Edit** the file at `<visual_transcript_path>`. Do this incrementally — no script needed; just edit the JSON each time you read new frames.
+
+**Dialogue segments — add `visual` field:**
+```json
+{
+  "start": 2.917,
+  "end": 7.586,
+  "text": "Hey, good afternoon everybody.",
+  "visual": "Man in red shirt speaking to camera in medium shot. Home office with bookshelf. Natural lighting.",
+  "words": [...]
+}
+```
+
+**B-roll segments — insert new entries:**
+```json
+{
+  "start": 35.474,
+  "end": 56.162,
+  "text": "",
+  "visual": "Green bicycle parked in front of building. Urban street with trees.",
+  "b_roll": true,
+  "words": []
+}
+```
+
+**Guidelines:**
+- Descriptions: 3 sentences max
+- First segment: detailed (subject, setting, shot type, lighting, camera style)
+- Continuing shots: brief if similar; up to 3 sentences if drastically different
+
+## 4. Cleanup & return
+
+```bash
+rm -rf tmp/frames/[video_name]
+```
+
+Return:
+```
+✓ [video_filename.mov] analyzed successfully
+  Visual transcript: <visual_transcript_path>
+  Video path: <video_path>
+```
+
+**Do NOT update library.yaml** — parent handles this to avoid race conditions in parallel execution.

--- a/.claude/skills/roughcut/SKILL.md
+++ b/.claude/skills/roughcut/SKILL.md
@@ -18,15 +18,16 @@ Before launching the roughcut agent, verify all transcripts are complete:
    ls libraries/[library-name]/library.yaml
    ```
 
-2. **Verify visual transcripts:**
-   Read `libraries/[library-name]/library.yaml` and check that every video entry has both:
-   - `transcript` populated (audio transcript filename)
-   - `visual_transcript` populated (visual descriptions filename)
+2. **Verify transcripts and summaries:**
+   Read `libraries/[library-name]/library.yaml` and check that every video entry has all three populated:
+   - `transcript` (audio transcript filename)
+   - `visual_transcript` (visual descriptions filename)
+   - `summary` (markdown summary filename)
 
-   If any visual transcripts are missing:
-   - Inform user that transcript processing must be completed first
-   - Ask if they want Claude to finish transcript processing using the `transcribe-audio` and `analyze-video` skills
-   - Do not proceed with roughcut creation until all transcripts are complete
+   If any are missing:
+   - Inform user that footage analysis must be completed first
+   - Ask if they want Claude to finish processing using the `transcribe-audio`, `analyze-video`, and `summarize-video` skills as needed
+   - Do not proceed with roughcut creation until all three are complete for every video
 
 ## Launch Roughcut Agent
 

--- a/.claude/skills/summarize-video/SKILL.md
+++ b/.claude/skills/summarize-video/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: summarize-video
+description: Generates a short markdown summary of a video from its visual transcript. Covers overview, key visuals, notable dialogue, and b-roll. Run after analyze-video as the final footage analysis step; summaries become a required field on every video before any roughcut can be created. Always launch this skill using the Haiku model.
+---
+
+# Skill: Summarize Video (parent brief)
+
+Generates a short markdown summary from a video's visual transcript. Always launch on the **Haiku model**.
+
+`SKILL.md` is the parent's dispatch brief. The sub-agent's working prompt lives in `agent_prompt.md` — inline its contents when launching the Task agent. Don't pass `SKILL.md`.
+
+## Parallelism
+
+Launch (at most) 10 agents in parallel until all videos are summarized.
+
+## Pre-create the skeleton (parent step, before launching the agent)
+
+For each video, the parent runs:
+
+```bash
+ruby .claude/skills/summarize-video/summary_skeleton.rb <visual_transcript_path> <summary_output_path>
+```
+
+This writes a skeleton file with the header (filename + duration) filled in and four `<!-- FILL_X -->` placeholders in the body. The agent fills them via `Edit`. The skeleton + Edit pattern is required: without it, Haiku frequently refuses Write and dumps markdown into its reply instead.
+
+## Inputs to gather and pass inline
+
+- `visual_transcript_path` — absolute path to the visual transcript JSON
+- `summary_output_path` — absolute path to the pre-created skeleton file
+
+After the agent returns, update `library.yaml` with `summary: <filename>.md`.

--- a/.claude/skills/summarize-video/agent_prompt.md
+++ b/.claude/skills/summarize-video/agent_prompt.md
@@ -1,0 +1,39 @@
+# Summarize Video (sub-agent prompt)
+
+You are a sub-agent on the Haiku model. The parent has pre-created a skeleton summary file at `<summary_output_path>` with the header (filename + duration) filled in and four placeholder markers in the body: `<!-- FILL_OVERVIEW -->`, `<!-- FILL_KEY_VISUALS -->`, `<!-- FILL_DIALOGUE -->`, `<!-- FILL_BROLL -->`.
+
+Your job is to replace each placeholder with content using the **Edit** tool. Your text reply is just a one-line confirmation.
+
+## Inputs (passed inline by the parent)
+
+- `visual_transcript_path` — absolute path to the visual transcript JSON
+- `summary_output_path` — absolute path to the pre-created skeleton file
+
+## Action 1 — Bash: extract the script
+
+```bash
+ruby .claude/skills/summarize-video/visual_script_extractor.rb <visual_transcript_path>
+```
+
+The stdout is your input data: a header followed by interleaved `[VISUAL]` descriptions and timestamped dialogue.
+
+## Action 2 — Read the skeleton
+
+Read `<summary_output_path>`. The Edit tool requires this before editing.
+
+## Action 3 — Edit each placeholder
+
+Use the **Edit** tool four times to replace each `<!-- FILL_X -->` marker with the corresponding content:
+
+- `<!-- FILL_OVERVIEW -->` → 2-3 sentences describing the narrative arc. Be specific; avoid vague endings like "the clip ends with..." or "discusses something."
+- `<!-- FILL_KEY_VISUALS -->` → 3-6 bullets covering locations, distinctive shots, visual changes.
+- `<!-- FILL_DIALOGUE -->` → 0–3 quotes formatted as `> [MM:SS] "Quote"`. For clips under 30 seconds, often 0 or 1 is enough — write `None` if nothing stands out. Skip filler ("um", "you know", "I have to be honest"). Use the `[MM:SS]` shown next to each line in the script.
+- `<!-- FILL_BROLL -->` → cutaway descriptions distinct from the main subject. For single-shot clips, write `None`. Do not speculate about how the footage could be used as b-roll elsewhere.
+
+## Action 4 — Reply with one line
+
+After the four Edits succeed, your text reply must be exactly:
+
+`✓ <video_filename> summarized`
+
+Nothing else. The file is the deliverable.

--- a/.claude/skills/summarize-video/summary_skeleton.rb
+++ b/.claude/skills/summarize-video/summary_skeleton.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+# Pre-create a summary skeleton file for the summarize-video skill,
+# with header (filename, duration) filled in and four placeholder markers
+# in the body for the sub-agent to replace via Edit.
+#
+# Usage:
+#   ruby summary_skeleton.rb <visual_transcript.json> <summary_output.md>
+
+require 'json'
+
+class SummarySkeleton
+  def self.create(transcript_path, output_path)
+    new(transcript_path, output_path).create
+  end
+
+  def initialize(transcript_path, output_path)
+    raise ArgumentError, "transcript_path is required" if transcript_path.nil? || transcript_path.empty?
+    raise ArgumentError, "output_path is required" if output_path.nil? || output_path.empty?
+
+    @transcript_path = transcript_path
+    @output_path = output_path
+  end
+
+  def create
+    File.write(output_path, skeleton)
+    puts "skeleton: #{output_path}"
+  end
+
+  private
+
+  attr_reader :transcript_path, :output_path
+
+  def data
+    @data ||= JSON.parse(File.read(transcript_path))
+  end
+
+  def video_filename
+    File.basename(data["video_path"].to_s)
+  end
+
+  def segments
+    data["segments"] or raise "transcript JSON has no 'segments' key: #{transcript_path}"
+  end
+
+  def total_duration
+    segments.last["end"].to_f
+  end
+
+  def format_timestamp(seconds)
+    total = seconds.to_i
+    "%02d:%02d" % [total / 60, total % 60]
+  end
+
+  def skeleton
+    <<~MD
+      # #{video_filename}
+      **Duration:** #{format_timestamp(total_duration)}
+
+      ## Overview
+      <!-- FILL_OVERVIEW -->
+
+      ## Key Visuals
+      <!-- FILL_KEY_VISUALS -->
+
+      ## Notable Dialogue
+      <!-- FILL_DIALOGUE -->
+
+      ## B-Roll
+      <!-- FILL_BROLL -->
+    MD
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  transcript_path, output_path = ARGV
+  abort("usage: summary_skeleton.rb <visual_transcript.json> <summary_output.md>") unless transcript_path && output_path
+  SummarySkeleton.create(transcript_path, output_path)
+end

--- a/.claude/skills/summarize-video/visual_script_extractor.rb
+++ b/.claude/skills/summarize-video/visual_script_extractor.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+# Extract a human-readable script from a visual transcript JSON,
+# interleaving [VISUAL] descriptions with timestamped dialogue.
+# Prints to stdout for direct consumption by the summarize-video skill.
+#
+# Usage:
+#   ruby visual_script_extractor.rb <visual_transcript.json>
+
+require 'json'
+
+class VisualScriptExtractor
+  def self.extract(transcript_path)
+    new(transcript_path).extract
+  end
+
+  def initialize(transcript_path)
+    raise ArgumentError, "transcript_path is required" if transcript_path.nil? || transcript_path.empty?
+
+    @transcript_path = transcript_path
+  end
+
+  def extract
+    puts header
+    puts
+    puts format_script
+  end
+
+  private
+
+  attr_reader :transcript_path
+
+  def data
+    @data ||= JSON.parse(File.read(transcript_path))
+  end
+
+  def segments
+    data["segments"] or raise "transcript JSON has no 'segments' key: #{transcript_path}"
+  end
+
+  def header
+    "# Video: #{video_filename}\n# Duration: #{format_timestamp(total_duration)}"
+  end
+
+  def video_filename
+    File.basename(data["video_path"].to_s)
+  end
+
+  def total_duration
+    segments.last["end"].to_f
+  end
+
+  def format_script
+    segments.filter_map { |s| format_segment(s) }.join("\n\n")
+  end
+
+  def format_segment(segment)
+    text   = segment["text"].to_s.strip
+    visual = segment["visual"].to_s.strip
+    ts     = format_timestamp(segment["start"].to_f)
+
+    lines = []
+    lines << "[#{ts}] [VISUAL] #{visual}" unless visual.empty?
+    lines << "[#{ts}] #{text}" unless text.empty?
+
+    lines.empty? ? nil : lines.join("\n")
+  end
+
+  def format_timestamp(seconds)
+    total = seconds.to_i
+    "%02d:%02d" % [total / 60, total % 60]
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  transcript_path = ARGV[0]
+  abort("usage: visual_script_extractor.rb <visual_transcript.json>") unless transcript_path
+  VisualScriptExtractor.extract(transcript_path)
+end

--- a/.claude/skills/transcribe-audio/SKILL.md
+++ b/.claude/skills/transcribe-audio/SKILL.md
@@ -3,88 +3,34 @@ name: transcribe-audio
 description: Transcribes video audio using WhisperX, preserving original timestamps. Creates JSON transcript with word-level timing. Use when you need to generate audio transcripts for videos.
 ---
 
-# Skill: Transcribe Audio
+# Skill: Transcribe Audio (parent brief)
 
-Transcribes video audio using WhisperX and creates clean JSON transcripts with word-level timing data.
+Transcribes video audio using WhisperX and produces a clean JSON transcript with word-level timing.
 
-## When to Use
-- Videos need audio transcripts before visual analysis
+`SKILL.md` is the parent's dispatch brief. The sub-agent's working prompt lives in `agent_prompt.md` — inline its contents when launching the Task agent. Don't pass `SKILL.md`.
 
-## Critical Requirements
+## Parallelism
 
-Use WhisperX, NOT standard Whisper. WhisperX preserves the original video timeline including leading silence, ensuring transcripts match actual video timestamps. Run WhisperX directly on video files. Don't extract audio separately - this ensures timestamp alignment.
+Launch at most **2 in parallel**. WhisperX is already multithreaded internally (~4 CPU threads via CTranslate2); 2 processes is the throughput-vs-RAM sweet spot on a 16GB Mac.
 
-## Workflow
+## Inputs to gather and pass inline
 
-### 1. Inputs from the parent
-
-This skill runs as a sub-agent. Do NOT read `library.yaml` or `settings.yaml` — the parent has that context and passes everything inline in your prompt. Expect these inputs:
+The parent reads `library.yaml` and `settings.yaml` and passes these values inline in each agent's prompt:
 
 - `video_path` — absolute path to the video file
 - `transcript_output_dir` — where to write the transcript JSON (e.g. `libraries/<library>/transcripts`)
-- `language_code` — ISO 639-1 code already mapped by the parent (e.g. `en`, `es`)
-- `whisper_model` — model size from the parent (e.g. `small`, `medium`, `turbo`)
-- `transcript_refinement` — boolean; if `true`, the parent will also pass `user_context` and `footage_summary` strings for Step 4
-- `user_context` (only when refinement is on) — may be empty string
-- `footage_summary` (only when refinement is on) — may be empty string
+- `language_code` — ISO 639-1 code (e.g. `en`, `es`) — parent maps from library.yaml's `language` name
+- `whisper_model` — model size from settings.yaml (e.g. `small`, `medium`, `turbo`)
+- `transcript_refinement` — boolean from library.yaml. If `true`, also pass:
+  - `user_context` (may be empty string)
+  - `footage_summary` (may be empty string)
 
-If any required input is missing from your prompt, stop and ask the parent rather than inferring it from the filesystem.
+After the agent returns, update `library.yaml` with `transcript: <filename>.json`.
 
-### 2. Run WhisperX
+## Next step
 
-```bash
-whisperx "<video_path>" \
-  --language <language_code> \
-  --model <whisper_model> \
-  --compute_type float32 \
-  --device cpu \
-  --output_format json \
-  --output_dir <transcript_output_dir>
-```
+Once all videos have audio transcripts, dispatch `analyze-video` for visual descriptions.
 
-### 3. Prepare Audio Transcript
+## Dependencies
 
-After WhisperX completes, format the JSON using our prepare_audio_script:
-
-```bash
-ruby .claude/skills/transcribe-audio/prepare_audio_script.rb \
-  <transcript_output_dir>/<video_basename>.json \
-  <video_path>
-```
-
-This script:
-- Adds video source path as metadata
-- Removes unnecessary fields to reduce file size
-- Prettifies JSON
-
-### 4. (Optional) Refine the transcript
-
-If the parent passed `transcript_refinement: true`, follow `.claude/skills/transcribe-audio/refine_instructions.md` using the `user_context` and `footage_summary` strings the parent supplied inline. Do NOT open `library.yaml`. If `transcript_refinement` is not set or is `false`, skip this step.
-
-### 5. Return Success Response
-
-After audio preparation completes, return this structured response to the parent agent:
-
-```
-✓ <video_basename.mov> transcribed successfully
-  Audio transcript: <transcript_output_dir>/<video_basename>.json
-  Video path: <video_path>
-```
-
-**DO NOT update library.yaml** - the parent agent will handle this to avoid race conditions when running multiple transcriptions in parallel.
-
-## Running in Parallel
-
-This skill is designed to run inside a Task agent for parallel execution:
-- Each agent handles ONE video file
-- Multiple agents can run simultaneously
-- Parent thread updates library.yaml sequentially after each agent completes
-- No race conditions on shared YAML file
-
-## Next Step
-
-After audio transcription, use the **analyze-video** skill to add visual descriptions and create the visual transcript.
-
-## Installation
-
-Ensure WhisperX is installed. Use the **setup** skill to verify dependencies.
+WhisperX must be installed. Use the **setup** skill to verify.

--- a/.claude/skills/transcribe-audio/agent_prompt.md
+++ b/.claude/skills/transcribe-audio/agent_prompt.md
@@ -1,0 +1,53 @@
+# Transcribe Audio (sub-agent prompt)
+
+You are a sub-agent. Transcribe one video file using WhisperX and produce a clean JSON transcript with word-level timing.
+
+**Critical:** Use WhisperX, NOT standard Whisper. WhisperX preserves the original video timeline including leading silence, ensuring transcripts match actual video timestamps. Run WhisperX directly on the video file — don't extract audio separately.
+
+## Inputs (passed inline by the parent)
+
+- `video_path` — absolute path to the video file
+- `transcript_output_dir` — where to write the transcript JSON
+- `language_code` — ISO 639-1 code (e.g. `en`, `es`)
+- `whisper_model` — model size (e.g. `small`, `medium`, `turbo`)
+- `transcript_refinement` — boolean; if `true`, also expect:
+  - `user_context` — string, may be empty
+  - `footage_summary` — string, may be empty
+
+Do NOT read `library.yaml` or `settings.yaml`. If a required input is missing from your prompt, stop and ask the parent rather than inferring from the filesystem.
+
+## 1. Run WhisperX
+
+```bash
+whisperx "<video_path>" \
+  --language <language_code> \
+  --model <whisper_model> \
+  --compute_type float32 \
+  --device cpu \
+  --output_format json \
+  --output_dir <transcript_output_dir>
+```
+
+## 2. Prepare audio transcript
+
+```bash
+ruby .claude/skills/transcribe-audio/prepare_audio_script.rb \
+  <transcript_output_dir>/<video_basename>.json \
+  <video_path>
+```
+
+This script adds the video source path as metadata, removes unnecessary fields, and prettifies the JSON.
+
+## 3. (Optional) Refine the transcript
+
+If `transcript_refinement: true`, follow `.claude/skills/transcribe-audio/refine_instructions.md`, using the `user_context` and `footage_summary` strings the parent supplied inline. Do NOT open `library.yaml`. Skip if `transcript_refinement` is missing or `false`.
+
+## 4. Return success response
+
+```
+✓ <video_basename.mov> transcribed successfully
+  Audio transcript: <transcript_output_dir>/<video_basename>.json
+  Video path: <video_path>
+```
+
+**Do NOT update library.yaml** — the parent handles all yaml I/O to avoid race conditions in parallel runs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,15 +23,15 @@ You are an AI video editor assistant working with a software engineer. You gener
    - If new: gather project information (library name, video file locations, language)
    - Create directory structure and library.yaml from template
    - Automatically start footage analysis after setup
-2. **Transcribe** → Use `transcribe-audio` and `analyze-video` skills to process videos
+2. **Transcribe** → Use `transcribe-audio`, `analyze-video`, and `summarize-video` skills to process videos
    - First: `transcribe-audio` creates audio transcripts with WhisperX (word-level timing)
    - Then: `analyze-video` adds visual descriptions by extracting and analyzing frames
-   - All videos must have BOTH audio transcripts AND visual transcripts before proceeding to rough cut or sequence creation
-   - Visual transcripts are essential for B-roll selection, shot composition, and editorial decisions
+   - Then: `summarize-video` generates a short markdown summary from each visual transcript
+   - All videos must have audio transcripts, visual transcripts, AND summaries before proceeding to rough cut or sequence creation
 3. **Edit** → Use `roughcut` skill to create timeline scripts from transcripts
    - **Rough cuts**: Multi-minute edits for full videos (typically 3-15+ minutes)
    - **Sequences**: 30-60 second clips that user will build to be imported into a larger video (created using the same roughcut skill with shorter target duration)
-   - **PREREQUISITE:** Check library.yaml to verify all videos have visual_transcript populated
+   - **PREREQUISITE:** Check library.yaml to verify all videos have `visual_transcript` and `summary` populated
 4. **Backup** → Use `backup-library` skill to create compressed archives of all libraries
    - Creates timestamped ZIP backup of entire libraries directory
    - Backups are stored in `/backups/` and excluded from git
@@ -121,6 +121,7 @@ Ask the user these questions for new libraries one at a time (never all at once)
 mkdir -p libraries/[library-name]
 mkdir -p libraries/[library-name]/transcripts
 mkdir -p libraries/[library-name]/roughcuts
+mkdir -p libraries/[library-name]/summaries
 ```
 
 Note: A single `/tmp/` directory at the root is used for all temporary files. Create subdirectories as needed and delete after use.
@@ -131,7 +132,7 @@ Duplicate `templates/library_template.yaml` to create `libraries/[library-name]/
 
 For each video file:
 1. Use `ffprobe` to get duration
-2. Add entry to library.yaml with empty `transcript` and `visual_transcript`
+2. Add entry to library.yaml with empty `transcript`, `visual_transcript`, and `summary`
 3. Empty fields mean "todo", valid filenames mean "done"
 
 The `language` field stores the language code for all videos in this library.
@@ -144,16 +145,23 @@ After library setup completes, **automatically start analyzing all footage**:
 
 1. Inform user: "Library setup complete. Found [N] videos ([total size]). Starting footage analysis..."
 2. Read `libraries/settings.yaml` (for `whisper_model`) and the library's `library.yaml` (for `language`, `transcript_refinement`, `user_context`, `footage_summary`) ONCE in the parent thread. If any expected field is missing, run the appropriate migration first (see Critical Principles below).
-3. Launch `transcribe-audio` agents (can run in parallel for multiple videos). Pass these values inline in each agent's prompt — the sub-agent never reads `library.yaml` or `settings.yaml`:
+3. Launch `transcribe-audio` agents. Pass these values inline in each agent's prompt — the sub-agent never reads `library.yaml` or `settings.yaml`:
    - `video_path`, `transcript_output_dir`, `language_code`, `whisper_model`
    - `transcript_refinement` (boolean). If `true`, also pass the current `user_context` and `footage_summary` strings (empty strings are fine — refinement still catches nonsense-token and self-witness fixes).
 4. As each agent completes, update library.yaml with `transcript` (filename only, not full path).
-5. After all audio transcripts complete, launch `analyze-video` agents (can run in parallel) following the same "parent passes context inline" contract. Pass inline: `video_path`, `audio_transcript_path`, `visual_transcript_path`.
+5. After all audio transcripts complete, launch `analyze-video` agents following the same "parent passes context inline" contract. Pass inline: `video_path`, `audio_transcript_path`, `visual_transcript_path`.
 6. As each agent completes, update library.yaml with `visual_transcript` (filename only, not full path).
-7. Analyze ALL videos before offering to create rough cuts.
-8. **After all analysis completes, automatically create a backup** using the `backup-library` skill.
+7. After all visual transcripts complete, summarize each video using the `summarize-video` skill on the **Haiku model**:
+   - For each video, first pre-create a skeleton file in the parent: `ruby .claude/skills/summarize-video/summary_skeleton.rb <visual_transcript_path> <summary_output_path>`
+   - Then launch the agent passing inline: `visual_transcript_path`, `summary_output_path` (e.g., `libraries/[library-name]/summaries/summary_[videoname].md`)
+   - The agent fills the four placeholders via Edit. The skeleton + Edit pattern is required: without it, Haiku frequently refuses Write and dumps markdown into its reply instead.
+8. As each agent completes, update library.yaml with `summary` (filename only, not full path).
+9. Analyze ALL videos before offering to create rough cuts.
+10. **After all analysis completes, automatically create a backup** using the `backup-library` skill.
 
 **Contract: sub-agents don't read `library.yaml`.** The parent owns `library.yaml` (and `settings.yaml`) — it reads once, passes values inline, and writes results once per agent completion. Sub-agents should not even know those files exist. This keeps the context boundary clean and avoids race conditions when many agents run in parallel.
+
+**Contract: sub-agents receive `agent_prompt.md`, not `SKILL.md`.** For parallelizable skills (`transcribe-audio`, `analyze-video`, `summarize-video`), the parent reads `SKILL.md` for dispatch info (parallelism cap, required inputs) and inlines `agent_prompt.md` into the sub-agent's prompt. `SKILL.md` is parent-only.
 
 **Note on refinement:** When `transcript_refinement: true`, each `transcribe-audio` agent reviews and corrects its transcript in place before returning, using the `user_context` and `footage_summary` the parent passed in. Empty context strings are fine — the agent still runs and catches nonsense-token and self-witness fixes. The parent still only writes `transcript: <filename>.json` to `library.yaml` after the agent completes.
 
@@ -200,6 +208,7 @@ Known migration triggers (match each to a `scripts/NNN_migrate_*.rb` script via 
 - `editor` missing (added in 0.4.0)
 - `transcript_refinement` missing (added in [Unreleased]; missing means "predates the feature, default to `false`" — NOT the template default of `true`)
 - `footage_summary` missing OR old name `footage_description` present (renamed in [Unreleased])
+- video entries with `summary` missing (added in [Unreleased]; missing means "todo", default to empty string)
 - video entries with `transcript_path` / `visual_transcript_path` (renamed to `transcript` / `visual_transcript` in 0.3.0)
 - video entries with `file_size_mb` (removed in 0.3.0)
 
@@ -209,7 +218,7 @@ A missing field is not the same as a field set to the template default — the t
 
 **Use actual filenames.** Never use generic labels like "Video 1" or "Clip A" - always reference actual filenames like "DJI_20250423171212_0210_D.mov" for clear traceability.
 
-**Visual transcripts are mandatory.** Before creating any rough cut or sequence, verify ALL videos have both audio and visual transcripts. Check `library.yaml` - every video entry must have a `visual_transcript` with a filename (not empty or null or ""). Transcripts are stored in `libraries/[library-name]/transcripts/`. Visual descriptions are essential for shot selection, pacing decisions, and B-roll placement.
+**Visual transcripts and summaries are mandatory.** Before creating any rough cut or sequence, verify ALL videos have audio transcripts, visual transcripts, AND summaries. Check `library.yaml` — every video entry must have `visual_transcript` and `summary` with filenames (not empty, null, or ""). Transcripts are stored in `libraries/[library-name]/transcripts/`; summaries in `libraries/[library-name]/summaries/`. Visual descriptions and summaries are essential for shot selection, pacing decisions, and B-roll placement.
 
 **Be curious and ask questions.** Occasionally ask users questions about their libraries and footage to better understand context, creative intent, and preferences. When you receive answers, add this information to the `user_context` key in the library.yaml file. This builds institutional knowledge that improves future rough cut and sequence decisions and helps maintain continuity across editing sessions.
 
@@ -219,7 +228,7 @@ A missing field is not the same as a field set to the template default — the t
 - Flag areas needing human judgment rather than making assumptions
 - When you have lots of videos to process (dozens or hundreds isn't out of the ordinary), create a reasonable task list with 5 tasks and then a final task that says to check the yaml processing file to see if you need to then generate more tasks. This way users can see progress and the agent doesn't get overwhelmed.
 - Generally avoid writing one-off scripts, but if you do need to write one, write it in Ruby unless you have a very strong reason to write in another language.
-- Only run 4 parallel tasks at a time.
+- Parallelism caps live in each skill's `SKILL.md` (parent brief). Read it before dispatching.
 - Whenever you export XML files, include a datetime timestamp in the filename so it's clear when they were generated.
 
 ## Programming Style

--- a/scripts/003_migrate_add_summary.rb
+++ b/scripts/003_migrate_add_summary.rb
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+# Migration script: Add `summary` field to video entries that predate the
+# summarize-video skill.
+#
+# The summarize-video skill produces a short markdown summary of each video
+# from its visual transcript. Libraries created before that skill existed have
+# no `summary:` key in their video entries. Missing means "todo" — the same
+# convention as `transcript:` and `visual_transcript:`. The migration inserts
+# an empty `summary:` line directly after each `visual_transcript:` line.
+#
+# Video entries that already have `summary:` are left alone. Video entries
+# without `visual_transcript:` (mid-pipeline videos) are skipped — they'll get
+# a `summary:` field added by the parent agent when their visual transcript is
+# produced.
+#
+# This migration edits the file textually — it does not round-trip through
+# YAML, so quote styles and indentation elsewhere in the file are preserved
+# exactly.
+#
+# Usage: ruby scripts/003_migrate_add_summary.rb [library_name]
+#        ruby scripts/003_migrate_add_summary.rb --all
+
+require 'yaml'
+
+def migrate_library(library_path)
+  unless File.exist?(library_path)
+    puts "  ✗ Not found: #{library_path}"
+    return false
+  end
+
+  content = File.read(library_path)
+  lines = content.lines
+
+  inserts = []
+  lines.each_with_index do |line, i|
+    next unless line =~ /^(\s+)visual_transcript:/
+    indent = $1
+    next_line = lines[i + 1]
+    next if next_line && next_line.match?(/^#{Regexp.escape(indent)}summary:/)
+    inserts << [i + 1, "#{indent}summary:\n"]
+  end
+
+  if inserts.empty?
+    puts "  - All applicable video entries already have `summary:`; no change"
+    return false
+  end
+
+  inserts.reverse_each { |idx, text| lines.insert(idx, text) }
+  new_content = lines.join
+
+  # Sanity check: parse the result to make sure we didn't produce invalid YAML.
+  parsed = YAML.load(new_content, permitted_classes: [Date, Time, Symbol])
+  unless parsed.is_a?(Hash) && parsed['videos'].is_a?(Array)
+    puts "  ✗ Insert produced unexpected YAML; refusing to write"
+    return false
+  end
+
+  File.write(library_path, new_content)
+  noun = inserts.length == 1 ? "entry" : "entries"
+  puts "  ✓ Added `summary:` to #{inserts.length} video #{noun}"
+  true
+end
+
+def find_libraries
+  Dir.glob("libraries/*/library.yaml")
+end
+
+if ARGV.empty?
+  puts "Usage: ruby scripts/003_migrate_add_summary.rb [library_name]"
+  puts "       ruby scripts/003_migrate_add_summary.rb --all"
+  exit 1
+end
+
+if ARGV[0] == '--all'
+  libraries = find_libraries
+  puts "Migrating #{libraries.length} libraries...\n\n"
+  libraries.each do |lib_path|
+    lib_name = lib_path.split('/')[1]
+    puts "#{lib_name}:"
+    migrate_library(lib_path)
+  end
+else
+  library_name = ARGV[0]
+  library_path = "libraries/#{library_name}/library.yaml"
+  puts "#{library_name}:"
+  migrate_library(library_path)
+end
+
+puts "\nMigration complete."

--- a/templates/library_template.yaml
+++ b/templates/library_template.yaml
@@ -20,3 +20,4 @@ videos:
     duration: "00:05:32"
     transcript: # filename only (stored in libraries/[library-name]/transcripts/)
     visual_transcript: # filename only (visual_*.json with frame descriptions)
+    summary: # filename only (summary_*.md overview stored in libraries/[library-name]/summaries/)


### PR DESCRIPTION
Improve roughcut/sequence generation by creating summaries of each footage. 

The next PR will include splitting rough cut generation into two steps, first finding the actual story via summaries, then actualizing creating the rough cut yaml and xml. 

This will give users much, much better control of rough cuts and allow agents to understand what's in videos without having to look at verbose audio and visual transcripts. 

- af

**Claude summary:**
- New summarize-video skill — three new files: SKILL.md (parent brief), agent_prompt.md (sub-agent instructions), summary_skeleton.rb (pre-creates the skeleton file), and visual_script_extractor.rb (extracts interleaved script from visual transcripts).

- analyze-video refactored — split into SKILL.md (parent-only dispatch brief) and agent_prompt.md (sub-agent prompt), slimming the original SKILL.md significantly.

- transcribe-audio same refactor — split into SKILL.md and agent_prompt.md.

- CLAUDE.md updated — documents the new summarize step as a mandatory part of the footage analysis workflow (after 
visual transcripts, before rough cuts), including the skeleton pre-creation pattern and the Haiku model requirement.

- library_template.yaml — added summary field to video entries.