### PR TITLE
Simplify lib: dedup helpers, drop dead code, use stdlib gcd

### DIFF
--- a/lib/buttercut/contact_sheet.rb
+++ b/lib/buttercut/contact_sheet.rb
@@ -237,6 +237,12 @@ class ContactSheet
     (0...@frames).map { |i| @start_time + (i + 0.5) * range / @frames }
   end
 
+  # Shared tail for both strategies: write exactly one JPEG with these encode
+  # settings to the output path.
+  def encode_output_args
+    ['-fps_mode', 'vfr', '-pix_fmt', 'yuvj420p', '-q:v', '3', @output_path]
+  end
+
   def single_pass_args(timestamps)
     range = @end_time - @start_time
     fps_value = @frames.to_f / range
@@ -248,7 +254,7 @@ class ContactSheet
     args += ['-to', format('%.3f', @end_time)] if @end_time < @source_duration - 0.5
     args += ['-i', @video_path, '-an', '-sn']
     args += ['-vf', single_pass_filter(timestamps, fps_value)]
-    args += ['-frames:v', '1', '-fps_mode', 'vfr', '-pix_fmt', 'yuvj420p', '-q:v', '3', @output_path]
+    args += ['-frames:v', '1', *encode_output_args]
     args
   end
 
@@ -305,10 +311,7 @@ class ContactSheet
       '-filter_complex', seek_and_grab_filter_complex(timestamps),
       '-frames:v', '1',
       '-update', '1',
-      '-fps_mode', 'vfr',
-      '-pix_fmt', 'yuvj420p',
-      '-q:v', '3',
-      @output_path
+      *encode_output_args
     ]
   end
 
@@ -343,12 +346,15 @@ class ContactSheet
     stderr
   end
 
-  def format_hms(seconds)
+  # Shared with ContactSheetJob — exposed as a class method so callers without
+  # a ContactSheet instance can format timestamps the same way.
+  def self.format_hms(seconds)
     total = seconds.to_i
-    h = total / 3600
-    m = (total % 3600) / 60
-    s = total % 60
-    format('%02d:%02d:%02d', h, m, s)
+    format('%02d:%02d:%02d', total / 3600, (total % 3600) / 60, total % 60)
+  end
+
+  def format_hms(seconds)
+    self.class.format_hms(seconds)
   end
 
   def report(range)

--- a/lib/buttercut/contact_sheet_job.rb
+++ b/lib/buttercut/contact_sheet_job.rb
@@ -75,7 +75,7 @@ class ContactSheetJob
 
     ContactSheet.extract(path, library_dir: @library.dir)
     chunk_ranges(duration).each do |range_start, range_end|
-      puts "  + chunk #{format_hms(range_start)}–#{format_hms(range_end)}"
+      puts "  + chunk #{ContactSheet.format_hms(range_start)}–#{ContactSheet.format_hms(range_end)}"
       ContactSheet.extract(path, range_start, range_end, library_dir: @library.dir)
     end
   end
@@ -96,11 +96,6 @@ class ContactSheetJob
   def parse_duration(hms)
     h, m, s = hms.split(':').map(&:to_f)
     h * 3600 + m * 60 + s
-  end
-
-  def format_hms(seconds)
-    total = seconds.to_i
-    format('%02d:%02d:%02d', total / 3600, (total % 3600) / 60, total % 60)
   end
 end
 

--- a/lib/buttercut/editor_base.rb
+++ b/lib/buttercut/editor_base.rb
@@ -54,16 +54,20 @@ class ButterCut
       @metadata_cache[video_path]
     end
 
+    def video_stream(video_path)
+      extract_metadata(video_path)['streams'].find { |s| s['codec_type'] == 'video' }
+    end
+
+    def audio_stream(video_path)
+      extract_metadata(video_path)['streams'].find { |s| s['codec_type'] == 'audio' }
+    end
+
     def video_width(video_path)
-      metadata = extract_metadata(video_path)
-      video_stream = metadata['streams'].find { |s| s['codec_type'] == 'video' }
-      video_stream['width']
+      video_stream(video_path)['width']
     end
 
     def video_height(video_path)
-      metadata = extract_metadata(video_path)
-      video_stream = metadata['streams'].find { |s| s['codec_type'] == 'video' }
-      video_stream['height']
+      video_stream(video_path)['height']
     end
 
     def video_duration(video_path)
@@ -72,9 +76,7 @@ class ButterCut
     end
 
     def frame_rate(video_path)
-      metadata = extract_metadata(video_path)
-      video_stream = metadata['streams'].find { |s| s['codec_type'] == 'video' }
-      video_stream['r_frame_rate']
+      video_stream(video_path)['r_frame_rate']
     end
 
     def frame_duration(video_path)
@@ -84,9 +86,7 @@ class ButterCut
     end
 
     def audio_sample_rate(video_path)
-      metadata = extract_metadata(video_path)
-      audio_stream = metadata['streams'].find { |s| s['codec_type'] == 'audio' }
-      audio_stream['sample_rate']
+      audio_stream(video_path)['sample_rate']
     end
 
     def nominal_frame_rate(video_path)
@@ -160,6 +160,11 @@ class ButterCut
     def drop_frame_timecode?(timecode, rate_num, rate_denom, fps_nominal)
       return false unless timecode.include?(';')
       return false unless fps_nominal == 30 || fps_nominal == 60
+      ntsc_drop_frame_rate?(rate_num, rate_denom)
+    end
+
+    # NTSC fractional rates (29.97 / 59.94) that use drop-frame timecode.
+    def ntsc_drop_frame_rate?(rate_num, rate_denom)
       (rate_num == 30000 && rate_denom == 1001) || (rate_num == 60000 && rate_denom == 1001)
     end
 
@@ -171,19 +176,11 @@ class ButterCut
       end
     end
 
-    def color_space(video_path)
-      metadata = extract_metadata(video_path)
-      video_stream = metadata['streams'].find { |s| s['codec_type'] == 'video' }
-
-      cs = video_stream['color_space']
-      cp = video_stream['color_primaries']
-      ct = video_stream['color_transfer']
-
-      if cs == 'bt709' || cp == 'bt709' || ct == 'bt709'
-        "1-1-1 (Rec. 709)"
-      else
-        "1-1-1 (Rec. 709)"
-      end
+    # Color space is currently always emitted as Rec. 709; non-709 sources
+    # (HDR / Rec. 2020, P3) are not yet mapped. Takes a path for signature
+    # parity with the other per-clip metadata accessors.
+    def color_space(_video_path)
+      "1-1-1 (Rec. 709)"
     end
 
     def duration_to_fraction(video_path)
@@ -228,11 +225,15 @@ class ButterCut
       audio_sample_rate(@clips.first[:path])
     end
 
+    # Greatest Common Divisor (GCD): the largest whole number that divides two
+    # integers evenly — e.g. gcd(25000, 10000) is 5000. ButterCut tracks every
+    # timeline duration and offset as an exact `numerator/denominators` fraction
+    # (the format Final Cut's XML uses), and those numbers balloon as the math
+    # compounds. Dividing both halves of a fraction by their GCD puts it back in
+    # lowest terms — 25000/10000s becomes 5/2s — keeping the values small and the
+    # output clean. Ruby's built-in Integer#gcd does the arithmetic.
     def gcd(a, b)
-      while b != 0
-        a, b = b, a % b
-      end
-      a
+      a.gcd(b)
     end
 
     def add_fractions(frac1, frac2)
@@ -270,16 +271,20 @@ class ButterCut
       "#{numerator / divisor}/#{denominator / divisor}s"
     end
 
+    # Parse a duration fraction ("N/Ds" or bare "Ns") into [numerator, denominator].
+    def fraction_parts(value)
+      if (match = value.match(/^(\d+)s$/))
+        [match[1].to_i, 1]
+      else
+        value.match(/(\d+)\/(\d+)/).captures.map(&:to_i)
+      end
+    end
+
     def round_to_frame_boundary(time_value, frame_duration)
       return "0s" if time_value == "0s" || time_value == 0
       time_value = seconds_to_fraction(time_value) if time_value.is_a?(Numeric)
 
-      if time_value.match(/^(\d+)s$/)
-        time_num = Regexp.last_match(1).to_i
-        time_denom = 1
-      else
-        time_num, time_denom = time_value.match(/(\d+)\/(\d+)/).captures.map(&:to_i)
-      end
+      time_num, time_denom = fraction_parts(time_value)
 
       frame_num, frame_denom = frame_duration.match(/(\d+)\/(\d+)/).captures.map(&:to_i)
 
@@ -300,19 +305,8 @@ class ButterCut
       return frac1 if frac2 == "0s"
       return "0s" if frac1 == frac2
 
-      if frac1.match(/^(\d+)s$/)
-        num1 = Regexp.last_match(1).to_i
-        denom1 = 1
-      else
-        num1, denom1 = frac1.match(/(\d+)\/(\d+)/).captures.map(&:to_i)
-      end
-
-      if frac2.match(/^(\d+)s$/)
-        num2 = Regexp.last_match(1).to_i
-        denom2 = 1
-      else
-        num2, denom2 = frac2.match(/(\d+)\/(\d+)/).captures.map(&:to_i)
-      end
+      num1, denom1 = fraction_parts(frac1)
+      num2, denom2 = fraction_parts(frac2)
 
       result_num = num1 * denom2 - num2 * denom1
       result_denom = denom1 * denom2
@@ -431,10 +425,6 @@ class ButterCut
       duration_rational = fraction_to_rational(duration_fraction)
       frame_rational = fraction_to_rational(frame_duration_fraction)
       ((duration_rational / frame_rational).round).to_i
-    end
-
-    def frame_duration_rational_for(frame_duration_fraction)
-      fraction_to_rational(frame_duration_fraction)
     end
 
     protected

--- a/lib/buttercut/fcp7.rb
+++ b/lib/buttercut/fcp7.rb
@@ -15,7 +15,7 @@ class ButterCut
       rate_num, rate_denom = format_frame_rate.split('/').map(&:to_i)
       timebase = format_nominal_frame_rate
       ntsc_flag = ntsc_flag_for(rate_denom)
-      drop_frame = drop_frame_rate?(rate_num, rate_denom)
+      drop_frame = ntsc_drop_frame_rate?(rate_num, rate_denom)
       display_format = drop_frame ? 'DF' : 'NDF'
 
       sequence_duration_frames = frames_for_fraction(sequence_duration_fraction, timeline_frame_duration)
@@ -98,17 +98,13 @@ class ButterCut
       rate_denom == 1 ? 'FALSE' : 'TRUE'
     end
 
-    def drop_frame_rate?(rate_num, rate_denom)
-      (rate_num == 30000 && rate_denom == 1001) || (rate_num == 60000 && rate_denom == 1001)
-    end
-
     def build_clip_payloads(timeline_clips, timeline_frame_duration)
       timeline_clips.each_with_index.map do |clip, index|
         asset = clip[:asset]
         asset_rate_num, asset_rate_denom = asset[:frame_rate].split('/').map(&:to_i)
         asset_timebase = (asset_rate_num.to_f / asset_rate_denom).round
         asset_ntsc = ntsc_flag_for(asset_rate_denom)
-        asset_display = drop_frame_rate?(asset_rate_num, asset_rate_denom) ? 'DF' : 'NDF'
+        asset_display = ntsc_drop_frame_rate?(asset_rate_num, asset_rate_denom) ? 'DF' : 'NDF'
 
         timeline_duration_frames = frames_for_fraction(clip[:duration], timeline_frame_duration)
         timeline_start_frames = frames_for_fraction(clip[:timeline_offset], timeline_frame_duration)

--- a/lib/buttercut/fcpx.rb
+++ b/lib/buttercut/fcpx.rb
@@ -19,7 +19,6 @@ class ButterCut
       first_path = clips.first[:path]
       first_filename = get_filename(first_path)
       project_basename = get_basename(first_filename)
-      event_name = project_basename
       timestamped_project_name = "#{project_basename} #{timestamp_suffix}"
 
       builder = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
@@ -50,7 +49,7 @@ class ButterCut
           end
 
           xml.library(location: './') do
-            xml.event(name: event_name, uid: event_uid) do
+            xml.event(name: project_basename, uid: event_uid) do
               xml.project(name: timestamped_project_name, uid: project_uid, modDate: '2025-10-31 17:25:16 GMT-7') do
                 xml.sequence(duration: sequence_duration, format: FORMAT_ID, tcStart: '0s', audioRate: '48k') do
                   xml.spine do


### PR DESCRIPTION
Quality-only cleanup pass over the Ruby app (`lib/buttercut/`), from `/simplify`. **No behavior change — all 199 specs pass.**

## Changes

**`editor_base.rb`**
- `gcd` now delegates to stdlib `Integer#gcd` (was a hand-rolled Euclid loop; method kept since `fcpx_spec` tests it directly)
- `color_space`: collapsed a dead `if/else` whose two arms both returned `"1-1-1 (Rec. 709)"` (kept the path arg + an honest comment that non-709 sources aren't mapped yet)
- Extracted `video_stream` / `audio_stream` helpers — removed 4 copies of `streams.find { codec_type … }`
- Extracted `fraction_parts` helper — removed 3 copies of the "`Ns` or `N/Ds`" parse block
- Hoisted the NTSC drop-frame rate test into `ntsc_drop_frame_rate?`
- Deleted dead `frame_duration_rational_for`

**`fcp7.rb`** — dropped its duplicate `drop_frame_rate?`; both call sites use the inherited `ntsc_drop_frame_rate?`

**`contact_sheet.rb` / `contact_sheet_job.rb`** — deduped `format_hms` (promoted to a `ContactSheet.format_hms` class method; the job calls it); extracted `encode_output_args` for the ffmpeg encode/output tail shared by both strategy builders

**`fcpx.rb`** — dropped the redundant `event_name` alias of `project_basename`

Net: −21 lines.
