### PR TITLE
Add a daily update-check gate to the Library CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /tmp
 .DS_Store
+/last_buttercut_update_check
 /libraries
 /media
 /backups

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Work is organized into **libraries** (video series/projects), each self-containe
 
 Libraries are the primary abstraction — each is a video series/project self-contained under `/libraries/[library-name]/`. Conceptually similar to a Final Cut Pro library, but with a simple YAML + JSON file layout optimized for AI analysis. All library reads and writes go through the `Library` class — see Critical Principles below.
 
-Each library has a `library.yaml` file that serves as persistent memory and the source of truth. This file contains all library metadata, footage descriptions, transcription status, and key learnings. The agent generally doesn't need to read this file directly, and instead can work through the Library ruby class.
+Each library has a `library.yaml` file that serves as persistent memory and the source of truth. This file contains all library metadata, footage descriptions, transcription status, and key learnings. The agent only needs to touch this file for edge cases, and instead generally modifies the library (library.yaml) through the Library ruby class.
 
 ## Critical Principles
 
@@ -79,6 +79,8 @@ ruby lib/buttercut/script_extractor.rb libraries/<name>/transcripts/<clip>.json 
 ```
 
 Writes (`add_videos`, `complete`, `update_metadata`), destructive resets, legacy cleanup, and `Library.create` via `ruby -e`: see `lib/buttercut/library.md` for full documentation.
+
+**Daily update-check gate.** Once a day, the first real-work `library.rb` command exits with `library: it's been over a day since ButterCut last checked for updates…`. When you see that: check GitHub (`git fetch origin main` then `git log --oneline HEAD..origin/main`); if `main` is ahead and you're in auto mode, run the `update-buttercut` skill. If you're not in auto mode, ask the user permission to update buttercut using that skill. Either way, run `ruby lib/buttercut/library.rb update_checked` to record it, then re-run your command. Discovery commands (`list`, `recent`, `exists`) are never gated.
 
 **Single-track timelines only.** ButterCut produces one sequential video track. Each clip's own audio plays during that clip — there is no second video track for cutaways layered over a continuing voiceover, and no separate audio track. When planning or pitching cuts, never propose "B-roll over VO," "story under meetup footage," picture-in-picture, or any structure that assumes a clip's audio continues while different visuals play on top. Cutaways are fine, but they're hard cuts: when you cut to the wide shot, you cut to that shot's audio too. Plan every cut as a strictly linear sequence of clips.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Daily update-check gate in the `Library` CLI.** Library commands now check a gitignored `last_buttercut_update_check` stamp first; once a day they raise `UpdateCheckNeeded`, surfaced as a `library:` error that tells the agent to check for a newer ButterCut and offer to update.
+
 ## [0.7.1] - 2026-05-23
 
 Final RubyGems release of ButterCut xml generator. Having the ButterCut (agent) codebase live across skill scripts, shared scripts, and traditional lib code has gotten messy to work on and to explain to agents. I want to do a refactor where we pull all 'business' code into a single directory and it doesn't make sense to have the agent ruby code live with the xml generation code. Using the agent is by far the most popular use of this repository so it makes sense to make it be as easy as possible to work on and use that code. The agent + xml generation project will continue at the same location https://github.com/barefootford/buttercut;

--- a/lib/buttercut/library.md
+++ b/lib/buttercut/library.md
@@ -1,6 +1,6 @@
 # Library
 
-The `Library` class is the one place that reads and writes `library.yaml`. The agent drives it through bash:
+The `Library` class is the one Ruby class that reads and writes `library.yaml`. The agent drives it through bash:
 
 ```bash
 ruby lib/buttercut/library.rb <library_name> <action> [args...]
@@ -11,9 +11,9 @@ ruby lib/buttercut/library.rb <library_name> <action> [args...]
 - **Main thread only.** `Library` mutates the shared `library.yaml`;
   sub-agents must never call it (race conditions). Have a sub-agent return
   the data the orchestrator needs and let the orchestrator write.
-- **Never read or write `library.yaml` directly.** Go through the CLI.
-  If you need an operation it doesn't expose, extend the CLI rather than
-  parsing the YAML inline.
+- **Avoid writing to `library.yaml` directly.** Go through the CLI.
+  Only write to library when handling edge cases or failed migrations. 99
+  percent of the time the library class should provide what you need.
 
 ## Fields and on-disk layout
 
@@ -31,8 +31,8 @@ pattern, and orphan-sweep filter live in the `FIELDS` table at the top of
 `library.yaml` AND its file must exist on disk before any YAML is written.
 If any check fails the call raises and the YAML is left untouched.
 
-Dialogue isn't a tracked field — the audio transcript JSON is the source of
-truth, and agents that want clean dialogue text run
+The audio transcript JSON is the source of truth for dialogue, and agents that
+want clean dialogue text run
 `ruby lib/buttercut/script_extractor.rb <transcript>` on demand (stdout).
 
 ## CLI
@@ -46,7 +46,12 @@ ruby lib/buttercut/library.rb <name> exists       # exit 0 if it exists, 1 if no
 ruby lib/buttercut/library.rb <name> summary      # JSON: metadata + clip-completion breakdown
 ruby lib/buttercut/library.rb <name> incomplete_videos
 ruby lib/buttercut/library.rb <name> ready        # exit 0 if every video is ready for roughcut, 1 if not
+ruby lib/buttercut/library.rb update_checked      # record that you just checked GitHub for a newer ButterCut
 ```
+
+**Daily update-check gate.** The Library class has a once-a-day gate to check
+for updates to ButterCut. If in Auto mode, check for updates. Otherwise ask the
+user.
 
 `recent` is the right tool for "which library was the user most recently working on?" — it sees activity across `transcripts/`, `contact_sheets/`, `summaries/`, and `cuts/`, not just `library.yaml`. `list` is fine when you want the full set.
 

--- a/lib/buttercut/library.rb
+++ b/lib/buttercut/library.rb
@@ -117,6 +117,38 @@ class Library
     raise ArgumentError, "ffprobe returned non-numeric duration for #{path}: #{e.message}"
   end
 
+  # Raised by check_for_update! to hand the actual update check to the agent.
+  class UpdateCheckNeeded < StandardError; end
+
+  REPO_ROOT = File.expand_path('../..', __dir__)
+  UPDATE_CHECK_FILE = 'last_buttercut_update_check' # repo-root mtime stamp; gitignored
+  UPDATE_CHECK_INTERVAL = 86_400 # seconds (24h)
+
+  def self.check_for_update!(repo_root: REPO_ROOT)
+    stamp = File.join(repo_root, UPDATE_CHECK_FILE)
+
+    # First run on a fresh checkout (clone, update-buttercut rsync, or setup):
+    # no stamp yet. The repo is current by definition, so seed the stamp and
+    # stay quiet — the first nudge comes a day later, not on the very first command.
+    unless File.exist?(stamp)
+      record_update_check!(repo_root: repo_root)
+      return
+    end
+
+    return if (Time.now - File.mtime(stamp)) < UPDATE_CHECK_INTERVAL
+
+    raise UpdateCheckNeeded,
+      "it's been over a day since ButterCut last checked for updates. " \
+      'Call `git fetch origin main` then `git log --oneline HEAD..origin/main`. ' \
+      'If `main` is ahead, use the update-buttercut skill. ' \
+      'Then run `ruby lib/buttercut/library.rb update_checked` to record the check ' \
+      'and re-run your command.'
+  end
+
+  def self.record_update_check!(repo_root: REPO_ROOT)
+    FileUtils.touch(File.join(repo_root, UPDATE_CHECK_FILE))
+  end
+
   attr_reader :name
 
   def initialize(library_name)
@@ -379,6 +411,7 @@ if __FILE__ == $PROGRAM_NAME
       ruby library.rb list                            — every library, newest first (library.yaml mtime)
       ruby library.rb recent [N]                      — N most recent libraries by deepest file mtime (default 10)
       ruby library.rb migrate                         — run all migrations across every library
+      ruby library.rb update_checked                  — record that you just checked GitHub for a newer ButterCut
       ruby library.rb <library_name> <action> [args]
 
     Existence + status (no library load required for `exists`):
@@ -406,6 +439,13 @@ if __FILE__ == $PROGRAM_NAME
                        transcript_refinement: true, video_paths: ['/abs/a.mov'])"
   USAGE
 
+  # Agent records that it just checked for updates (see check_for_update!). Kept
+  # ahead of the daily gate below so recording a check is never itself gated.
+  if ARGV.first == 'update_checked'
+    Library.record_update_check!
+    exit 0
+  end
+
   if ARGV.first == 'list'
     puts Library.list
     exit 0
@@ -419,7 +459,7 @@ if __FILE__ == $PROGRAM_NAME
 
   if ARGV.first == 'migrate' && ARGV.size == 1
     migrate_script = File.expand_path('../../scripts/migrate_all.rb', __dir__)
-    repo_root = File.expand_path('../..', __dir__)
+    repo_root = Library::REPO_ROOT
     exec('ruby', migrate_script, chdir: repo_root)
   end
 
@@ -443,6 +483,8 @@ if __FILE__ == $PROGRAM_NAME
   split_files = ->(args) { args.flat_map { |a| a.split(',').map(&:strip).reject(&:empty?) } }
 
   begin
+    Library.check_for_update!
+
     case action
     when 'summary'
       puts JSON.pretty_generate(library.summary)

--- a/spec/buttercut/library_spec.rb
+++ b/spec/buttercut/library_spec.rb
@@ -638,4 +638,43 @@ RSpec.describe Library do
     end
   end
 
+  describe '.check_for_update! / .record_update_check!' do
+    around do |example|
+      Dir.mktmpdir('update-check-') do |root|
+        @repo_root = root
+        example.run
+      end
+    end
+
+    let(:stamp) { File.join(@repo_root, Library::UPDATE_CHECK_FILE) }
+
+    def age_stamp(seconds_ago)
+      FileUtils.touch(stamp)
+      t = Time.now - seconds_ago
+      File.utime(t, t, stamp)
+    end
+
+    it 'seeds the stamp and stays quiet on a fresh checkout (no stamp yet)' do
+      expect(File.exist?(stamp)).to be(false)
+      expect { Library.check_for_update!(repo_root: @repo_root) }.not_to raise_error
+      expect(File.exist?(stamp)).to be(true)
+    end
+
+    it 'raises when the last check was more than a day ago' do
+      age_stamp(Library::UPDATE_CHECK_INTERVAL + 60)
+      expect { Library.check_for_update!(repo_root: @repo_root) }.to raise_error(Library::UpdateCheckNeeded)
+    end
+
+    it 'does not raise when a check was recorded within the last day' do
+      age_stamp(60)
+      expect { Library.check_for_update!(repo_root: @repo_root) }.not_to raise_error
+    end
+
+    it 'record_update_check! writes the stamp so the next check stays quiet' do
+      expect(File.exist?(stamp)).to be(false)
+      Library.record_update_check!(repo_root: @repo_root)
+      expect(File.exist?(stamp)).to be(true)
+      expect { Library.check_for_update!(repo_root: @repo_root) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## What

Nudges users to update ButterCut about once a day, so they don't fall behind without realizing it — and does it in a way that works across **any** agent (Claude Code, Codex, etc.), not just one with session hooks.

## How

The check lives in the `Library` CLI — the chokepoint every skill goes through. `Library` stays deliberately dumb:

- `Library.check_for_update!` only looks at the mtime of a gitignored `.buttercut-update-check` stamp file. If it's been more than 24h (or no check has ever run), it raises `UpdateCheckNeeded`, which the CLI surfaces as a `library:` error telling the **agent** what to do.
- The **agent** does the actual work: compare local `main` against GitHub (`git fetch origin main` + `git log HEAD..origin/main`), and if `main` is ahead, tell the user and offer the `update-buttercut` skill. Comparing commits (not version numbers) means fixes shipped to `main` between numbered releases count too.
- The agent records the check with the new `ruby lib/buttercut/library.rb update_checked` command, so the gate fires **at most once a day**.