### PR TITLE
Use precompiled Ruby and Python binaries via mise

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,23 @@
 # Mise configuration for video-agent project
 # This locks down tool versions to ensure reproducible transcription
 
+# 2025.12.4 introduced `ruby.compile` (precompiled Ruby support).
+min_version = "2025.12.4"
+
 [tools]
 python = "3.12.8"
 ruby = "3.3.6"
+
+# Use precompiled binaries instead of building from source.
+# - Ruby: pulled from github.com/jdx/ruby (macOS arm64 supported)
+# - Python: pulled from python-build-standalone
+# Falls back to source compile if no binary exists for the requested version.
+[settings]
+ruby.compile = false
+python.compile = false
+# python-build-standalone 3.12.8 (Jan 2025) predates GitHub artifact
+# attestations. The tarball is still checksum-verified.
+python.github_attestations = false
 
 # Notes on dependencies:
 # - whisperx 3.4.2 requires pyannote-audio <4.0.0

--- a/skills/setup/advanced-setup.md
+++ b/skills/setup/advanced-setup.md
@@ -53,6 +53,8 @@ ruby --version  # Should show 3.3.6
 
 ### 5. Bundler
 
+Skip this step if you installed Ruby via mise — the precompiled Ruby tarball ships with Bundler. Otherwise:
+
 ```bash
 gem install bundler
 ```
@@ -136,6 +138,6 @@ All items should show OK.
 
 ## Notes
 
-- The `.mise.toml` file is provided for mise users but is not required
+- The `.mise.toml` file is provided for mise users but is not required. It pins `ruby.compile = false` and `python.compile = false` so `mise install` pulls precompiled binaries (Ruby from jdx/ruby, Python from python-build-standalone) instead of building from source. Requires mise >= 2025.12.4. Override in your user config if you'd rather compile.
 - WhisperX uses CPU-only mode for simplicity (no CUDA/GPU setup needed)
 - If you use pyenv-virtualenv or similar, you can install whisperx in a dedicated virtualenv instead of `~/.buttercut/venv`

--- a/skills/setup/simple-setup.md
+++ b/skills/setup/simple-setup.md
@@ -83,6 +83,13 @@ brew install libyaml
 which mise || brew install mise
 ```
 
+If mise is already installed, make sure it's at least version 2025.12.4 (the release that added precompiled Ruby support):
+
+```bash
+mise --version
+brew upgrade mise   # run if version is older than 2025.12.4
+```
+
 Activate mise in shell profile:
 
 ```bash
@@ -107,7 +114,7 @@ mise trust
 mise install
 ```
 
-**Note:** Ruby is compiled from source and can take 5-10 minutes. This is normal.
+Mise downloads precompiled Ruby and Python binaries (configured in `.mise.toml`), so this typically finishes in under a minute. If a precompiled binary isn't available for the pinned version, mise falls back to building from source, which can take 5-10 minutes.
 
 Verify versions:
 
@@ -116,19 +123,13 @@ ruby --version    # Should show 3.3.6
 python3 --version # Should show 3.12.8
 ```
 
-## Step 5: Bundler
-
-```bash
-which bundle || gem install bundler
-```
-
-## Step 6: FFmpeg
+## Step 5: FFmpeg
 
 ```bash
 which ffmpeg || brew install ffmpeg
 ```
 
-## Step 7: WhisperX Virtual Environment
+## Step 6: WhisperX Virtual Environment
 
 ```bash
 mkdir -p ~/.buttercut
@@ -143,7 +144,7 @@ pip install whisperx
 deactivate
 ```
 
-## Step 8: WhisperX Wrapper Script
+## Step 7: WhisperX Wrapper Script
 
 ```bash
 cat > ~/.buttercut/whisperx << 'EOF'
@@ -155,7 +156,7 @@ EOF
 chmod +x ~/.buttercut/whisperx
 ```
 
-## Step 9: Add to PATH
+## Step 8: Add to PATH
 
 ```bash
 if [[ "$SHELL" == *"zsh"* ]]; then
@@ -165,7 +166,7 @@ elif [[ "$SHELL" == *"bash"* ]]; then
 fi
 ```
 
-## Step 10: Install ButterCut Dependencies
+## Step 9: Install ButterCut Dependencies
 
 ```bash
 bundle install


### PR DESCRIPTION
## Summary
Update `mise install` to download precompiled Ruby (from `jdx/ruby`) and Python (from `python-build-standalone`) instead of compiling. The 5–10 min Ruby compile becomes a seconds-long download on Apple Silicon.

- Pins `min_version = "2025.12.4"` (the mise release that introduced `ruby.compile`) and disables `python.github_attestations` for 3.12.8 (its tarball predates attestation publishing; checksum still verified).
- Drops the manual `gem install bundler` step from simple-setup — Bundler ships with the precompiled Ruby tarball. Advanced setup keeps the step but notes it's skippable for mise users.