### PR TITLE
Sprint 1 Phase 4: FCPXML 1.10 backend with timeMap speed ramps

### DIFF
--- a/.claude/skills/roughcut/agent_instructions.md
+++ b/.claude/skills/roughcut/agent_instructions.md
@@ -147,12 +147,26 @@ bundle exec ./.claude/skills/roughcut/export_to_fcpxml.rb libraries/[library-nam
 
 Run the `backup-library` skill to preserve the completed work.
 
+### 6b. Surface the Apply Script to the User
+
+The exporter writes three artifacts next to each rough cut: `<name>.<ext>` (XML), `<name>.recipe.json`, and `<name>_apply.py`. Tell the user how to use the apply script:
+
+> "Once you've imported the XML in Resolve and the timeline is loaded, drop `<name>_apply.py` into Resolve's Edit scripts directory and run it from `Workspace > Scripts > Edit`. If the menu doesn't show your script, run it from the Console instead (`Workspace > Console`, switch to `Py3`):
+>
+> ```python
+> exec(open("<absolute path to _apply.py>", encoding="utf-8").read())
+> ```
+>
+> Resolve's Edit scripts directory: `~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Edit/` (macOS)."
+
+The apply script handles: color tags, markers, render preset, constant speed ramps (single point), and best-effort PowerGrade detection. It logs (but doesn't apply): multi-point speed ramps, transitions, title cards — those are manual finishes per the Sprint 1 Phase 3 audit.
+
 ### 7. Report Results
 
 Provide summary with:
 - Rough cut name and duration
 - Number of clips included
-- File paths for XML and recipe.json
+- File paths for XML, recipe.json, and `_apply.py`
 - Backup confirmation
 
-The exporter writes `<roughcut>.recipe.json` next to the XML automatically — no separate command needed.
+The exporter writes all three artifacts automatically — no separate command needed.

--- a/.claude/skills/roughcut/agent_instructions.md
+++ b/.claude/skills/roughcut/agent_instructions.md
@@ -80,6 +80,53 @@ Each clip needs:
 - `created_date`: `YYYY-MM-DD HH:MM:SS`
 - `total_duration`: Sum of all clips in `HH:MM:SS.ss` format
 
+### 4b. Capture Editorial Directives (during clip selection, NOT as a post-pass)
+
+While picking clips, also capture the editorial reasoning you're already doing — speed ramps, color tags, markers, transitions, title cards — into the same YAML. The exporter will turn this into a `.recipe.json` that a Resolve apply script consumes after import.
+
+Clips are referenced by their **1-based position in the `clips:` list** (assigned automatically — you don't write the index field).
+
+**Per-clip directives** (add directly to the clip):
+
+```yaml
+- source_file: medicine-ball-slams.mp4
+  in_point: "00:00:01.50"
+  out_point: "00:00:04.00"
+  dialogue: ""
+  visual_description: "..."
+  speed_ramps:
+    - { at: 0.0, speed: 200, ease: ease-out }   # ramp to 200% over the slam
+    - { at: 1.0, speed: 100, ease: ease-in }
+  color_tag: Orange                              # Resolve clip color tag
+  markers:
+    - { at: 0.3, name: impact, color: Red }      # SFX hook for the editor
+```
+
+**Top-level directives** (siblings of `clips:`):
+
+```yaml
+transitions:
+  - { between: [3, 4], type: dip_to_color, color: black, duration_frames: 4 }
+  - { between: [11, 12], type: dip_to_color, color: white, duration_frames: 4 }
+title_card:
+  at_clip: 12
+  text: "{{user_handle}}"
+  fade_in_at: 0.5
+  fade_in_frames: 6
+render_preset: { format: mp4, codec: h264, resolution: 1080p, bitrate_kbps: 25000 }
+powergrade: { name: GymBlueOrange-v1, apply_to: all }
+```
+
+**Allowed values** (validated at export — invalid values fail the export):
+
+- `ease`: `linear`, `ease-in`, `ease-out`, `ease-in-out`
+- `color_tag` (Resolve clip colors): `Orange`, `Apricot`, `Yellow`, `Lime`, `Olive`, `Green`, `Teal`, `Navy`, `Blue`, `Purple`, `Violet`, `Pink`, `Tan`, `Beige`, `Brown`, `Chocolate`
+- marker `color` (Resolve marker colors): `Blue`, `Cyan`, `Green`, `Yellow`, `Red`, `Pink`, `Purple`, `Fuchsia`, `Rose`, `Lavender`, `Sky`, `Mint`, `Lemon`, `Sand`, `Cocoa`, `Cream`
+- transition `type`: `dip_to_color` (requires `color: black|white`) or `cross_dissolve`
+- `transitions[*].between`: must reference adjacent clips in YAML order
+
+If you have no editorial directives for a clip or the cut as a whole, omit the fields — they're all optional. The recipe is still emitted with the clips alone.
+
 ### 5. Export to Video Editor
 
 Check `library.yaml` for the `editor` field. If it's set, use that value. If it's not set or empty, check `libraries/settings.yaml` for the default `editor` value and use that (also save it back to `library.yaml`). If neither has an editor set, ask the user for their editor choice (Final Cut Pro X, Adobe Premiere Pro, or DaVinci Resolve), then save their choice back to both `library.yaml` and `libraries/settings.yaml`.
@@ -105,5 +152,7 @@ Run the `backup-library` skill to preserve the completed work.
 Provide summary with:
 - Rough cut name and duration
 - Number of clips included
-- File path for XML
+- File paths for XML and recipe.json
 - Backup confirmation
+
+The exporter writes `<roughcut>.recipe.json` next to the XML automatically — no separate command needed.

--- a/.claude/skills/roughcut/export_to_fcpxml.rb
+++ b/.claude/skills/roughcut/export_to_fcpxml.rb
@@ -4,6 +4,7 @@
 require 'date'
 require 'yaml'
 require 'buttercut'
+require_relative 'recipe_from_roughcut'
 
 def timecode_to_seconds(timecode)
   # Convert HH:MM:SS or HH:MM:SS.s to seconds (supports decimal seconds)
@@ -65,8 +66,9 @@ def main
     source_file = clip['source_file']
 
     unless video_paths[source_file]
-      puts "Warning: Source file not found in library data: #{source_file}"
-      next
+      warn "Error: Source file not found in library data: #{source_file}"
+      warn "Refusing to export — silently skipping a clip would break recipe.json clip indices."
+      exit 1
     end
 
     full_path = video_paths[source_file]
@@ -104,6 +106,16 @@ def main
   puts "\n✓ Rough cut exported to: #{output_path}"
 
   validate_fcpxml(output_path) if editor_symbol == :fcpx
+
+  recipe_path = output_path.sub(/\.[^.]+\z/, '') + '.recipe.json'
+  timeline_name = File.basename(roughcut_path, File.extname(roughcut_path))
+  RecipeFromRoughcut.export(
+    roughcut_path: roughcut_path,
+    recipe_path: recipe_path,
+    library_name: library_name,
+    timeline_name: timeline_name
+  )
+  puts "✓ Recipe exported to: #{recipe_path}"
 end
 
 def validate_fcpxml(xml_path)

--- a/.claude/skills/roughcut/export_to_fcpxml.rb
+++ b/.claude/skills/roughcut/export_to_fcpxml.rb
@@ -5,6 +5,7 @@ require 'date'
 require 'yaml'
 require 'buttercut'
 require_relative 'recipe_from_roughcut'
+require_relative 'generate_apply_script'
 
 def timecode_to_seconds(timecode)
   # Convert HH:MM:SS or HH:MM:SS.s to seconds (supports decimal seconds)
@@ -116,6 +117,10 @@ def main
     timeline_name: timeline_name
   )
   puts "✓ Recipe exported to: #{recipe_path}"
+
+  apply_path = output_path.sub(/\.[^.]+\z/, '') + '_apply.py'
+  GenerateApplyScript.generate(recipe_path: recipe_path, output_path: apply_path)
+  puts "✓ Apply script generated: #{apply_path}"
 end
 
 def validate_fcpxml(xml_path)

--- a/.claude/skills/roughcut/export_to_fcpxml.rb
+++ b/.claude/skills/roughcut/export_to_fcpxml.rb
@@ -77,11 +77,13 @@ def main
     out_point = timecode_to_seconds(clip['out_point'])
     duration = out_point - start_at
 
-    buttercut_clips << {
+    clip_entry = {
       path: full_path,
       start_at: start_at.to_f,
       duration: duration.to_f
     }
+    clip_entry[:speed_ramps] = clip['speed_ramps'] if clip['speed_ramps']
+    buttercut_clips << clip_entry
   end
 
   # Validate and normalize editor choice
@@ -124,7 +126,7 @@ def main
 end
 
 def validate_fcpxml(xml_path)
-  dtd_path = File.expand_path('../../../dtd/FCPXMLv1_8.dtd', __dir__)
+  dtd_path = File.expand_path('../../../dtd/FCPXMLv1_10.dtd', __dir__)
   unless File.exist?(dtd_path)
     puts "⚠ DTD not found at #{dtd_path}; skipping validation."
     return

--- a/.claude/skills/roughcut/generate_apply_script.rb
+++ b/.claude/skills/roughcut/generate_apply_script.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+# Generate <name>_apply.py from the apply_recipe.py template by stamping in
+# the absolute recipe path. The result is fully self-contained and can be
+# dropped into Resolve's Edit scripts directory.
+
+require 'json'
+
+class GenerateApplyScript
+  TEMPLATE_PATH = File.expand_path('templates/apply_recipe.py', __dir__)
+  PLACEHOLDER = '{{RECIPE_PATH}}'.freeze
+
+  def self.generate(recipe_path:, output_path:)
+    new(recipe_path: recipe_path, output_path: output_path).generate
+  end
+
+  def initialize(recipe_path:, output_path:)
+    raise ArgumentError, "recipe_path required" if recipe_path.nil? || recipe_path.empty?
+    raise ArgumentError, "output_path required" if output_path.nil? || output_path.empty?
+
+    @recipe_path = File.expand_path(recipe_path)
+    @output_path = output_path
+  end
+
+  def generate
+    template = File.read(TEMPLATE_PATH)
+    raise "template missing #{PLACEHOLDER}" unless template.include?(PLACEHOLDER)
+
+    # JSON string syntax is a strict subset of Python string syntax (both use
+    # double quotes, both escape \ and " the same way, both handle unicode
+    # the same), so JSON.dump produces a valid Python string literal — quotes
+    # included. The template's placeholder appears unquoted for that reason.
+    # Use the block form of sub so backslashes in the replacement aren't
+    # interpreted as regex backreferences.
+    replacement = JSON.dump(@recipe_path)
+    stamped = template.sub(PLACEHOLDER) { replacement }
+    File.write(@output_path, stamped)
+    File.chmod(0o755, @output_path)
+    @output_path
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  if ARGV.length != 2
+    warn "Usage: #{$PROGRAM_NAME} <recipe.json> <output_apply.py>"
+    exit 1
+  end
+  GenerateApplyScript.generate(recipe_path: ARGV[0], output_path: ARGV[1])
+  puts "✓ Apply script generated: #{ARGV[1]}"
+end

--- a/.claude/skills/roughcut/recipe_from_roughcut.rb
+++ b/.claude/skills/roughcut/recipe_from_roughcut.rb
@@ -1,0 +1,124 @@
+#!/usr/bin/env ruby
+# Build a ButterCut::Recipe (and its JSON file) from a rough-cut YAML.
+#
+# The YAML is the source of truth: clips are numbered 1..N by YAML order,
+# and editorial directives (speed_ramps, color_tag, markers, transitions,
+# title_card, render_preset, powergrade) are read off the same document.
+
+require 'date'
+require 'yaml'
+require 'buttercut'
+
+class RecipeFromRoughcut
+  def self.export(roughcut_path:, recipe_path:, library_name:, timeline_name:)
+    new(
+      roughcut_path: roughcut_path,
+      recipe_path: recipe_path,
+      library_name: library_name,
+      timeline_name: timeline_name
+    ).export
+  end
+
+  def initialize(roughcut_path:, recipe_path:, library_name:, timeline_name:)
+    raise ArgumentError, "roughcut_path required" if roughcut_path.nil? || roughcut_path.empty?
+    raise ArgumentError, "recipe_path required" if recipe_path.nil? || recipe_path.empty?
+    raise ArgumentError, "library_name required" if library_name.nil? || library_name.empty?
+    raise ArgumentError, "timeline_name required" if timeline_name.nil? || timeline_name.empty?
+
+    @roughcut_path = roughcut_path
+    @recipe_path = recipe_path
+    @library_name = library_name
+    @timeline_name = timeline_name
+  end
+
+  def export
+    recipe = build_recipe
+    recipe.save(@recipe_path)
+    @recipe_path
+  end
+
+  def build_recipe
+    ButterCut::Recipe.from_hash(build_hash)
+  end
+
+  private
+
+  def roughcut
+    @roughcut ||= YAML.load_file(@roughcut_path, permitted_classes: [Date, Time, Symbol])
+  end
+
+  def build_hash
+    h = {
+      "version" => ButterCut::Recipe::SCHEMA_VERSION,
+      "library" => @library_name,
+      "timeline" => @timeline_name,
+      "clips" => build_clips
+    }
+    h["render_preset"] = stringify(roughcut["render_preset"]) if roughcut["render_preset"]
+    h["powergrade"] = stringify(roughcut["powergrade"]) if roughcut["powergrade"]
+    h["transitions"] = stringify(roughcut["transitions"]) if roughcut["transitions"]
+    h["title_card"] = stringify(roughcut["title_card"]) if roughcut["title_card"]
+    h
+  end
+
+  def build_clips
+    raw_clips = roughcut["clips"]
+    raise ArgumentError, "roughcut must have a clips array" unless raw_clips.is_a?(Array) && !raw_clips.empty?
+
+    raw_clips.each_with_index.map do |clip, i|
+      entry = {
+        "index" => i + 1,
+        "source_file" => clip["source_file"]
+      }
+      entry["speed_ramps"] = stringify(clip["speed_ramps"]) if clip.key?("speed_ramps")
+      entry["color_tag"] = clip["color_tag"] if clip.key?("color_tag")
+      entry["markers"] = stringify(clip["markers"]) if clip.key?("markers")
+      entry
+    end
+  end
+
+  # YAML round-trips with string keys by default, but nested hashes loaded from
+  # YAML may have symbol keys depending on author style. Normalize to strings so
+  # the output JSON matches the Recipe schema exactly.
+  def stringify(obj)
+    case obj
+    when Hash
+      obj.each_with_object({}) { |(k, v), h| h[k.to_s] = stringify(v) }
+    when Array
+      obj.map { |v| stringify(v) }
+    else
+      obj
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  if ARGV.length != 2
+    warn "Usage: #{$PROGRAM_NAME} <roughcut.yaml> <output.recipe.json>"
+    exit 1
+  end
+
+  roughcut_path = ARGV[0]
+  recipe_path = ARGV[1]
+
+  unless File.exist?(roughcut_path)
+    warn "Error: Rough cut file not found: #{roughcut_path}"
+    exit 1
+  end
+
+  library_match = roughcut_path.match(%r{libraries/([^/]+)/roughcuts})
+  unless library_match
+    warn "Error: Could not extract library name from path: #{roughcut_path}"
+    exit 1
+  end
+  library_name = library_match[1]
+  timeline_name = File.basename(roughcut_path, File.extname(roughcut_path))
+
+  RecipeFromRoughcut.export(
+    roughcut_path: roughcut_path,
+    recipe_path: recipe_path,
+    library_name: library_name,
+    timeline_name: timeline_name
+  )
+  puts "✓ Recipe exported to: #{recipe_path}"
+end

--- a/.claude/skills/roughcut/templates/apply_recipe.py
+++ b/.claude/skills/roughcut/templates/apply_recipe.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Apply a ButterCut recipe.json to the current Resolve timeline.
+
+This file is generated per-cut by .claude/skills/roughcut/generate_apply_script.rb.
+The RECIPE_PATH constant below is stamped at generation time.
+
+Run from inside Resolve:
+  Workspace > Scripts > Edit > <name>_apply
+or from the Console (Workspace > Console, switch to Py3):
+  exec(open("<this file path>", encoding="utf-8").read())
+
+Scope (locked by Sprint 1, Phase 3 audit on Resolve 20.2.3):
+  applied:    color_tag, markers, render_preset, constant speed_ramps, powergrade (best-effort)
+  logged:     multi-point speed_ramps, transitions, title_card
+"""
+
+from __future__ import annotations
+import json
+import os
+import sys
+import traceback
+
+
+RECIPE_PATH = {{RECIPE_PATH}}
+
+
+def get_resolve():
+    if "resolve" in globals():
+        return globals()["resolve"]
+    try:
+        import DaVinciResolveScript as dvr_script  # type: ignore
+        return dvr_script.scriptapp("Resolve")
+    except Exception:
+        return None
+
+
+class Applier:
+    def __init__(self, recipe, project, timeline):
+        self.recipe = recipe
+        self.project = project
+        self.timeline = timeline
+        self.timeline_items = timeline.GetItemListInTrack("video", 1) or []
+        self.frame_rate = self._get_frame_rate()
+        self.counts = {
+            "color_tags": [0, 0],
+            "markers": [0, 0],
+            "constant_speed_ramps": [0, 0],
+            "render_preset": [0, 0],
+            "powergrade": [0, 0],
+        }
+        self.manual = {"transitions": 0, "multi_point_ramps": 0, "constant_speed_ramps": 0, "title_card": 0}
+        self.warnings = []
+
+    def apply(self):
+        self._apply_per_clip()
+        self._apply_render_preset()
+        self._apply_powergrade()
+        self._log_manual_transitions()
+        self._log_manual_title_card()
+        self._report()
+
+    def _get_frame_rate(self):
+        try:
+            rate = self.timeline.GetSetting("timelineFrameRate")
+            return float(rate) if rate else 24.0
+        except Exception:
+            return 24.0
+
+    def _clip_for(self, index):
+        # Recipe indices are 1-based and align with YAML order. Timeline order
+        # matches that order because export_to_fcpxml.rb writes clips in YAML
+        # order with no skips (skipping raises).
+        pos = index - 1
+        if pos < 0 or pos >= len(self.timeline_items):
+            self.warnings.append(f"clip {index}: not present on V1 (have {len(self.timeline_items)} items)")
+            return None
+        return self.timeline_items[pos]
+
+    def _apply_per_clip(self):
+        for clip in self.recipe.get("clips", []):
+            idx = clip["index"]
+            item = self._clip_for(idx)
+            if not item:
+                continue
+            self._apply_color_tag(item, clip, idx)
+            self._apply_markers(item, clip, idx)
+            self._apply_speed_ramps(item, clip, idx)
+
+    def _apply_color_tag(self, item, clip, idx):
+        if "color_tag" not in clip:
+            return
+        self.counts["color_tags"][1] += 1
+        try:
+            ok = bool(item.SetClipColor(clip["color_tag"]))
+            if ok:
+                self.counts["color_tags"][0] += 1
+            else:
+                self.warnings.append(f"clip {idx}: SetClipColor({clip['color_tag']!r}) returned False")
+        except Exception as e:
+            self.warnings.append(f"clip {idx}: SetClipColor raised {type(e).__name__}: {e}")
+
+    def _apply_markers(self, item, clip, idx):
+        for marker_pos, marker in enumerate(clip.get("markers", []), start=1):
+            self.counts["markers"][1] += 1
+            frame = int(round(marker["at"] * self.frame_rate))
+            # Disambiguate by clip index + marker position so duplicate names
+            # within the same clip don't overwrite each other on cleanup.
+            custom_data = f"buttercut:{idx}:{marker_pos}:{marker['name']}"
+            # Make idempotent: a previous apply may have placed a buttercut
+            # marker at this same frame. Clear it before re-adding so the
+            # script can be run repeatedly.
+            try:
+                if hasattr(item, "DeleteMarkerByCustomData"):
+                    item.DeleteMarkerByCustomData(custom_data)
+            except Exception as e:
+                self.warnings.append(
+                    f"clip {idx}: DeleteMarkerByCustomData({custom_data!r}) raised {type(e).__name__}: {e}"
+                )
+            # Belt-and-braces: if a buttercut marker exists at the target
+            # frame but its customData doesn't match (e.g. an old run used a
+            # different name), remove it too — but ONLY when the marker's
+            # customData is recognizably ours. Don't touch user markers that
+            # happen to share the same frame.
+            try:
+                if hasattr(item, "GetMarkers") and hasattr(item, "DeleteMarkerAtFrame"):
+                    markers = item.GetMarkers() or {}
+                    existing = markers.get(frame) or markers.get(float(frame)) or markers.get(str(frame))
+                    if existing and str(existing.get("customData", "")).startswith("buttercut:"):
+                        item.DeleteMarkerAtFrame(frame)
+            except Exception as e:
+                self.warnings.append(
+                    f"clip {idx}: marker cleanup at frame {frame} raised {type(e).__name__}: {e}"
+                )
+            try:
+                ok = bool(item.AddMarker(frame, marker["color"], marker["name"], marker.get("note", ""), 1, custom_data))
+                if ok:
+                    self.counts["markers"][0] += 1
+                else:
+                    self.warnings.append(f"clip {idx}: AddMarker at frame {frame} returned False")
+            except Exception as e:
+                self.warnings.append(f"clip {idx}: AddMarker raised {type(e).__name__}: {e}")
+
+    def _apply_speed_ramps(self, item, clip, idx):
+        ramps = clip.get("speed_ramps", [])
+        if not ramps:
+            return
+        if len(ramps) > 1:
+            self.manual["multi_point_ramps"] += 1
+            print(f"[apply_recipe] manual: multi-point ramp on clip {idx} — apply via Resolve retime curve")
+            return
+        self.counts["constant_speed_ramps"][1] += 1
+        speed = ramps[0]["speed"]
+        mpi = None
+        if hasattr(item, "GetMediaPoolItem"):
+            try:
+                mpi = item.GetMediaPoolItem()
+            except Exception as e:
+                self.warnings.append(f"clip {idx}: GetMediaPoolItem raised {type(e).__name__}: {e}")
+        # Resolve's speed API is flaky across versions; try the documented
+        # paths in order, accept the first one that returns truthy.
+        attempts = []
+        if mpi:
+            attempts += [
+                ("MediaPoolItem.SetClipProperty('Speed', str)", lambda: mpi.SetClipProperty("Speed", str(speed))),
+                ("MediaPoolItem.SetClipProperty('Speed', float)", lambda: mpi.SetClipProperty("Speed", float(speed) / 100.0)),
+                ("MediaPoolItem.SetClipProperty('Speed Change', %)", lambda: mpi.SetClipProperty("Speed Change", f"{speed}%")),
+            ]
+        attempts += [
+            ("TimelineItem.SetProperty('Speed', float)", lambda: item.SetProperty("Speed", float(speed) / 100.0) if hasattr(item, "SetProperty") else False),
+        ]
+        for label, fn in attempts:
+            try:
+                if bool(fn()):
+                    self.counts["constant_speed_ramps"][0] += 1
+                    return
+            except Exception as e:
+                self.warnings.append(f"clip {idx}: {label} raised {type(e).__name__}: {e}")
+        # All attempts returned False or raised. Fall back to manual log,
+        # not warning — speed scripting is unreliable enough that "apply
+        # manually" is the right user instruction.
+        self.manual["constant_speed_ramps"] += 1
+        print(
+            f"[apply_recipe] manual: constant ramp on clip {idx} → {speed}% — "
+            f"set in Resolve (Inspector > Speed) since scripted set returned False"
+        )
+
+    def _apply_render_preset(self):
+        preset = self.recipe.get("render_preset")
+        if not preset:
+            return
+        self.counts["render_preset"][1] += 1
+        candidates = self._render_preset_candidates(preset)
+        try:
+            available = self.project.GetRenderPresetList() or []
+        except Exception:
+            available = []
+        match = next((name for name in candidates if name in available), None)
+        if not match:
+            self.warnings.append(
+                f"render_preset: no available preset matched {candidates!r}; "
+                f"available={available!r} — load matching preset manually"
+            )
+            return
+        try:
+            if not bool(self.project.LoadRenderPreset(match)):
+                self.warnings.append(f"render_preset: LoadRenderPreset({match!r}) returned False")
+                return
+            if not bool(self.project.SetCurrentRenderMode(0)):
+                self.warnings.append(f"render_preset: SetCurrentRenderMode(0) returned False after LoadRenderPreset({match!r})")
+                return
+            self.counts["render_preset"][0] += 1
+            print(f"[apply_recipe] loaded render preset: {match}")
+        except Exception as e:
+            self.warnings.append(f"render_preset: raised {type(e).__name__}: {e}")
+
+    def _render_preset_candidates(self, preset):
+        # Recipe encodes format/codec/resolution/bitrate_kbps; Resolve presets
+        # are by name. Generate candidates that match Resolve's actual naming
+        # conventions (dots in codec names, ' - ' separator in platform presets).
+        codec = preset.get("codec", "")
+        resolution = preset.get("resolution", "")
+        codec_pretty = self._pretty_codec(codec)
+        return [
+            preset.get("name", ""),               # explicit name wins if set
+            f"{codec_pretty} Master",             # "H.264 Master", "H.265 Master", "ProRes 422 HQ"
+            f"YouTube - {resolution}",            # "YouTube - 1080p"
+            f"Vimeo - {resolution}",
+            f"TikTok - {resolution}",
+            f"Dropbox - {resolution}",
+            # Loose fallbacks
+            f"YouTube {resolution}",
+            f"{resolution} {codec_pretty}",
+        ]
+
+    def _pretty_codec(self, codec):
+        # h264 -> H.264, h265 -> H.265, prores422hq -> ProRes 422 HQ (best-effort)
+        c = codec.lower().strip()
+        if c in ("h264", "avc"):
+            return "H.264"
+        if c in ("h265", "hevc"):
+            return "H.265"
+        return codec.upper() if codec else ""
+
+    def _apply_powergrade(self):
+        grade = self.recipe.get("powergrade")
+        if not grade:
+            return
+        self.counts["powergrade"][1] += 1
+        name = grade.get("name", "")
+        try:
+            gallery = self.project.GetGallery()
+            if not gallery:
+                self.warnings.append(f"powergrade: no gallery — apply '{name}' manually")
+                return
+            albums = gallery.GetGalleryStillAlbums() or []
+            still = self._find_still_by_label(albums, name)
+            if not still:
+                self.warnings.append(
+                    f"powergrade: still '{name}' not found in any album — "
+                    f"apply manually (right-click hero clip → Apply Grade > {name})"
+                )
+                return
+            # Best-effort apply: select the still album, then apply the still
+            # to every clip in apply_to. The exact API path varies across
+            # Resolve versions; if any step fails, log and continue.
+            print(f"[apply_recipe] powergrade: found still '{name}'; manual apply still recommended on first run")
+            self.warnings.append(
+                f"powergrade: still '{name}' located but auto-apply path is brittle in 20.2.x — "
+                f"apply manually for now (Phase 3 ships best-effort detection only)"
+            )
+        except Exception as e:
+            self.warnings.append(f"powergrade: raised {type(e).__name__}: {e}")
+
+    def _find_still_by_label(self, albums, name):
+        for album in albums:
+            try:
+                stills = album.GetStills() if hasattr(album, "GetStills") else []
+            except Exception:
+                stills = []
+            for still in stills:
+                try:
+                    label = still.GetLabel() if hasattr(still, "GetLabel") else None
+                except Exception:
+                    label = None
+                if label == name:
+                    return still
+        return None
+
+    def _log_manual_transitions(self):
+        for t in self.recipe.get("transitions", []):
+            self.manual["transitions"] += 1
+            a, b = t["between"]
+            print(f"[apply_recipe] manual: {t['type']} between clip {a} and {b} — Phase 4 (FCPXML 1.10) or apply manually")
+
+    def _log_manual_title_card(self):
+        if self.recipe.get("title_card"):
+            self.manual["title_card"] += 1
+            tc = self.recipe["title_card"]
+            print(f"[apply_recipe] manual: title card on clip {tc['at_clip']} — add manually")
+
+    def _report(self):
+        print()
+        print("[apply_recipe] applied:")
+        for cap, (ok, total) in self.counts.items():
+            if total:
+                print(f"  {cap}: {ok}/{total}")
+        if any(self.manual.values()):
+            print("[apply_recipe] manual:")
+            for cap, count in self.manual.items():
+                if count:
+                    print(f"  {cap}: {count}")
+        if self.warnings:
+            print("[apply_recipe] warnings:")
+            for w in self.warnings:
+                print(f"  - {w}")
+
+
+def main():
+    if not os.path.isfile(RECIPE_PATH):
+        print(f"[apply_recipe] ERROR: recipe not found at {RECIPE_PATH}")
+        sys.exit(1)
+
+    with open(RECIPE_PATH, encoding="utf-8") as f:
+        recipe = json.load(f)
+
+    expected_version = 1
+    if recipe.get("version") != expected_version:
+        print(f"[apply_recipe] ERROR: recipe version {recipe.get('version')!r} unsupported (expected {expected_version})")
+        sys.exit(1)
+
+    resolve = get_resolve()
+    if not resolve:
+        print("[apply_recipe] ERROR: could not connect to Resolve. Run from inside Resolve via Workspace > Scripts or Console.")
+        sys.exit(1)
+
+    project = resolve.GetProjectManager().GetCurrentProject()
+    if not project:
+        print("[apply_recipe] ERROR: no project open.")
+        sys.exit(1)
+    timeline = project.GetCurrentTimeline()
+    if not timeline:
+        print("[apply_recipe] ERROR: no timeline open. Import the rough-cut XML first.")
+        sys.exit(1)
+
+    print(f"[apply_recipe] recipe: {RECIPE_PATH}")
+    print(f"[apply_recipe] library: {recipe.get('library')!r}  timeline: {recipe.get('timeline')!r}")
+    print(f"[apply_recipe] active timeline: {timeline.GetName()!r}  ({len(timeline.GetItemListInTrack('video', 1) or [])} items on V1)")
+
+    Applier(recipe, project, timeline).apply()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        traceback.print_exc()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to ButterCut will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **FCPXML output upgraded from 1.8 to 1.10.** When a roughcut clip carries `speed_ramps`, ButterCut now emits a `<timeMap>` with `<timept>` waypoints inside the `<asset-clip>`, so DaVinci Resolve preserves speed ramps on import without needing the apply script. Easing values map to FCPXML `interp`: `linear` → `linear`; `ease-in` / `ease-out` / `ease-in-out` → `smooth2`. Transitions and color tags are not yet emitted via FCPXML — those still flow through the recipe + apply script (or stay manual in Resolve).
+
 ## [0.5.0] - 2026-04-24
 
 ### Added

--- a/docs/sprints/sprint-01-editorial-automation.md
+++ b/docs/sprints/sprint-01-editorial-automation.md
@@ -1,0 +1,130 @@
+# Sprint 1 — Editorial Automation
+
+**Status:** planning · **Branch:** `sprint/editorial-automation` (to create) · **Target:** ~2 weeks · **Date:** 2026-04-30
+
+## Goal
+
+Extend ButterCut so a rough cut isn't just a cuts-only timeline — it ships with an **editorial recipe** that can be applied to the imported timeline to produce an ~80%-finished edit hands-free. Speed ramps, transitions, color, markers, render presets — automated.
+
+The remaining 20% (music, art-direction color taste, titles) stays in the editor's hands because those are creative judgement calls.
+
+## Background — why
+
+Today ButterCut emits XML and the editor (DaVinci Resolve / Premiere / FCP) imports it as straight cuts. Everything else — speed ramps on slams, color grading, transitions, sound cue placement — is manual. We've prototyped a markdown/HTML edit guide that documents these choices, but it still requires the human to apply each one.
+
+The recipe + apply-script architecture closes that loop. ButterCut already knows *which* clips to ramp/grade because the editorial reasoning happened in the roughcut agent — we just lose that reasoning at the XML boundary. This sprint persists it.
+
+## Out of scope
+
+- Automatic music selection or sound-design generation.
+- Color grading taste decisions (we apply a saved PowerGrade; we don't generate one).
+- Premiere Pro / Final Cut Pro automation. Resolve only this sprint — Premiere has a separate scripting model (UXP/ExtendScript) and FCP X has a different XML round-trip. Both follow-on sprints.
+- Headless ffmpeg rendering. NLE-driven only.
+
+## Architecture
+
+```text
+ButterCut roughcut skill
+  ├── highlight-reel_<ts>.yaml         (existing)
+  ├── highlight-reel_<ts>.xml          (existing — Resolve xmeml v5)
+  ├── highlight-reel_<ts>.recipe.json  (NEW — per-clip directives)
+  ├── highlight-reel_<ts>_apply.py     (NEW — Resolve Python, drop into Scripts/Edit/)
+  └── highlight-reel_<ts>_edit_guide.html (existing prototype, formalized)
+```
+
+The user imports the XML in Resolve (one-click), then runs `Workspace > Scripts > Edit > Apply <name>` and the recipe is applied to the timeline they just imported.
+
+## Phases
+
+### Phase 1 — Recipe schema (1–2 days)
+
+- `lib/buttercut/recipe.rb` — Ruby class that builds the recipe alongside the XML.
+- Schema (JSON):
+  ```json
+  {
+    "version": 1,
+    "library": "march-30-workout",
+    "timeline": "highlight-reel_20260430_184655",
+    "render_preset": { "format": "mp4", "codec": "h264", "resolution": "1080p", "bitrate_kbps": 25000 },
+    "powergrade": { "name": "GymBlueOrange-v1", "apply_to": "all" },
+    "clips": [
+      {
+        "index": 3,
+        "source_file": "medicine-ball-slams.mp4",
+        "speed_ramps": [
+          { "at": 1.5, "speed": 200, "ease": "ease-out" },
+          { "at": 2.5, "speed": 100, "ease": "ease-in" }
+        ],
+        "color_tag": "Orange",
+        "markers": [{ "at": 1.8, "name": "impact", "color": "Red" }]
+      }
+    ],
+    "transitions": [
+      { "between": [3, 4], "type": "dip_to_color", "color": "black", "duration_frames": 4 },
+      { "between": [11, 12], "type": "dip_to_color", "color": "white", "duration_frames": 4 }
+    ],
+    "title_card": {
+      "at_clip": 12,
+      "text": "{{user_handle}}",
+      "fade_in_at": 0.5,
+      "fade_in_frames": 6
+    }
+  }
+  ```
+- **Acceptance:** unit test in `spec/recipe_spec.rb` round-trips the schema; invalid inputs raise.
+
+### Phase 2 — Roughcut agent emits recipe (2–3 days)
+
+- Update `.claude/skills/roughcut/agent_instructions.md` to instruct the agent to produce recipe directives during clip selection (not as a post-pass) — the editorial reasoning ("ramp this slam to 200%", "dip to white before the hero") is already happening in the agent's head; capture it.
+- Wire `lib/buttercut/recipe.rb` into the roughcut export so YAML→XML+recipe is one operation.
+- **Acceptance:** running the roughcut skill produces all four artifacts (yaml, xml, recipe.json, edit_guide.html). The `march-30-workout` library is the regression fixture.
+
+### Phase 3 — Resolve apply script (3–4 days)
+
+- `.claude/skills/roughcut/templates/apply_recipe.py` — template Python that reads `<name>.recipe.json` next to itself.
+- Generate `<name>_apply.py` per cut by stamping the template with the recipe path.
+- Capabilities (in priority order):
+  1. Speed ramps via `clip.GetClipProperty("Speed")` and retime curve API.
+  2. Clip color tags via `SetClipColor()`.
+  3. Markers via `clip.AddMarker()`.
+  4. Apply saved PowerGrade by name (apply via `MediaPool.AppendToTimeline` workaround if direct API unavailable).
+  5. Render preset via `Project.LoadRenderPreset()` / `SetCurrentRenderMode`.
+  6. Transitions: best-effort — Resolve API for transitions is limited; may have to skip and document as manual.
+- **Acceptance:** drop the `march-30-workout` rough-cut XML into a fresh Resolve project, import, run the apply script, observe ramps + color tags + markers + render preset applied.
+
+### Phase 4 — Optional: FCPXML 1.10 backend (3 days, deferred if Phase 3 takes long)
+
+- `lib/buttercut/fcpx.rb` already exists (FCPXML 1.8). Bump to 1.10 and emit `<timeMap>` for speed ramps, `<filter-video>` references for transitions/color.
+- Resolve's FCPXML import is more permissive than its xmeml import — many recipe directives may "just work" without the apply script, giving fallback path.
+- **Acceptance:** same regression library imports into Resolve via FCPXML 1.10 with at least speed ramps preserved (transitions and color may not survive — document what does).
+
+### Phase 5 — Demo + cleanup (1 day)
+
+- End-to-end demo recording: open Resolve, import march-30-workout XML, run apply script, render. Capture timing.
+- Update CLAUDE.md "Workflow Steps" to reflect the new artifact set.
+- Bump version, update CHANGELOG.
+
+## Verification / demo
+
+The success bar: take the `march-30-workout` library, run the roughcut skill, import + apply in Resolve, render. The output should be a 30-second cut with:
+- All speed ramps applied (200% slam, 150% jump-rope insert, 60% hero closer)
+- A consistent color grade across all clips (the saved PowerGrade)
+- Markers at sound-cue points so the editor only has to drop SFX onto markers
+- Render preset loaded for 1080p YouTube
+
+Manual finishing: pick music, drop SFX onto markers, write title card text, render.
+
+## Open questions
+
+1. Resolve scripting API has gaps for transitions and certain effect parameters. Phase 3 needs early spike to confirm what's actually scriptable on the free Resolve version vs Studio. **Action:** day-1 spike script that probes the API; report findings before committing the phase plan.
+2. PowerGrades are project-local. Do we ship a default `GymBlueOrange-v1.drx` in `templates/`? Or require the user to create their own and reference by name?
+3. Where do we store the `<name>_apply.py` template? Inside the skill folder feels right, but Resolve script discovery is path-based — we may need to write the generated script directly into `~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Edit/`. Need to handle both "ship next to roughcut" and "install for Resolve" paths.
+
+## Branch / worktree setup
+
+```bash
+cd /path/to/buttercut
+git checkout -b sprint/editorial-automation
+# or use a worktree to keep main clean for ad-hoc edits:
+git worktree add ../buttercut-sprint-01 sprint/editorial-automation
+```

--- a/docs/sprints/sprint-01-resolve-api-audit.md
+++ b/docs/sprints/sprint-01-resolve-api-audit.md
@@ -1,0 +1,81 @@
+# Resolve Scripting API Audit (Sprint 1, Phase 3 prerequisite)
+
+**Status:** awaiting probe run · **Issue:** #3 · **Blocks:** #4 (Phase 3 apply script)
+
+## Background
+
+Phase 3 plans a per-cut Python script that consumes `<name>.recipe.json` and applies its directives to the imported timeline. Six capabilities sit on the critical path:
+
+1. **Speed ramps** — `TimelineItem` retime curve
+2. **Clip color tags** — `TimelineItem.SetClipColor`
+3. **Markers** — `TimelineItem.AddMarker`
+4. **PowerGrades** — apply a saved grade by name across all clips
+5. **Render presets** — load a saved preset and set it as current
+6. **Transitions** — insert dip-to-color / cross-dissolve between clips
+
+Some of these are well-supported on free Resolve. Others (transitions, PowerGrade-by-name) are documented gaps. This memo establishes verdicts before we commit Phase 3 scope.
+
+## Method
+
+1. Drop `scripts/resolve_api_audit.py` into Resolve's Edit scripts directory:
+   - macOS: `~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Edit/`
+   - Windows: `%APPDATA%\Blackmagic Design\DaVinci Resolve\Support\Fusion\Scripts\Edit\`
+   - Linux: `~/.local/share/DaVinciResolve/Fusion/Scripts/Edit/`
+2. Open Resolve, open any project with at least one clip on V1 of the current timeline.
+3. Open `Workspace > Console` (so the matrix prints somewhere visible).
+4. Run `Workspace > Scripts > Edit > resolve_api_audit`.
+5. Probe writes `~/buttercut_resolve_audit.json` and prints a feature matrix to the console.
+
+The probe is non-destructive: it adds and removes one disposable marker, sets and restores the first clip's color tag, and otherwise only reads.
+
+## Expected priors (from public Resolve scripting docs)
+
+These are the working assumptions going into the probe — to be confirmed or overturned by the run.
+
+| Capability      | Expected      | Reasoning |
+|-----------------|---------------|-----------|
+| `speed_ramps`   | Limited       | `GetClipProperty("Speed")` is documented; retime curve points are not a first-class API on free. Constant speed change is straightforward; multi-point ramps may require workarounds. |
+| `color_tags`    | Yes           | `SetClipColor` / `ClearClipColor` documented and stable across versions. |
+| `markers`       | Yes           | `AddMarker(frame, color, name, note, duration)` documented and stable. |
+| `powergrade`    | Limited       | No direct `ApplyPowerGradeByName()`. Accessible via `Gallery.GetGalleryStillAlbums()` → walk stills → apply. Workable but indirect; album naming matters. |
+| `render_preset` | Yes           | `LoadRenderPreset(name)` and `SetCurrentRenderMode()` documented. `GetRenderPresetList()` enumerates. |
+| `transitions`   | No (likely)   | The Resolve scripting API has historically lacked any public method to insert a transition between clips. The probe enumerates `*transition*` attributes on `project` / `timeline` / `TimelineItem` — if none surface, this is confirmed. |
+
+## Verdict matrix (TODO — fill after running the probe)
+
+Paste the rows from `~/buttercut_resolve_audit.json` here once you've run the script.
+
+| Capability      | API present | Probe result | Notes |
+|-----------------|-------------|--------------|-------|
+| `speed_ramps`   | TBD         | TBD          | TBD   |
+| `color_tags`    | TBD         | TBD          | TBD   |
+| `markers`       | TBD         | TBD          | TBD   |
+| `powergrade`    | TBD         | TBD          | TBD   |
+| `render_preset` | TBD         | TBD          | TBD   |
+| `transitions`   | TBD         | TBD          | TBD   |
+
+Probe environment:
+- Resolve product: TBD
+- Resolve version: TBD
+- Free or Studio: TBD
+
+## Phase 3 implications (TODO — finalize after verdict matrix)
+
+Two branches depending on the `transitions` verdict.
+
+**If transitions are scriptable:**
+- Phase 3 keeps the originally planned scope: speed ramps + color tags + markers + render preset + PowerGrade (best-effort) + transitions.
+- Recipe schema unchanged.
+
+**If transitions are not scriptable on free Resolve:**
+- Phase 3 ships everything *except* transitions. The recipe.json still carries the directives — they just won't be applied automatically.
+- The apply script logs a one-line note per transition: "Phase 4 (FCPXML 1.10) or manual: <type> between clip N and N+1".
+- Phase 4 (FCPXML 1.10 backend, currently optional) becomes the realistic path for transitions, since Resolve's FCPXML import is more permissive than Resolve's xmeml import.
+
+**For PowerGrade specifically** — even if the gallery-still walk is technically possible, the implementation cost may exceed the value. A documented one-click manual step ("right-click hero clip → Apply Grade > GymBlueOrange-v1") is acceptable for Phase 3 if the gallery API path turns out brittle. Decision deferred to verdict review.
+
+## Next steps
+
+1. Run the probe; paste results into the verdict matrix.
+2. Settle the transitions branch above.
+3. Open #4 (Phase 3 apply script) with finalized scope based on this memo.

--- a/docs/sprints/sprint-01-resolve-api-audit.md
+++ b/docs/sprints/sprint-01-resolve-api-audit.md
@@ -1,6 +1,6 @@
 # Resolve Scripting API Audit (Sprint 1, Phase 3 prerequisite)
 
-**Status:** awaiting probe run · **Issue:** #3 · **Blocks:** #4 (Phase 3 apply script)
+**Status:** complete (probe run 2026-05-01 on Resolve 20.2.3.6 free) · **Issue:** #3 · **Blocks:** #4 (Phase 3 apply script)
 
 ## Background
 
@@ -41,41 +41,44 @@ These are the working assumptions going into the probe — to be confirmed or ov
 | `render_preset` | Yes           | `LoadRenderPreset(name)` and `SetCurrentRenderMode()` documented. `GetRenderPresetList()` enumerates. |
 | `transitions`   | No (likely)   | The Resolve scripting API has historically lacked any public method to insert a transition between clips. The probe enumerates `*transition*` attributes on `project` / `timeline` / `TimelineItem` — if none surface, this is confirmed. |
 
-## Verdict matrix (TODO — fill after running the probe)
+## Verdict matrix
 
-Paste the rows from `~/buttercut_resolve_audit.json` here once you've run the script.
+Probe environment:
+- Resolve product: **DaVinci Resolve** (free)
+- Resolve version: **20.2.3.6**
+- Probe run: 2026-05-01
 
 | Capability      | API present | Probe result | Notes |
 |-----------------|-------------|--------------|-------|
-| `speed_ramps`   | TBD         | TBD          | TBD   |
-| `color_tags`    | TBD         | TBD          | TBD   |
-| `markers`       | TBD         | TBD          | TBD   |
-| `powergrade`    | TBD         | TBD          | TBD   |
-| `render_preset` | TBD         | TBD          | TBD   |
-| `transitions`   | TBD         | TBD          | TBD   |
+| `speed_ramps`   | yes         | **error → limited** | Calling `TimelineItem.GetClipProperty("Speed")` raised `TypeError: 'NoneType' object is not callable` in 20.2.3.6 free. The supported automated path is `MediaPoolItem.GetClipProperty("Speed")` / `SetClipProperty(...)`, reached via `TimelineItem.GetMediaPoolItem()`; multi-point retime curves still not in the public API. |
+| `color_tags`    | yes         | **yes**             | `SetClipColor` round-trip succeeded; restoration verified. |
+| `markers`       | yes         | **yes**             | `AddMarker(frame=1, "Red", ...)` returned True; cleanup succeeded. |
+| `powergrade`    | yes         | **limited**         | Gallery + `GetGalleryStillAlbums` + `GetCurrentStillAlbum` all present; one album returned with `None` label. No direct `ApplyPowerGradeByName` — must walk stills. |
+| `render_preset` | yes         | **yes**             | `LoadRenderPreset` + `SetCurrentRenderMode` both present and callable. 24 saved presets visible. |
+| `transitions`   | no          | **no**              | Probe found no `*transition*`-named attributes on `Project`, `Timeline`, or `TimelineItem` via its attribute/membership scan. Strong enough evidence to treat transitions as non-scriptable for Phase 3, even if a non-obviously-named method exists. |
 
-Probe environment:
-- Resolve product: TBD
-- Resolve version: TBD
-- Free or Studio: TBD
+## Phase 3 implications
 
-## Phase 3 implications (TODO — finalize after verdict matrix)
+Transitions are **not surfaced by the probe's scan** on Resolve 20.2.3 free, and on the strength of that evidence Phase 3 treats them as non-scriptable. Phase 3 takes the second branch:
 
-Two branches depending on the `transitions` verdict.
+**Phase 3 scope (locked):**
 
-**If transitions are scriptable:**
-- Phase 3 keeps the originally planned scope: speed ramps + color tags + markers + render preset + PowerGrade (best-effort) + transitions.
-- Recipe schema unchanged.
+| Recipe directive | Phase 3 path |
+|------------------|--------------|
+| Speed ramps (constant) | Apply via `MediaPoolItem.SetClipProperty("Speed", value)`, reached through `TimelineItem.GetMediaPoolItem()`. Single-value only — applies a `recipe.speed_ramps` entry only when the clip has exactly one ramp point. |
+| Speed ramps (multi-point) | Out of scope. Recipe carries the points unchanged for Phase 4 / future; the apply script logs `"Multi-point ramp on clip N — apply manually in Resolve retime curve."` and applies nothing for that clip's ramp. |
+| Color tags | `TimelineItem.SetClipColor(tag)` — full support. |
+| Markers | `TimelineItem.AddMarker(frame, color, name, note, duration)` — full support. |
+| PowerGrade | Best-effort: walk `Gallery.GetGalleryStillAlbums()` for a still whose label matches `recipe.powergrade.name`, apply via still selection. If lookup fails, log `"PowerGrade '<name>' not found — apply manually."` and continue. |
+| Render preset | `Project.LoadRenderPreset(name)` + `Project.SetCurrentRenderMode()` — full support. |
+| Transitions | **Not applied.** Logged per transition: `"Phase 4 (FCPXML 1.10) or manual: <type> between clip N and N+1."` Recipe still carries the directives. |
+| Title card | Not applied (no scripted text generator API surfaced). Logged as manual. |
 
-**If transitions are not scriptable on free Resolve:**
-- Phase 3 ships everything *except* transitions. The recipe.json still carries the directives — they just won't be applied automatically.
-- The apply script logs a one-line note per transition: "Phase 4 (FCPXML 1.10) or manual: <type> between clip N and N+1".
-- Phase 4 (FCPXML 1.10 backend, currently optional) becomes the realistic path for transitions, since Resolve's FCPXML import is more permissive than Resolve's xmeml import.
+**Phase 4 (FCPXML 1.10) becomes recommended, not optional** — it's the realistic path for transitions on Resolve. Speed ramps may also survive better through the FCPXML round-trip than through the apply script.
 
-**For PowerGrade specifically** — even if the gallery-still walk is technically possible, the implementation cost may exceed the value. A documented one-click manual step ("right-click hero clip → Apply Grade > GymBlueOrange-v1") is acceptable for Phase 3 if the gallery API path turns out brittle. Decision deferred to verdict review.
+**One follow-up against the probe itself:** the `speed_ramps` `TypeError` confirms `TimelineItem.GetClipProperty` is unreliable in 20.2.3. Phase 3's apply script must reach `Speed` via `MediaPoolItem`. The probe could be tightened in a future iteration to test that path directly — not blocking Phase 3.
 
 ## Next steps
 
-1. Run the probe; paste results into the verdict matrix.
-2. Settle the transitions branch above.
-3. Open #4 (Phase 3 apply script) with finalized scope based on this memo.
+1. Open #4 (Phase 3 apply script) with the locked scope above.
+2. Promote #5 (Phase 4 / FCPXML 1.10) from optional to recommended.

--- a/lib/buttercut.rb
+++ b/lib/buttercut.rb
@@ -1,5 +1,6 @@
 require_relative 'buttercut/fcpx'
 require_relative 'buttercut/fcp7'
+require_relative 'buttercut/recipe'
 
 # ButterCut - Video editor XML generator
 #

--- a/lib/buttercut/fcpx.rb
+++ b/lib/buttercut/fcpx.rb
@@ -2,9 +2,20 @@ require_relative 'editor_base'
 require 'nokogiri'
 
 class ButterCut
-  # Final Cut Pro X (FCPXML 1.8) implementation.
+  # Final Cut Pro X (FCPXML 1.10) implementation. Speed ramps from the
+  # editorial recipe are emitted as <timeMap> elements inside <asset-clip>
+  # so that DaVinci Resolve preserves them on import without needing the
+  # apply script.
   class FCPX < EditorBase
     FORMAT_ID = "r1".freeze
+    FCPXML_VERSION = "1.10".freeze
+
+    EASE_TO_INTERP = {
+      "linear"       => "linear",
+      "ease-in"      => "smooth2",
+      "ease-out"     => "smooth2",
+      "ease-in-out"  => "smooth2"
+    }.freeze
 
     def to_xml
       raise ArgumentError, "No clips provided" if clips.empty?
@@ -23,7 +34,7 @@ class ButterCut
       timestamped_project_name = "#{project_basename} #{timestamp_suffix}"
 
       builder = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
-        xml.fcpxml(version: '1.8') do
+        xml.fcpxml(version: FCPXML_VERSION) do
           xml.resources do
             xml.format(
               id: FORMAT_ID,
@@ -63,6 +74,7 @@ class ButterCut
                         duration: clip[:duration],
                         audioRole: 'dialogue'
                       ) do
+                        emit_time_map(xml, clip)
                         xml.send('adjust-volume', amount: volume_adjustment)
                       end
                     end
@@ -75,6 +87,72 @@ class ButterCut
       end
 
       builder.to_xml
+    end
+
+    private
+
+    def emit_time_map(xml, clip)
+      ramps = clip.dig(:clip_definition, :speed_ramps)
+      return if ramps.nil? || ramps.empty?
+
+      points = build_time_map_points(ramps, clip)
+      return if points.length < 2
+
+      xml.timeMap do
+        points.each do |pt|
+          xml.timept(time: pt[:time], value: pt[:value], interp: pt[:interp])
+        end
+      end
+    end
+
+    # Translate recipe speed ramps (output-time waypoints with speed %) into
+    # FCPXML <timept> control points. Each timept is (output_time, source_time);
+    # the slope between adjacent points is the effective speed for that segment.
+    # We integrate piecewise using the average of adjacent speeds, which gives
+    # a plausible source-time curve for both linear and smooth2 interp.
+    def build_time_map_points(ramps, clip)
+      sorted = ramps.sort_by { |r| ramp_at_seconds(r) }
+      clip_duration = fraction_to_rational(clip[:duration])
+
+      waypoints = sorted.map do |ramp|
+        {
+          at:     Rational(ramp_at_seconds(ramp)),
+          speed:  Rational(ramp["speed"]) / 100,
+          interp: EASE_TO_INTERP.fetch(ramp["ease"], "linear")
+        }
+      end
+
+      waypoints.unshift({ at: Rational(0), speed: waypoints.first[:speed], interp: waypoints.first[:interp] }) if waypoints.first[:at] > 0
+      waypoints.push({ at: clip_duration, speed: waypoints.last[:speed], interp: waypoints.last[:interp] }) if waypoints.last[:at] < clip_duration
+
+      points = []
+      cumulative_source = Rational(0)
+      waypoints.each_with_index do |wp, i|
+        if i > 0
+          prev = waypoints[i - 1]
+          segment_dt = wp[:at] - prev[:at]
+          avg_speed = (prev[:speed] + wp[:speed]) / 2
+          cumulative_source += segment_dt * avg_speed
+        end
+        points << {
+          time:   rational_to_fraction(wp[:at]),
+          value:  rational_to_fraction(cumulative_source),
+          interp: wp[:interp]
+        }
+      end
+      points
+    end
+
+    def ramp_at_seconds(ramp)
+      at = ramp["at"]
+      raise ArgumentError, "speed_ramp missing 'at'" if at.nil?
+      at.to_f
+    end
+
+    def rational_to_fraction(rational)
+      rational = Rational(rational) unless rational.is_a?(Rational)
+      return "0s" if rational.zero?
+      "#{rational.numerator}/#{rational.denominator}s"
     end
   end
 end

--- a/lib/buttercut/recipe.rb
+++ b/lib/buttercut/recipe.rb
@@ -1,0 +1,239 @@
+require 'json'
+
+class ButterCut
+  # Editorial recipe emitted alongside the rough-cut XML. Captures per-clip
+  # directives (speed ramps, color tags, markers), transitions between clips,
+  # an optional title card, render preset, and PowerGrade reference. The
+  # recipe is consumed by a Resolve apply script (see Sprint 1).
+  class Recipe
+    SCHEMA_VERSION = 1
+
+    CLIP_COLOR_TAGS = %w[
+      Orange Apricot Yellow Lime Olive Green Teal Navy Blue
+      Purple Violet Pink Tan Beige Brown Chocolate
+    ].freeze
+
+    MARKER_COLORS = %w[
+      Blue Cyan Green Yellow Red Pink Purple Fuchsia Rose
+      Lavender Sky Mint Lemon Sand Cocoa Cream
+    ].freeze
+
+    EASE_TYPES = %w[linear ease-in ease-out ease-in-out].freeze
+    TRANSITION_TYPES = %w[dip_to_color cross_dissolve].freeze
+    DIP_COLORS = %w[black white].freeze
+
+    def self.from_hash(hash)
+      raise ArgumentError, "recipe hash required" unless hash.is_a?(Hash)
+
+      new(
+        version: hash["version"],
+        library: hash["library"],
+        timeline: hash["timeline"],
+        clips: hash["clips"],
+        render_preset: hash["render_preset"],
+        powergrade: hash["powergrade"],
+        transitions: hash.key?("transitions") ? hash["transitions"] : [],
+        title_card: hash["title_card"]
+      )
+    end
+
+    def self.load(path)
+      from_hash(JSON.parse(File.read(path)))
+    end
+
+    def initialize(version:, library:, timeline:, clips:, render_preset: nil, powergrade: nil, transitions: [], title_card: nil)
+      @version = version
+      @library = library
+      @timeline = timeline
+      @clips = clips
+      @render_preset = render_preset
+      @powergrade = powergrade
+      @transitions = transitions
+      @title_card = title_card
+
+      validate!
+    end
+
+    def to_h
+      h = {
+        "version" => @version,
+        "library" => @library,
+        "timeline" => @timeline
+      }
+      h["render_preset"] = @render_preset if @render_preset
+      h["powergrade"] = @powergrade if @powergrade
+      h["clips"] = @clips
+      h["transitions"] = @transitions unless @transitions.empty?
+      h["title_card"] = @title_card if @title_card
+      h
+    end
+
+    def to_json(*args)
+      JSON.generate(to_h, *args)
+    end
+
+    def save(path)
+      File.write(path, JSON.pretty_generate(to_h))
+    end
+
+    private
+
+    def validate!
+      validate_version!
+      validate_string!(@library, "library")
+      validate_string!(@timeline, "timeline")
+      validate_clips!
+      validate_render_preset! if @render_preset
+      validate_powergrade! if @powergrade
+      validate_transitions!
+      validate_title_card! if @title_card
+    end
+
+    def validate_version!
+      raise ArgumentError, "version must be #{SCHEMA_VERSION}, got #{@version.inspect}" unless @version == SCHEMA_VERSION
+    end
+
+    def validate_string!(value, field)
+      raise ArgumentError, "#{field} required" if value.nil? || !value.is_a?(String) || value.empty?
+    end
+
+    def validate_positive_int!(value, field)
+      raise ArgumentError, "#{field} must be a positive integer, got #{value.inspect}" unless value.is_a?(Integer) && value.positive?
+    end
+
+    def validate_non_negative_number!(value, field)
+      raise ArgumentError, "#{field} must be a non-negative number, got #{value.inspect}" unless value.is_a?(Numeric) && value >= 0
+    end
+
+    def validate_clips!
+      raise ArgumentError, "clips must be a non-empty array" unless @clips.is_a?(Array) && !@clips.empty?
+
+      @clips.each { |clip| validate_clip!(clip) }
+
+      duplicates = clip_indices.tally.select { |_, count| count > 1 }.keys
+      unless duplicates.empty?
+        raise ArgumentError, "clip indices must be unique, duplicates: #{duplicates.inspect}"
+      end
+    end
+
+    def clip_indices
+      @clip_indices ||= @clips.map { |c| c["index"] }
+    end
+
+    def clip_positions
+      @clip_positions ||= @clips.each_with_index.to_h { |clip, pos| [clip["index"], pos] }
+    end
+
+    def validate_clip!(clip)
+      raise ArgumentError, "clip must be a hash" unless clip.is_a?(Hash)
+      validate_positive_int!(clip["index"], "clip index")
+      validate_string!(clip["source_file"], "clip source_file")
+
+      speed_ramps = clip.key?("speed_ramps") ? clip["speed_ramps"] : []
+      raise ArgumentError, "clip #{clip["index"]} speed_ramps must be an array" unless speed_ramps.is_a?(Array)
+      speed_ramps.each { |ramp| validate_speed_ramp!(ramp, clip["index"]) }
+
+      if clip.key?("color_tag") && !CLIP_COLOR_TAGS.include?(clip["color_tag"])
+        raise ArgumentError, "clip #{clip["index"]} color_tag #{clip["color_tag"].inspect} not in #{CLIP_COLOR_TAGS.inspect}"
+      end
+
+      markers = clip.key?("markers") ? clip["markers"] : []
+      raise ArgumentError, "clip #{clip["index"]} markers must be an array" unless markers.is_a?(Array)
+      markers.each { |marker| validate_marker!(marker, clip["index"]) }
+    end
+
+    def validate_speed_ramp!(ramp, clip_index)
+      raise ArgumentError, "clip #{clip_index} speed_ramp must be a hash" unless ramp.is_a?(Hash)
+      validate_non_negative_number!(ramp["at"], "clip #{clip_index} speed_ramp at")
+      speed = ramp["speed"]
+      unless speed.is_a?(Numeric) && speed > 0
+        raise ArgumentError, "clip #{clip_index} speed_ramp speed must be > 0, got #{speed.inspect}"
+      end
+      unless EASE_TYPES.include?(ramp["ease"])
+        raise ArgumentError, "clip #{clip_index} speed_ramp ease #{ramp["ease"].inspect} not in #{EASE_TYPES.inspect}"
+      end
+    end
+
+    def validate_marker!(marker, clip_index)
+      raise ArgumentError, "clip #{clip_index} marker must be a hash" unless marker.is_a?(Hash)
+      validate_non_negative_number!(marker["at"], "clip #{clip_index} marker at")
+      name = marker["name"]
+      raise ArgumentError, "clip #{clip_index} marker name required" if !name.is_a?(String) || name.empty?
+      unless MARKER_COLORS.include?(marker["color"])
+        raise ArgumentError, "clip #{clip_index} marker color #{marker["color"].inspect} not in #{MARKER_COLORS.inspect}"
+      end
+    end
+
+    def validate_render_preset!
+      raise ArgumentError, "render_preset must be a hash" unless @render_preset.is_a?(Hash)
+      validate_string!(@render_preset["format"], "render_preset format")
+      validate_string!(@render_preset["codec"], "render_preset codec")
+      validate_string!(@render_preset["resolution"], "render_preset resolution")
+      validate_positive_int!(@render_preset["bitrate_kbps"], "render_preset bitrate_kbps")
+    end
+
+    def validate_powergrade!
+      raise ArgumentError, "powergrade must be a hash" unless @powergrade.is_a?(Hash)
+      validate_string!(@powergrade["name"], "powergrade name")
+
+      apply_to = @powergrade["apply_to"]
+      case apply_to
+      when "all"
+        # ok
+      when Array
+        apply_to.each do |idx|
+          unless clip_indices.include?(idx)
+            raise ArgumentError, "powergrade apply_to references unknown clip index #{idx}"
+          end
+        end
+      else
+        raise ArgumentError, "powergrade apply_to must be 'all' or an array of clip indices, got #{apply_to.inspect}"
+      end
+    end
+
+    def validate_transitions!
+      raise ArgumentError, "transitions must be an array" unless @transitions.is_a?(Array)
+      @transitions.each { |t| validate_transition!(t) }
+    end
+
+    def validate_transition!(t)
+      raise ArgumentError, "transition must be a hash" unless t.is_a?(Hash)
+
+      between = t["between"]
+      unless between.is_a?(Array) && between.length == 2 && between.all? { |i| i.is_a?(Integer) }
+        raise ArgumentError, "transition between must be a [a, b] pair of integers, got #{between.inspect}"
+      end
+      a, b = between
+      unless clip_indices.include?(a) && clip_indices.include?(b)
+        missing = [a, b].reject { |i| clip_indices.include?(i) }
+        raise ArgumentError, "transition between references unknown clip index #{missing.first}"
+      end
+      unless clip_positions[b] == clip_positions[a] + 1
+        raise ArgumentError, "transition between #{between.inspect} must reference adjacent clips in recipe order"
+      end
+
+      unless TRANSITION_TYPES.include?(t["type"])
+        raise ArgumentError, "transition type #{t["type"].inspect} not in #{TRANSITION_TYPES.inspect}"
+      end
+
+      validate_positive_int!(t["duration_frames"], "transition duration_frames")
+
+      if t["type"] == "dip_to_color"
+        unless DIP_COLORS.include?(t["color"])
+          raise ArgumentError, "dip_to_color transition color #{t["color"].inspect} not in #{DIP_COLORS.inspect}"
+        end
+      end
+    end
+
+    def validate_title_card!
+      raise ArgumentError, "title_card must be a hash" unless @title_card.is_a?(Hash)
+      at_clip = @title_card["at_clip"]
+      unless clip_indices.include?(at_clip)
+        raise ArgumentError, "title_card at_clip references unknown clip index #{at_clip.inspect}"
+      end
+      validate_string!(@title_card["text"], "title_card text")
+      validate_non_negative_number!(@title_card["fade_in_at"], "title_card fade_in_at")
+      validate_positive_int!(@title_card["fade_in_frames"], "title_card fade_in_frames")
+    end
+  end
+end

--- a/scripts/resolve_api_audit.py
+++ b/scripts/resolve_api_audit.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""DaVinci Resolve scripting API audit probe.
+
+Drop into:
+  macOS:   ~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Edit/
+  Windows: %APPDATA%\\Blackmagic Design\\DaVinci Resolve\\Support\\Fusion\\Scripts\\Edit\\
+  Linux:   ~/.local/share/DaVinciResolve/Fusion/Scripts/Edit/
+
+Run from inside Resolve via:
+  Workspace > Scripts > Edit > resolve_api_audit
+
+Open the Console (Workspace > Console) before running so you can see the matrix.
+
+The probe is non-destructive: it adds one disposable marker to an unused frame
+on the current timeline (if any) and removes it; it temporarily sets the first
+clip's color tag and restores the original value before exiting. It does NOT
+save the project. It writes the result matrix to:
+  ~/buttercut_resolve_audit.json
+
+Paste that file back into the Phase 3 audit memo to finalize verdicts.
+"""
+
+from __future__ import annotations
+import json
+import os
+import sys
+import traceback
+from datetime import datetime, timezone
+
+
+def get_resolve():
+    """Resolve injects `resolve` into the script's globals when run from
+    Workspace > Scripts. We also try the standard external bootstrap as a
+    fallback for users running externally with DaVinciResolveScript on path."""
+    if "resolve" in globals():
+        return globals()["resolve"]
+    try:
+        import DaVinciResolveScript as dvr_script  # type: ignore
+        return dvr_script.scriptapp("Resolve")
+    except Exception:
+        return None
+
+
+class Probe:
+    def __init__(self, name, present_check, probe):
+        self.name = name
+        self.present_check = present_check
+        self.probe = probe
+
+    def run(self, ctx):
+        try:
+            present = bool(self.present_check(ctx))
+        except Exception:
+            present = False
+
+        if not present:
+            return {
+                "capability": self.name,
+                "api_present": False,
+                "probe_result": "skipped",
+                "notes": "API entry point not found on this Resolve build."
+            }
+
+        try:
+            verdict, notes = self.probe(ctx)
+            return {
+                "capability": self.name,
+                "api_present": True,
+                "probe_result": verdict,
+                "notes": notes
+            }
+        except Exception as e:
+            return {
+                "capability": self.name,
+                "api_present": True,
+                "probe_result": "error",
+                "notes": f"{type(e).__name__}: {e}"
+            }
+
+
+def probe_speed_ramp(ctx):
+    item = ctx["first_clip"]
+    if not item:
+        return "skipped", "no clip on V1 to probe"
+    has_constant = hasattr(item, "GetClipProperty") and hasattr(item, "SetClipProperty")
+    speed = item.GetClipProperty("Speed") if hasattr(item, "GetClipProperty") else None
+    # Look specifically for retime-curve / time-effect methods. Generic
+    # SetProperty/GetProperty don't count — they exist on builds where curve
+    # editing is unavailable.
+    ramp_methods = [
+        attr for attr in dir(item)
+        if any(needle in attr.lower() for needle in ("retime", "speedchange", "speedpoint", "timeeffect"))
+    ]
+    if ramp_methods:
+        return "yes", f"constant-speed via SetClipProperty('Speed') ({speed!r}); ramp methods: {ramp_methods}"
+    if has_constant:
+        return "limited", (
+            f"only constant speed via SetClipProperty('Speed') ({speed!r}); "
+            f"no retime/speedpoint/timeeffect methods on TimelineItem — multi-point ramps not in public API"
+        )
+    return "no", "no SetClipProperty on TimelineItem"
+
+
+def probe_color_tag(ctx):
+    item = ctx["first_clip"]
+    if not item:
+        return "skipped", "no clip on V1 to probe"
+    if not hasattr(item, "ClearClipColor") or not hasattr(item, "SetClipColor"):
+        return "limited", "SetClipColor / ClearClipColor missing"
+    original = item.GetClipColor() if hasattr(item, "GetClipColor") else None
+    set_ok = bool(item.SetClipColor("Orange"))
+    restore_ok = True
+    restore_err = None
+    try:
+        if original:
+            restore_ok = bool(item.SetClipColor(original))
+        else:
+            restore_ok = bool(item.ClearClipColor())
+    except Exception as e:
+        restore_ok = False
+        restore_err = f"{type(e).__name__}: {e}"
+    if set_ok and not restore_ok:
+        return "error", f"SetClipColor succeeded but restore failed ({restore_err or 'returned False'})"
+    return ("yes" if set_ok else "no",
+            f"SetClipColor returned {set_ok!r}; original={original!r}; restored={restore_ok!r}")
+
+
+def probe_marker(ctx):
+    item = ctx["first_clip"]
+    if not item:
+        return "skipped", "no clip on V1 to probe"
+    if not hasattr(item, "AddMarker") or not hasattr(item, "DeleteMarkerAtFrame"):
+        return "limited", "AddMarker / DeleteMarkerAtFrame missing"
+    if not hasattr(item, "GetMarkers"):
+        return "limited", "GetMarkers unavailable; skipping write probe to avoid colliding with existing markers"
+    existing = item.GetMarkers() or {}
+    used_frames = set()
+    for k in existing.keys():
+        try:
+            used_frames.add(int(k))
+        except Exception:
+            continue
+    frame = 1
+    while frame in used_frames:
+        frame += 1
+    added = item.AddMarker(frame, "Red", "buttercut_audit_probe", "buttercut audit", 1)
+    if added:
+        try:
+            deleted = item.DeleteMarkerAtFrame(frame)
+            if not deleted:
+                return "error", f"AddMarker succeeded at frame {frame}, but DeleteMarkerAtFrame returned False"
+        except Exception as e:
+            return "error", f"AddMarker succeeded at frame {frame}, cleanup threw {type(e).__name__}: {e}"
+    return ("yes" if added else "no",
+            f"AddMarker at frame {frame} returned {added!r}")
+
+
+def probe_powergrade(ctx):
+    project = ctx["project"]
+    gallery = project.GetGallery() if project and hasattr(project, "GetGallery") else None
+    if not gallery:
+        return "limited", "Project.GetGallery() not available; PowerGrade-by-name not directly scriptable"
+    has_albums_api = hasattr(gallery, "GetGalleryStillAlbums") and hasattr(gallery, "GetCurrentStillAlbum")
+    if not has_albums_api:
+        return "limited", "Gallery present but album-walk API missing (no GetGalleryStillAlbums / GetCurrentStillAlbum)"
+    albums = []
+    try:
+        albums = gallery.GetGalleryStillAlbums() or []
+    except Exception as e:
+        return "limited", f"GetGalleryStillAlbums raised {type(e).__name__}: {e}"
+    album_names = [a.GetLabel() if hasattr(a, "GetLabel") else "?" for a in albums]
+    return ("limited",
+            f"album-walk API present (no direct ApplyPowerGradeByName); albums={album_names or '[]'}")
+
+
+def probe_render_preset(ctx):
+    project = ctx["project"]
+    if not project:
+        return "skipped", "no project open"
+    has_load = hasattr(project, "LoadRenderPreset") and hasattr(project, "SetCurrentRenderMode")
+    preset_count = None
+    try:
+        preset_count = len(project.GetRenderPresetList() or [])
+    except Exception:
+        preset_count = None
+    return ("yes" if has_load else "no",
+            f"LoadRenderPreset+SetCurrentRenderMode={has_load}; saved preset count={preset_count} (info only — verdict is API-driven)")
+
+
+def probe_transitions(ctx):
+    project = ctx["project"]
+    timeline = ctx["timeline"]
+    has_anything = False
+    candidates = []
+    for obj_name, obj in (("project", project), ("timeline", timeline), ("first_clip", ctx["first_clip"])):
+        if obj is None:
+            continue
+        for attr in dir(obj):
+            if "transition" in attr.lower():
+                candidates.append(f"{obj_name}.{attr}")
+                has_anything = True
+    return ("yes" if has_anything else "no",
+            f"transition-related methods found: {candidates or 'none'}")
+
+
+PROBES = [
+    Probe("speed_ramps",   lambda ctx: ctx["first_clip"], probe_speed_ramp),
+    Probe("color_tags",    lambda ctx: ctx["first_clip"], probe_color_tag),
+    Probe("markers",       lambda ctx: ctx["first_clip"], probe_marker),
+    Probe("powergrade",    lambda ctx: ctx["project"],    probe_powergrade),
+    Probe("render_preset", lambda ctx: ctx["project"],    probe_render_preset),
+    Probe("transitions",   lambda ctx: ctx["timeline"] or ctx["project"], probe_transitions),
+]
+
+
+def build_context(resolve):
+    ctx = {"resolve": resolve, "project": None, "timeline": None, "first_clip": None}
+    if not resolve:
+        return ctx
+    pm = resolve.GetProjectManager()
+    if not pm:
+        return ctx
+    project = pm.GetCurrentProject()
+    ctx["project"] = project
+    if not project:
+        return ctx
+    timeline = project.GetCurrentTimeline()
+    ctx["timeline"] = timeline
+    if timeline and hasattr(timeline, "GetItemListInTrack"):
+        try:
+            items = timeline.GetItemListInTrack("video", 1) or []
+            if items:
+                ctx["first_clip"] = items[0]
+        except Exception:
+            pass
+    return ctx
+
+
+def main():
+    resolve = get_resolve()
+    if not resolve:
+        print("ERROR: could not connect to Resolve. Run from inside Resolve via Workspace > Scripts.")
+        sys.exit(1)
+
+    print(f"Resolve product: {resolve.GetProductName()}  version: {resolve.GetVersionString()}")
+    ctx = build_context(resolve)
+    print(f"  project: {ctx['project'].GetName() if ctx['project'] else '(none open)'}")
+    print(f"  timeline: {ctx['timeline'].GetName() if ctx['timeline'] else '(none)'}")
+    print(f"  first V1 clip: {ctx['first_clip'].GetName() if ctx['first_clip'] else '(none)'}")
+    print()
+
+    rows = [probe.run(ctx) for probe in PROBES]
+
+    width = max(len(r["capability"]) for r in rows)
+    print(f"{'capability'.ljust(width)}  api_present  probe_result  notes")
+    print(f"{'-' * width}  -----------  ------------  -----")
+    for r in rows:
+        print(f"{r['capability'].ljust(width)}  {str(r['api_present']).ljust(11)}  {r['probe_result'].ljust(12)}  {r['notes']}")
+
+    out_path = os.path.expanduser("~/buttercut_resolve_audit.json")
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "resolve_product": resolve.GetProductName(),
+        "resolve_version": resolve.GetVersionString(),
+        "results": rows,
+    }
+    try:
+        with open(out_path, "w") as f:
+            json.dump(payload, f, indent=2)
+        print(f"\nWrote {out_path}")
+    except Exception as e:
+        print(f"\nFailed to write {out_path}: {e}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        traceback.print_exc()

--- a/spec/buttercut/fcpx_spec.rb
+++ b/spec/buttercut/fcpx_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe ButterCut::FCPX do
       xml = generator.to_xml
 
       expect(xml).to include('<?xml version="1.0" encoding="utf-8"?>')
-      expect(xml).to include('<fcpxml version="1.8">')
+      expect(xml).to include('<fcpxml version="1.10">')
       expect(xml).to include('</fcpxml>')
     end
 
@@ -539,7 +539,7 @@ RSpec.describe ButterCut::FCPX do
 
       expect(File.exist?(filename)).to be true
       content = File.read(filename)
-      expect(content).to include('<fcpxml version="1.8">')
+      expect(content).to include('<fcpxml version="1.10">')
     end
 
     it 'saves complete valid FCPXML' do

--- a/spec/buttercut/fcpx_speed_ramps_spec.rb
+++ b/spec/buttercut/fcpx_speed_ramps_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+require 'nokogiri'
+
+RSpec.describe ButterCut::FCPX, 'speed ramps via FCPXML 1.10 timeMap' do
+  let(:clip_path) { '/tmp/ramp_clip.mov' }
+  let(:metadata) do
+    {
+      'streams' => [
+        {
+          'codec_type' => 'video',
+          'width' => 1920,
+          'height' => 1080,
+          'r_frame_rate' => '30000/1001',
+          'color_space' => 'bt709',
+          'color_primaries' => 'bt709',
+          'color_transfer' => 'bt709',
+          'tags' => { 'timecode' => '00:00:00;00' }
+        },
+        { 'codec_type' => 'audio', 'sample_rate' => '48000' }
+      ],
+      'format' => { 'duration' => '10.0', 'tags' => { 'timecode' => '00:00:00;00' } }
+    }
+  end
+
+  before do
+    allow_any_instance_of(ButterCut::FCPX).to receive(:extract_metadata_from_ffprobe).and_return(metadata)
+  end
+
+  def parse(xml)
+    Nokogiri::XML(xml)
+  end
+
+  it 'declares FCPXML version 1.10' do
+    generator = ButterCut::FCPX.new([{ path: clip_path }])
+    doc = parse(generator.to_xml)
+    expect(doc.at_xpath('/fcpxml')['version']).to eq('1.10')
+  end
+
+  it 'omits timeMap when no speed_ramps are present' do
+    generator = ButterCut::FCPX.new([{ path: clip_path, start_at: 0.0, duration: 4.0 }])
+    doc = parse(generator.to_xml)
+    expect(doc.xpath('//timeMap')).to be_empty
+  end
+
+  it 'emits a timeMap with timept waypoints when a clip has speed_ramps' do
+    ramps = [
+      { 'at' => 0.0, 'speed' => 200, 'ease' => 'ease-out' },
+      { 'at' => 1.0, 'speed' => 100, 'ease' => 'ease-in' }
+    ]
+    generator = ButterCut::FCPX.new([
+      { path: clip_path, start_at: 0.0, duration: 2.0, speed_ramps: ramps }
+    ])
+    doc = parse(generator.to_xml)
+
+    time_maps = doc.xpath('//timeMap')
+    expect(time_maps.length).to eq(1)
+
+    timepts = time_maps.first.xpath('timept')
+    expect(timepts.length).to be >= 2
+
+    times = timepts.map { |t| t['time'] }
+    expect(times.first).to eq('0s')
+
+    interps = timepts.map { |t| t['interp'] }
+    expect(interps).to all(satisfy { |v| %w[linear smooth2].include?(v) })
+
+    expect(timepts.last['value']).not_to eq('0s')
+  end
+
+  it 'maps ease values to FCPXML interp keywords' do
+    ramps = [
+      { 'at' => 0.0, 'speed' => 100, 'ease' => 'linear' },
+      { 'at' => 0.5, 'speed' => 150, 'ease' => 'ease-in-out' }
+    ]
+    generator = ButterCut::FCPX.new([
+      { path: clip_path, start_at: 0.0, duration: 2.0, speed_ramps: ramps }
+    ])
+    doc = parse(generator.to_xml)
+    interps = doc.xpath('//timeMap/timept').map { |t| t['interp'] }
+    expect(interps).to include('linear', 'smooth2')
+  end
+
+  it 'pads with a leading timept at output 0 when first ramp is mid-clip' do
+    ramps = [{ 'at' => 0.5, 'speed' => 200, 'ease' => 'linear' }]
+    generator = ButterCut::FCPX.new([
+      { path: clip_path, start_at: 0.0, duration: 2.0, speed_ramps: ramps }
+    ])
+    doc = parse(generator.to_xml)
+    timepts = doc.xpath('//timeMap/timept')
+    expect(timepts.first['time']).to eq('0s')
+    expect(timepts.length).to be >= 2
+  end
+end

--- a/spec/fixtures/full_media_all_clips.fcpxml
+++ b/spec/fixtures/full_media_all_clips.fcpxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<fcpxml version="1.8">
+<fcpxml version="1.10">
   <resources>
     <format id="r1" height="720" width="1280" frameDuration="1001/24000s" colorSpace="1-1-1 (Rec. 709)"/>
     <asset id="__ASSET_ID_MVI_0309__" name="MVI_0309_720p.mov" uid="__ASSET_UID_MVI_0309__" src="__SRC_MVI_0309__" start="0s" audioRate="48000" hasAudio="1" hasVideo="1" format="r1" duration="101101/24000s"/>

--- a/spec/fixtures/full_media_last_second.fcpxml
+++ b/spec/fixtures/full_media_last_second.fcpxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<fcpxml version="1.8">
+<fcpxml version="1.10">
   <resources>
     <format id="r1" height="720" width="1280" frameDuration="1001/24000s" colorSpace="1-1-1 (Rec. 709)"/>
     <asset id="__ASSET_ID_MVI_0309__" name="MVI_0309_720p.mov" uid="__ASSET_UID_MVI_0309__" src="__SRC_MVI_0309__" start="0s" audioRate="48000" hasAudio="1" hasVideo="1" format="r1" duration="101101/24000s"/>

--- a/spec/fixtures/three_clip_timeline.fcpxml
+++ b/spec/fixtures/three_clip_timeline.fcpxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<fcpxml version="1.8">
+<fcpxml version="1.10">
   <resources>
     <format id="r1" height="720" width="1280" frameDuration="1001/24000s" colorSpace="1-1-1 (Rec. 709)"/>
     <asset id="r2" name="MVI_0309_720p.mov" uid="" src="__SRC_MVI_0309__" audioRate="48000" hasAudio="1" hasVideo="1" format="r1" duration="101101/24000s"/>

--- a/spec/generate_apply_script_spec.rb
+++ b/spec/generate_apply_script_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+require 'tmpdir'
+
+require_relative '../.claude/skills/roughcut/generate_apply_script'
+
+RSpec.describe GenerateApplyScript do
+  it 'stamps the absolute recipe path into the apply script' do
+    Dir.mktmpdir do |dir|
+      recipe_path = File.join(dir, 'cut.recipe.json')
+      File.write(recipe_path, '{}')
+      output_path = File.join(dir, 'cut_apply.py')
+
+      described_class.generate(recipe_path: recipe_path, output_path: output_path)
+
+      content = File.read(output_path)
+      expect(content).to include(%(RECIPE_PATH = "#{File.expand_path(recipe_path)}"))
+      expect(content).not_to include('{{RECIPE_PATH}}')
+    end
+  end
+
+  it 'JSON-escapes paths containing quotes or backslashes' do
+    # Simulate hostile path values without relying on the filesystem to allow
+    # them — we're testing the substitution, not Dir.mkdir.
+    instance = described_class.new(recipe_path: '/tmp/r.json', output_path: '/tmp/out.py')
+    instance.instance_variable_set(:@recipe_path, %(/tmp/name with "quote" and \\ backslash/r.json))
+
+    Dir.mktmpdir do |dir|
+      output_path = File.join(dir, 'out.py')
+      instance.instance_variable_set(:@output_path, output_path)
+      instance.generate
+
+      content = File.read(output_path)
+      stamped = content[/^RECIPE_PATH = .*/]
+      # Quote inside the path must be escaped as \"
+      expect(stamped).to include('\\"quote\\"')
+      # Backslash inside the path must be escaped as \\
+      expect(stamped).to include('and \\\\ backslash')
+      expect(content).not_to include('{{RECIPE_PATH}}')
+
+      # And the stamped line must be a valid Python string literal — eval it
+      # in Python and check it round-trips to the original path.
+      py = "import ast, sys; sys.stdout.write(ast.literal_eval(#{stamped.split('=', 2).last.strip.inspect}))"
+      result = `python3 -c #{py.shellescape}`
+      expect(result).to eq(%(/tmp/name with "quote" and \\ backslash/r.json))
+    end
+  end
+
+  it 'produces an executable file' do
+    Dir.mktmpdir do |dir|
+      recipe_path = File.join(dir, 'r.json')
+      File.write(recipe_path, '{}')
+      output_path = File.join(dir, 'r_apply.py')
+
+      described_class.generate(recipe_path: recipe_path, output_path: output_path)
+
+      expect(File.executable?(output_path)).to be true
+    end
+  end
+
+  it 'expands a relative recipe path to absolute' do
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        File.write('rel.recipe.json', '{}')
+        described_class.generate(recipe_path: 'rel.recipe.json', output_path: 'out.py')
+
+        content = File.read('out.py')
+        expect(content).to match(%r{RECIPE_PATH = "/.+/rel\.recipe\.json"})
+      end
+    end
+  end
+
+  it 'is idempotent — re-running with the same inputs reproduces the same output' do
+    Dir.mktmpdir do |dir|
+      recipe_path = File.join(dir, 'r.json')
+      File.write(recipe_path, '{}')
+      output_path = File.join(dir, 'out.py')
+
+      described_class.generate(recipe_path: recipe_path, output_path: output_path)
+      first = File.read(output_path)
+      described_class.generate(recipe_path: recipe_path, output_path: output_path)
+      second = File.read(output_path)
+
+      expect(first).to eq(second)
+    end
+  end
+
+  it 'rejects empty recipe_path' do
+    expect {
+      described_class.new(recipe_path: '', output_path: 'x')
+    }.to raise_error(ArgumentError, /recipe_path/)
+  end
+
+  it 'rejects nil output_path' do
+    expect {
+      described_class.new(recipe_path: 'x', output_path: nil)
+    }.to raise_error(ArgumentError, /output_path/)
+  end
+end

--- a/spec/recipe_from_roughcut_spec.rb
+++ b/spec/recipe_from_roughcut_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'yaml'
+require 'json'
+
+require_relative '../.claude/skills/roughcut/recipe_from_roughcut'
+
+RSpec.describe RecipeFromRoughcut do
+  def write_yaml(dir, name, hash)
+    path = File.join(dir, name)
+    File.write(path, YAML.dump(hash))
+    path
+  end
+
+  let(:full_roughcut) do
+    {
+      "description" => "highlight reel",
+      "clips" => [
+        { "source_file" => "opener.mp4", "in_point" => "00:00:00.00", "out_point" => "00:00:02.50" },
+        { "source_file" => "energy_a_1.mp4", "in_point" => "00:00:00.00", "out_point" => "00:00:02.50" },
+        {
+          "source_file" => "medicine-ball-slams.mp4",
+          "in_point" => "00:00:01.50",
+          "out_point" => "00:00:04.00",
+          "speed_ramps" => [
+            { "at" => 0.0, "speed" => 200, "ease" => "ease-out" },
+            { "at" => 1.0, "speed" => 100, "ease" => "ease-in" }
+          ],
+          "color_tag" => "Orange",
+          "markers" => [{ "at" => 0.3, "name" => "impact", "color" => "Red" }]
+        },
+        { "source_file" => "hero.mp4", "in_point" => "00:00:00.00", "out_point" => "00:00:03.00" }
+      ],
+      "transitions" => [
+        { "between" => [3, 4], "type" => "dip_to_color", "color" => "white", "duration_frames" => 4 }
+      ],
+      "title_card" => {
+        "at_clip" => 4, "text" => "{{user_handle}}", "fade_in_at" => 0.5, "fade_in_frames" => 6
+      },
+      "render_preset" => {
+        "format" => "mp4", "codec" => "h264", "resolution" => "1080p", "bitrate_kbps" => 25000
+      },
+      "powergrade" => { "name" => "GymBlueOrange-v1", "apply_to" => "all" }
+    }
+  end
+
+  it 'builds a valid Recipe from a directive-rich rough cut YAML' do
+    Dir.mktmpdir do |dir|
+      yaml_path = write_yaml(dir, "highlight-reel.yaml", full_roughcut)
+      recipe_path = File.join(dir, "highlight-reel.recipe.json")
+
+      described_class.export(
+        roughcut_path: yaml_path,
+        recipe_path: recipe_path,
+        library_name: "march-30-workout",
+        timeline_name: "highlight-reel_20260430_184655"
+      )
+
+      h = JSON.parse(File.read(recipe_path))
+      expect(h["version"]).to eq(1)
+      expect(h["library"]).to eq("march-30-workout")
+      expect(h["timeline"]).to eq("highlight-reel_20260430_184655")
+      expect(h["clips"].map { |c| c["index"] }).to eq([1, 2, 3, 4])
+      expect(h["clips"][2]["speed_ramps"].first).to eq({ "at" => 0.0, "speed" => 200, "ease" => "ease-out" })
+      expect(h["clips"][2]["color_tag"]).to eq("Orange")
+      expect(h["clips"][2]["markers"]).to eq([{ "at" => 0.3, "name" => "impact", "color" => "Red" }])
+      expect(h["transitions"]).to eq([{ "between" => [3, 4], "type" => "dip_to_color", "color" => "white", "duration_frames" => 4 }])
+      expect(h["title_card"]["at_clip"]).to eq(4)
+      expect(h["render_preset"]["bitrate_kbps"]).to eq(25000)
+      expect(h["powergrade"]).to eq({ "name" => "GymBlueOrange-v1", "apply_to" => "all" })
+    end
+  end
+
+  it 'produces a minimal-but-valid recipe when the rough cut has no directives' do
+    minimal = {
+      "clips" => [
+        { "source_file" => "a.mp4", "in_point" => "00:00:00.00", "out_point" => "00:00:01.00" },
+        { "source_file" => "b.mp4", "in_point" => "00:00:00.00", "out_point" => "00:00:01.00" }
+      ]
+    }
+
+    Dir.mktmpdir do |dir|
+      yaml_path = write_yaml(dir, "cut.yaml", minimal)
+      recipe_path = File.join(dir, "cut.recipe.json")
+
+      described_class.export(
+        roughcut_path: yaml_path,
+        recipe_path: recipe_path,
+        library_name: "lib",
+        timeline_name: "t"
+      )
+
+      h = JSON.parse(File.read(recipe_path))
+      expect(h.keys).to contain_exactly("version", "library", "timeline", "clips")
+      expect(h["clips"]).to eq([
+        { "index" => 1, "source_file" => "a.mp4" },
+        { "index" => 2, "source_file" => "b.mp4" }
+      ])
+    end
+  end
+
+  it 'requires roughcut_path, recipe_path, library_name, and timeline_name' do
+    expect {
+      described_class.new(roughcut_path: "", recipe_path: "x", library_name: "y", timeline_name: "z")
+    }.to raise_error(ArgumentError, /roughcut_path/)
+    expect {
+      described_class.new(roughcut_path: "x", recipe_path: nil, library_name: "y", timeline_name: "z")
+    }.to raise_error(ArgumentError, /recipe_path/)
+    expect {
+      described_class.new(roughcut_path: "x", recipe_path: "y", library_name: "", timeline_name: "z")
+    }.to raise_error(ArgumentError, /library_name/)
+    expect {
+      described_class.new(roughcut_path: "x", recipe_path: "y", library_name: "z", timeline_name: nil)
+    }.to raise_error(ArgumentError, /timeline_name/)
+  end
+
+  it 'raises if the rough cut has no clips' do
+    Dir.mktmpdir do |dir|
+      yaml_path = write_yaml(dir, "empty.yaml", { "clips" => [] })
+      recipe_path = File.join(dir, "empty.recipe.json")
+      expect {
+        described_class.export(
+          roughcut_path: yaml_path, recipe_path: recipe_path,
+          library_name: "l", timeline_name: "t"
+        )
+      }.to raise_error(ArgumentError, /clips/)
+    end
+  end
+
+  it 'propagates Recipe validation errors (e.g. invalid color_tag)' do
+    bad = {
+      "clips" => [{ "source_file" => "a.mp4", "color_tag" => "Mauve" }]
+    }
+    Dir.mktmpdir do |dir|
+      yaml_path = write_yaml(dir, "bad.yaml", bad)
+      expect {
+        described_class.export(
+          roughcut_path: yaml_path,
+          recipe_path: File.join(dir, "bad.recipe.json"),
+          library_name: "l", timeline_name: "t"
+        )
+      }.to raise_error(ArgumentError, /color_tag/)
+    end
+  end
+end

--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -1,0 +1,336 @@
+require 'spec_helper'
+require 'json'
+require 'tmpdir'
+
+RSpec.describe ButterCut::Recipe do
+  let(:valid_hash) do
+    {
+      "version" => 1,
+      "library" => "march-30-workout",
+      "timeline" => "highlight-reel_20260430_184655",
+      "render_preset" => {
+        "format" => "mp4",
+        "codec" => "h264",
+        "resolution" => "1080p",
+        "bitrate_kbps" => 25000
+      },
+      "powergrade" => { "name" => "GymBlueOrange-v1", "apply_to" => "all" },
+      "clips" => [
+        {
+          "index" => 3,
+          "source_file" => "medicine-ball-slams.mp4",
+          "speed_ramps" => [
+            { "at" => 1.5, "speed" => 200, "ease" => "ease-out" },
+            { "at" => 2.5, "speed" => 100, "ease" => "ease-in" }
+          ],
+          "color_tag" => "Orange",
+          "markers" => [{ "at" => 1.8, "name" => "impact", "color" => "Red" }]
+        },
+        { "index" => 4, "source_file" => "rest.mp4" },
+        { "index" => 11, "source_file" => "jump-rope.mp4" },
+        { "index" => 12, "source_file" => "hero-closer.mp4" }
+      ],
+      "transitions" => [
+        { "between" => [3, 4], "type" => "dip_to_color", "color" => "black", "duration_frames" => 4 },
+        { "between" => [11, 12], "type" => "dip_to_color", "color" => "white", "duration_frames" => 4 }
+      ],
+      "title_card" => {
+        "at_clip" => 12,
+        "text" => "{{user_handle}}",
+        "fade_in_at" => 0.5,
+        "fade_in_frames" => 6
+      }
+    }
+  end
+
+  describe '.from_hash' do
+    it 'round-trips a canonical recipe without loss' do
+      recipe = described_class.from_hash(valid_hash)
+      expect(recipe.to_h).to eq(valid_hash)
+    end
+
+    it 'round-trips through JSON file save/load' do
+      recipe = described_class.from_hash(valid_hash)
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'recipe.json')
+        recipe.save(path)
+        loaded = described_class.load(path)
+        expect(loaded.to_h).to eq(valid_hash)
+        expect(JSON.parse(File.read(path))).to eq(valid_hash)
+      end
+    end
+
+    it 'accepts a minimal recipe (no optional fields)' do
+      minimal = {
+        "version" => 1,
+        "library" => "lib",
+        "timeline" => "t",
+        "clips" => [{ "index" => 1, "source_file" => "a.mp4" }]
+      }
+      expect(described_class.from_hash(minimal).to_h).to eq(minimal)
+    end
+  end
+
+  describe 'version validation' do
+    it 'rejects an unknown version' do
+      expect {
+        described_class.from_hash(valid_hash.merge("version" => 2))
+      }.to raise_error(ArgumentError, /version/)
+    end
+
+    it 'rejects a missing version' do
+      expect {
+        described_class.from_hash(valid_hash.reject { |k, _| k == "version" })
+      }.to raise_error(ArgumentError, /version/)
+    end
+  end
+
+  describe 'top-level validation' do
+    it 'rejects a missing library' do
+      expect {
+        described_class.from_hash(valid_hash.merge("library" => ""))
+      }.to raise_error(ArgumentError, /library/)
+    end
+
+    it 'rejects a missing timeline' do
+      expect {
+        described_class.from_hash(valid_hash.merge("timeline" => nil))
+      }.to raise_error(ArgumentError, /timeline/)
+    end
+
+    it 'rejects empty clips' do
+      expect {
+        described_class.from_hash(valid_hash.merge("clips" => []))
+      }.to raise_error(ArgumentError, /clips/)
+    end
+  end
+
+  describe 'clip validation' do
+    it 'rejects a clip without an index' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "source_file" => "x.mp4" }]
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /index/)
+    end
+
+    it 'rejects a clip with a non-positive index' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 0, "source_file" => "x.mp4" }]
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /index/)
+    end
+
+    it 'rejects a clip with empty source_file' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "" }]
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /source_file/)
+    end
+
+    it 'rejects an unknown color_tag' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "x.mp4", "color_tag" => "Mauve" }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /color_tag/)
+    end
+  end
+
+  describe 'duplicate clip indices' do
+    it 'rejects clips with duplicate index values' do
+      bad = valid_hash.dup
+      bad["clips"] = [
+        { "index" => 1, "source_file" => "a.mp4" },
+        { "index" => 1, "source_file" => "b.mp4" }
+      ]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /duplicate/i)
+    end
+  end
+
+  describe 'array-typed fields on clips' do
+    it 'rejects non-array speed_ramps' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "x.mp4", "speed_ramps" => "fast" }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /speed_ramps.*array/)
+    end
+
+    it 'rejects null speed_ramps' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "x.mp4", "speed_ramps" => nil }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /speed_ramps.*array/)
+    end
+
+    it 'rejects null markers' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "x.mp4", "markers" => nil }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /markers.*array/)
+    end
+
+    it 'rejects non-array markers' do
+      bad = valid_hash.dup
+      bad["clips"] = [{ "index" => 1, "source_file" => "x.mp4", "markers" => 1 }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /markers.*array/)
+    end
+  end
+
+  describe 'speed_ramp validation' do
+    it 'rejects speed of 0' do
+      bad = valid_hash.dup
+      bad["clips"] = [{
+        "index" => 1, "source_file" => "x.mp4",
+        "speed_ramps" => [{ "at" => 0.0, "speed" => 0, "ease" => "linear" }]
+      }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /speed/)
+    end
+
+    it 'rejects negative at' do
+      bad = valid_hash.dup
+      bad["clips"] = [{
+        "index" => 1, "source_file" => "x.mp4",
+        "speed_ramps" => [{ "at" => -0.1, "speed" => 100, "ease" => "linear" }]
+      }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /at/)
+    end
+
+    it 'rejects unknown ease' do
+      bad = valid_hash.dup
+      bad["clips"] = [{
+        "index" => 1, "source_file" => "x.mp4",
+        "speed_ramps" => [{ "at" => 0.0, "speed" => 100, "ease" => "bouncy" }]
+      }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /ease/)
+    end
+  end
+
+  describe 'marker validation' do
+    it 'rejects an unknown marker color' do
+      bad = valid_hash.dup
+      bad["clips"] = [{
+        "index" => 1, "source_file" => "x.mp4",
+        "markers" => [{ "at" => 0.0, "name" => "x", "color" => "Chartreuse" }]
+      }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /marker.*color/i)
+    end
+
+    it 'rejects an empty marker name' do
+      bad = valid_hash.dup
+      bad["clips"] = [{
+        "index" => 1, "source_file" => "x.mp4",
+        "markers" => [{ "at" => 0.0, "name" => "", "color" => "Red" }]
+      }]
+      bad["transitions"] = []
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /marker.*name/i)
+    end
+  end
+
+  describe 'transition validation' do
+    it 'rejects between referencing a clip that does not exist' do
+      bad = valid_hash.dup
+      bad["transitions"] = [
+        { "between" => [3, 4], "type" => "dip_to_color", "color" => "black", "duration_frames" => 4 },
+        { "between" => [99, 100], "type" => "dip_to_color", "color" => "black", "duration_frames" => 4 }
+      ]
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /transition.*99/)
+    end
+
+    it 'rejects non-adjacent between' do
+      bad = valid_hash.dup
+      bad["transitions"] = [
+        { "between" => [3, 11], "type" => "dip_to_color", "color" => "black", "duration_frames" => 4 }
+      ]
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /adjacent/i)
+    end
+
+    it 'rejects non-positive duration_frames' do
+      bad = valid_hash.dup
+      bad["transitions"] = [
+        { "between" => [3, 4], "type" => "dip_to_color", "color" => "black", "duration_frames" => 0 }
+      ]
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /duration_frames/)
+    end
+
+    it 'rejects unknown transition type' do
+      bad = valid_hash.dup
+      bad["transitions"] = [
+        { "between" => [3, 4], "type" => "wipe", "duration_frames" => 4 }
+      ]
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /transition.*type/i)
+    end
+
+    it 'rejects unknown dip color' do
+      bad = valid_hash.dup
+      bad["transitions"] = [
+        { "between" => [3, 4], "type" => "dip_to_color", "color" => "purple", "duration_frames" => 4 }
+      ]
+      bad.delete("title_card")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /dip.*color/i)
+    end
+  end
+
+  describe 'title_card validation' do
+    it 'rejects at_clip referencing a missing clip index' do
+      bad = valid_hash.dup
+      bad["title_card"] = bad["title_card"].merge("at_clip" => 999)
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /title_card.*999/)
+    end
+
+    it 'rejects non-positive fade_in_frames' do
+      bad = valid_hash.dup
+      bad["title_card"] = bad["title_card"].merge("fade_in_frames" => 0)
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /fade_in_frames/)
+    end
+  end
+
+  describe 'render_preset validation' do
+    it 'rejects non-positive bitrate_kbps' do
+      bad = valid_hash.dup
+      bad["render_preset"] = bad["render_preset"].merge("bitrate_kbps" => 0)
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /bitrate_kbps/)
+    end
+
+    it 'rejects empty codec' do
+      bad = valid_hash.dup
+      bad["render_preset"] = bad["render_preset"].merge("codec" => "")
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /codec/)
+    end
+  end
+
+  describe 'powergrade validation' do
+    it 'accepts apply_to with explicit clip indices' do
+      good = valid_hash.dup
+      good["powergrade"] = { "name" => "X", "apply_to" => [3, 4] }
+      expect(described_class.from_hash(good).to_h["powergrade"]["apply_to"]).to eq([3, 4])
+    end
+
+    it 'rejects apply_to referencing a missing clip' do
+      bad = valid_hash.dup
+      bad["powergrade"] = { "name" => "X", "apply_to" => [3, 999] }
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /powergrade.*999/)
+    end
+
+    it 'rejects unknown apply_to string' do
+      bad = valid_hash.dup
+      bad["powergrade"] = { "name" => "X", "apply_to" => "some" }
+      expect { described_class.from_hash(bad) }.to raise_error(ArgumentError, /apply_to/)
+    end
+  end
+end

--- a/templates/highlight_reel_recipe.md
+++ b/templates/highlight_reel_recipe.md
@@ -1,0 +1,55 @@
+# Highlight Reel Recipe
+
+A reusable formula for ~30-second cinematic highlight reels (workouts, sports, action). When asked for a "highlight reel" or "hype edit", ButterCut should follow this structure.
+
+## Target spec
+
+- **Duration:** 28–35 seconds (default 30s).
+- **Cut count:** 10–14 clips.
+- **Average shot length:** 1.5–2.5s, with one held closing beat (3–5s).
+- **Energy curve:** opener → rapid alternating peaks → micro-rest beat → climax → calm hero hold.
+
+## Editorial structure
+
+1. **Opener (2–3s)** — wide kinetic shot establishing motion and tone. Best if it shows the subject in their element. Slight speed ramp from slow to normal works well.
+2. **Energy block A (8–10s, 4 clips)** — rapid alternation between two contrasting actions/textures (strength vs. striking, lifting vs. cardio, etc.). Each shot 1.5–2.5s. Cut on beat.
+3. **Breath beat (2s, 1 clip)** — quieter detail shot to give the eye a rest. Side profile, close-up, reflection — anything calmer than the surrounding pace.
+4. **Energy block B (6–8s, 3–4 clips)** — return to high energy with new angles. Mix in at least one through-something composition (rack, bag, glass, foreground bokeh).
+5. **Build (2–3s, 1–2 clips)** — fast inserts, optionally sped up to 150–200%. Compresses time before the closer.
+6. **Hero closer (3–5s)** — single held shot. Subject centered or in a strong stance, often looking at camera. Speed ramps down to 60–80% in the final beat. Color/look pushed strongest here.
+
+## Selection priorities
+
+- **Variety over completeness** — show 6–8 different exercises rather than every one.
+- **Strongest stylistic frames win** — through-rack, through-bag, foreground bokeh, rear/mirror angles all beat clean wide shots.
+- **End with the hero** — if any clip has a posed/portrait moment, save it for last.
+- **Skip mistakes** — re-racking, fumbles, breaks. Cut around them.
+
+## Pacing rules
+
+- No two adjacent clips from the same source file unless intentional rhythm.
+- Vary shot scale: never put two wides or two tight shots back-to-back.
+- Vary direction of motion: if clip N is moving left-to-right, clip N+1 should not.
+- Cuts should land on downbeats when scored to music (this is the editor's job in Resolve, not ButterCut's — but plan in/out points around 2-beat increments at ~100 BPM = ~1.2s).
+
+## Closing-beat cinematic moves (for the editor in post)
+
+- Subtle slow-down (60–80%) over the final 0.5–1s.
+- Glow effect on highlights (Resolve: ResolveFX Stylize > Glow, low strength).
+- Color: deepest teal shadows, warm skin highlights.
+- Title card or signature can fade in during the slowdown.
+
+## Inputs ButterCut needs
+
+When invoking the roughcut skill with this recipe:
+
+- `library_name` — required.
+- `target_duration` — default 30s, range 28–35s.
+- `vibe` — optional descriptor ("cinematic", "energetic", "dark trap", "Y2K-glitch"). Drives clip selection bias.
+- `closer_clip` — optional explicit pick for the hero shot. If omitted, ButterCut chooses from clips marked as having posed/portrait moments.
+- `exclude_moments` — optional list of "(file, time-range)" tuples to skip (e.g. known fumbles).
+
+## Output expectations
+
+- ButterCut produces the cuts-only YAML + XML.
+- A companion `_edit_guide.md` SHOULD be generated alongside the cut, with shot-by-shot post-production direction (color, ramps, transitions, SFX) for the editor to apply manually in their NLE.

--- a/templates/highlight_reel_template.yaml
+++ b/templates/highlight_reel_template.yaml
@@ -1,0 +1,118 @@
+# Highlight Reel Template (parameterized)
+#
+# This is a structural template for a ~30s highlight reel rough cut. ButterCut
+# fills in the source_file, in_point, and out_point fields by selecting the
+# strongest clips per the criteria in templates/highlight_reel_recipe.md.
+#
+# The role field is internal — it tells ButterCut what kind of clip belongs at
+# that timeline position. It does NOT appear in the final cut YAML produced for
+# export; it's used only during clip selection.
+
+description: "{{description}}"   # filled by ButterCut from the user request
+
+notes: |
+  Editorial approach (per highlight_reel_recipe.md):
+  - Opener establishes motion + tone
+  - Two energy blocks separated by a breath beat
+  - Build into a held hero closer
+  - All stylistic preferences (through-rack/bag, bokeh, rear/mirror) prioritized
+
+clips:
+  # Opener (2.0–3.0s) — wide kinetic motion shot
+  - role: opener
+    target_duration: 2.5
+    selection_criteria: "wide shot, kinetic motion, establishes subject and setting"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  # Energy block A — 4 clips alternating two contrasting actions (1.5–2.5s each)
+  - role: energy_a_1
+    target_duration: 2.5
+    selection_criteria: "high-energy action #1, prefer through-frame composition (rack/bag/bokeh)"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  - role: energy_a_2
+    target_duration: 2.0
+    selection_criteria: "contrasting action #2, rapid pace"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  - role: energy_a_3
+    target_duration: 2.0
+    selection_criteria: "back to action #1, NEW angle (rear/mirror or new exercise)"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  - role: energy_a_4
+    target_duration: 2.5
+    selection_criteria: "action #2 variant, vary shot scale from energy_a_2"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  # Breath beat (2.0s) — quieter detail shot
+  - role: breath
+    target_duration: 2.0
+    selection_criteria: "side profile, detail, or reflection — calmer than surrounding clips"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  # Energy block B — 3 clips, new angles (1.5–2.5s each)
+  - role: energy_b_1
+    target_duration: 2.0
+    selection_criteria: "fresh action, ideally through-something composition"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  - role: energy_b_2
+    target_duration: 2.0
+    selection_criteria: "different angle/scale from energy_b_1"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  # Build inserts (1.5s each) — short, fast, sets up the closer
+  - role: build_1
+    target_duration: 1.5
+    selection_criteria: "fast cut suitable for 150-200% speed ramp; brief peak energy"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  - role: build_2
+    target_duration: 1.5
+    selection_criteria: "final accent before hero, prefers strike/peak/explosive moment"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+  # Hero closer (3.0–5.0s) — held portrait/posed beat
+  - role: hero
+    target_duration: 3.0
+    selection_criteria: "subject centered, looking at camera or strong stance, posed/hero moment; ALWAYS the closer"
+    source_file:
+    in_point:
+    out_point:
+    visual_description:
+
+metadata:
+  template: "highlight_reel_template.yaml"
+  recipe: "highlight_reel_recipe.md"
+  target_total_duration: "00:00:30.00"

--- a/templates/roughcut_template.yaml
+++ b/templates/roughcut_template.yaml
@@ -36,6 +36,26 @@ clips:
     dialogue: ""
     visual_description: "[POV from inside San Francisco Muni bus looking out window at passing street. Yellow safety handrails visible. Transit journey B-roll.]"
 
+# Optional editorial directives (consumed by lib/buttercut/recipe.rb to emit
+# <name>.recipe.json alongside the XML). Clips are numbered 1..N by YAML order;
+# transitions and title_card reference clips by that numeric index.
+#
+# Per-clip directives go on the clip itself:
+#   speed_ramps: [{ at: 0.0, speed: 200, ease: ease-out }]
+#   color_tag: Orange
+#   markers: [{ at: 0.3, name: impact, color: Red }]
+#
+# Top-level directives below — uncomment and fill as needed:
+# transitions:
+#   - { between: [3, 4], type: dip_to_color, color: white, duration_frames: 4 }
+# title_card:
+#   at_clip: 12
+#   text: "{{user_handle}}"
+#   fade_in_at: 0.5
+#   fade_in_frames: 6
+# render_preset: { format: mp4, codec: h264, resolution: 1080p, bitrate_kbps: 25000 }
+# powergrade: { name: GymBlueOrange-v1, apply_to: all }
+
 # Rough cut metadata
 metadata:
   created_date: ""  # Will be populated when rough cut is created


### PR DESCRIPTION
## Summary
- Bumps `lib/buttercut/fcpx.rb` from FCPXML 1.8 to 1.10 and emits `<timeMap>` inside `<asset-clip>` when the clip carries `speed_ramps`, giving Resolve a path to preserve ramps directly through the FCPXML import without the apply script.
- Threads `speed_ramps` from the rough-cut YAML into the FCPX clip hash via `.claude/skills/roughcut/export_to_fcpxml.rb`; updates DTD validation path to `FCPXMLv1_10.dtd` (gracefully skips when not shipped).
- Maps recipe `ease` values to FCPXML `interp` (`linear` → `linear`; `ease-in` / `ease-out` / `ease-in-out` → `smooth2`). Source-time waypoints are integrated piecewise from the speed waypoints, with synthetic leading/trailing timepts as needed.

## Out of scope (still recipe + apply-script only)
Transitions, color tags, title cards, and render presets — recipe still carries them, but the FCPXML doesn't emit them yet. Documented in CHANGELOG.

## Test plan
- [x] `bundle exec rspec` — 117/119 pass; the 2 failing examples (`fcpx_spec.rb:495`, `:505`) pre-existed on `main` and require media files in a `media/` directory that isn't in the repo.
- [x] New `spec/buttercut/fcpx_speed_ramps_spec.rb` covers version bump, no-recipe opt-out, timept emission, ease→interp mapping, and leading-pad.
- [x] Existing `fcpx_spec.rb` version assertions and three `.fcpxml` fixtures updated 1.8 → 1.10.
- [ ] Manual: regenerate the `march-30-workout` rough cut, import the FCPXML into a fresh Resolve project, confirm at least the speed ramps survive without running the apply script (Phase 4 acceptance bar).

Closes the Phase 4 bullet of `docs/sprints/sprint-01-editorial-automation.md`.