### PR TITLE
Bake rotation into Premiere export for vertical footage (Which is an incredible application that I love to use and pay for)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Writes (`add_videos`, `complete`, `update_metadata`), destructive resets, legacy
 
 ## Key Reminders
 
-- After exporting an XML file, offer to open it directly in the user's editor with `open -a "Final Cut Pro"`, `open -a "Adobe Premiere Pro"`, or `open -a "DaVinci Resolve"` (matching the library's `editor` setting). Check `libraries/settings.yaml` for `open_in_editor_after_export` — if the key is missing, ask and save the preference.
+- After exporting an XML file, offer to open it directly in the user's editor with `open -a "Final Cut Pro"`, `open -a "Adobe Premiere Pro"`, or `open -a "DaVinci Resolve"` (matching the library's `editor` setting). Check `libraries/settings.yaml` for `open_in_editor_after_export` — if the key is missing, ask and save the preference. If `open -a` fails with "Unable to find application named ...", don't assume the editor is missing — the app may be installed under a slightly different name (e.g. a version suffix). Grep the installed apps for it (`ls /Applications | grep -i premiere`, or `mdfind "kMDItemKind == 'Application'" | grep -i resolve`) and retry `open -a` with the actual name before telling the user it isn't installed.
 - Never modify source video files - always preserve originals
 - Flag areas needing human judgment rather than making assumptions
 - When possible, use the existing Ruby files to get work done. Make scripts when the skill or step doesn't provide what you need.

--- a/lib/buttercut.rb
+++ b/lib/buttercut.rb
@@ -1,13 +1,19 @@
 require_relative 'buttercut/distribution'
 require_relative 'buttercut/fcpx'
 require_relative 'buttercut/fcp7'
+require_relative 'buttercut/resolve'
+require_relative 'buttercut/premiere'
 
 # ButterCut - Video editor XML generator
 #
 # Factory class that creates editor-specific generators based on the editor parameter.
 # Currently supports:
 #   - :fcpx - Final Cut Pro X (FCPXML 1.8 format)
-#   - :fcp7 - Final Cut Pro 7 XML (xmeml version 5)
+#   - :resolve - DaVinci Resolve (plain FCP7 / xmeml v5 interchange format)
+#   - :premiere - FCP7 XML with explicit rotation for Adobe Premiere Pro
+#
+# FCP7 itself is the shared xmeml-v5 format base that Resolve and Premiere subclass;
+# it is not a public editor symbol.
 #
 # Example usage:
 #   clips = [
@@ -17,7 +23,7 @@ require_relative 'buttercut/fcp7'
 #   generator = ButterCut.new(clips, editor: :fcpx)
 #   generator.save('output.fcpxml')
 class ButterCut
-  SUPPORTED_EDITORS = [:fcpx, :fcp7].freeze
+  SUPPORTED_EDITORS = [:fcpx, :resolve, :premiere].freeze
 
   def self.new(clips, editor:)
     raise ArgumentError, "editor: parameter is required" if editor.nil?
@@ -29,8 +35,10 @@ class ButterCut
     case editor
     when :fcpx
       ButterCut::FCPX.new(clips)
-    when :fcp7
-      ButterCut::FCP7.new(clips)
+    when :resolve
+      ButterCut::Resolve.new(clips)
+    when :premiere
+      ButterCut::Premiere.new(clips)
     else
       raise ArgumentError, "Editor #{editor.inspect} is not yet implemented."
     end

--- a/lib/buttercut/contact_sheet.rb
+++ b/lib/buttercut/contact_sheet.rb
@@ -5,8 +5,11 @@ require 'english'
 require 'json'
 require 'optparse'
 require 'shellwords'
+require_relative 'rotation_metadata'
 
 class ContactSheet
+  extend RotationMetadata
+
   DEFAULT_FRAMES = 16
   DEFAULT_COLS = 4
   SHORT_CLIP_THRESHOLD = 10.0
@@ -129,24 +132,6 @@ class ContactSheet
     @vfr = self.class.compute_vfr(stream['r_frame_rate'], stream['avg_frame_rate'])
   rescue JSON::ParserError
     raise "ffprobe failed for #{@video_path}"
-  end
-
-  # Exposed as a class method so tests can verify the parsing without touching ffmpeg.
-  # Returns degrees clockwise in 0..359. Old MP4/MOV containers store rotation in the
-  # stream `rotate` tag (clockwise). Modern files store a displaymatrix in
-  # `side_data_list[i].rotation` measured counter-clockwise — negate it.
-  def self.extract_rotation(stream)
-    tag = stream.dig('tags', 'rotate') || stream.dig('tags', 'ROTATE')
-    return normalize_rotation(tag.to_i) if tag
-
-    side = (stream['side_data_list'] || []).find { |sd| sd['rotation'] }
-    return normalize_rotation(-side['rotation'].to_i) if side
-
-    0
-  end
-
-  def self.normalize_rotation(degrees)
-    ((degrees.to_i % 360) + 360) % 360
   end
 
   # :all_intra → every frame is a keyframe; seek is essentially free.

--- a/lib/buttercut/editor_base.rb
+++ b/lib/buttercut/editor_base.rb
@@ -3,10 +3,13 @@ require 'pathname'
 require 'cgi'
 require 'json'
 require 'digest'
+require_relative 'rotation_metadata'
 
 class ButterCut
   # Shared functionality for editor-specific generators.
   class EditorBase
+    extend RotationMetadata
+
     DEFAULT_START_TIME = "0s"
     DEFAULT_INITIAL_OFFSET = "0s"
     DEFAULT_VOLUME_ADJUSTMENT = "-13.100000000000001db"
@@ -68,6 +71,12 @@ class ButterCut
 
     def video_height(video_path)
       video_stream(video_path)['height']
+    end
+
+    # Degrees clockwise (0/90/180/270) the source must be rotated to display upright,
+    # read from container rotation metadata via RotationMetadata.
+    def video_rotation(video_path)
+      self.class.extract_rotation(video_stream(video_path))
     end
 
     def video_duration(video_path)
@@ -368,6 +377,7 @@ class ButterCut
           frame_rate: frame_rate(video_file_path),
           width: video_width(video_file_path),
           height: video_height(video_file_path),
+          rotation: video_rotation(video_file_path),
           color_space: color_space(video_file_path)
         }
       end

--- a/lib/buttercut/export.rb
+++ b/lib/buttercut/export.rb
@@ -7,22 +7,10 @@ require 'yaml'
 require_relative '../buttercut'
 
 class Export
-  EDITOR_ALIASES = {
-    'fcpx'             => :fcpx,
-    'finalcut'         => :fcpx,
-    'finalcutpro'      => :fcpx,
-    'fcp'              => :fcpx,
-    'premiere'         => :fcp7,
-    'premierepro'      => :fcp7,
-    'adobepremiere'    => :fcp7,
-    'resolve'          => :fcp7,
-    'davinci'          => :fcp7,
-    'davinciresolve'   => :fcp7
-  }.freeze
-
   EDITOR_LABELS = {
     fcpx: 'Final Cut Pro X',
-    fcp7: 'Premiere / Resolve (FCP7 XML)'
+    resolve: 'DaVinci Resolve (FCP7 XML)',
+    premiere: 'Adobe Premiere Pro (FCP7 XML + rotation)'
   }.freeze
 
   def self.perform(roughcut_path:, output_path:, editor: 'fcpx')
@@ -98,8 +86,10 @@ class Export
   end
 
   def resolve_editor(input)
-    EDITOR_ALIASES[input.downcase] ||
-      raise(ArgumentError, "Unknown editor '#{input}'. Use 'fcpx', 'premiere', or 'resolve'")
+    editor = input.downcase.to_sym
+    return editor if EDITOR_LABELS.key?(editor)
+
+    raise ArgumentError, "Unknown editor '#{input}'. Use 'fcpx', 'premiere', or 'resolve'"
   end
 
   def write_xml(clips, editor)

--- a/lib/buttercut/fcp7.rb
+++ b/lib/buttercut/fcp7.rb
@@ -188,6 +188,9 @@ class ButterCut
             end
           end
         end
+        # FCP7/xmeml orders <filter> after <file> and before <sourcetrack>;
+        # Premiere ignores filters that appear out of order.
+        add_video_filters(xml, payload)
         xml.sourcetrack do
           xml.mediatype 'video'
           xml.trackindex 1
@@ -195,6 +198,11 @@ class ButterCut
         build_link_entries(xml, payload)
       end
     end
+
+    # Hook for subclasses to inject <filter> elements into a video clipitem.
+    # No-op in the base FCP7 format (and therefore in Resolve, which reads the
+    # source rotation flag itself). Premiere overrides this to bake in rotation.
+    def add_video_filters(xml, payload); end
 
     def build_audio_clipitem(xml, payload)
       asset = payload[:asset]

--- a/lib/buttercut/premiere.rb
+++ b/lib/buttercut/premiere.rb
@@ -1,0 +1,58 @@
+require_relative 'fcp7'
+
+class ButterCut
+  # Adobe Premiere Pro FCP7 XML (xmeml version 5).
+  #
+  # Shares the FCP7 base with the Resolve generator but diverges on rotation. Resolve
+  # (and Final Cut) read the source file's own rotation flag on import and auto-correct,
+  # so vertical footage stored as a rotated landscape frame comes in upright — the plain
+  # FCP7 output is enough. Premiere honors ONLY what the XML declares: it ignores the
+  # source rotation flag, so the same XML imports sideways. Premiere therefore needs the
+  # rotation written explicitly into the timeline.
+  #
+  class Premiere < FCP7
+    # The sequence frame follows the first clip's *display* orientation, so a quarter-turn
+    # source gives a portrait timeline (the stored landscape dimensions swapped) rather than
+    # a landscape one the rotated footage can't fill.
+    def format_width
+      quarter_turn?(@clips.first[:path]) ? video_height(@clips.first[:path]) : super
+    end
+
+    def format_height
+      quarter_turn?(@clips.first[:path]) ? video_width(@clips.first[:path]) : super
+    end
+
+    private
+
+    def quarter_turn?(video_path)
+      [90, 270].include?(video_rotation(video_path))
+    end
+
+    # Premiere ignores the source rotation flag, so bake the rotation into the timeline
+    # as a Basic Motion effect. Rotation is clockwise-positive; 270 is written as -90 so
+    # the applied turn is the short way around.
+    def add_video_filters(xml, payload)
+      rotation = payload[:asset][:rotation].to_i
+      return if rotation.zero?
+
+      degrees = rotation > 180 ? rotation - 360 : rotation
+
+      xml.filter do
+        xml.effect do
+          xml.name 'Basic Motion'
+          xml.effectid 'basic'
+          xml.effectcategory 'motion'
+          xml.effecttype 'motion'
+          xml.mediatype 'video'
+          xml.parameter do
+            xml.parameterid 'rotation'
+            xml.name 'Rotation'
+            xml.valuemin(-100000)
+            xml.valuemax 100000
+            xml.value degrees
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/buttercut/resolve.rb
+++ b/lib/buttercut/resolve.rb
@@ -1,0 +1,16 @@
+require_relative 'fcp7'
+
+class ButterCut
+  # DaVinci Resolve timeline export.
+  #
+  # Resolve imports the plain FCP7 (xmeml v5) interchange format as-is: it reads each
+  # source file's own rotation flag on import and auto-corrects orientation, so vertical
+  # footage stored as a rotated landscape frame comes in upright with no help from the XML.
+  # That's why this is a thin pass-through over FCP7 while Premiere (which ignores the
+  # source rotation flag) needs its own subclass that writes rotation explicitly.
+  #
+  # Keeping it as a named subclass — rather than pointing the factory straight at FCP7 —
+  # gives Resolve-specific behavior a home if the two formats ever need to diverge.
+  class Resolve < FCP7
+  end
+end

--- a/lib/buttercut/rotation_metadata.rb
+++ b/lib/buttercut/rotation_metadata.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Reads container rotation metadata from an ffprobe video stream and returns the
+# degrees clockwise (0/90/180/270) the source must be rotated to display upright.
+# Shared by the contact-sheet pipeline and the editor exporters so orientation
+# handling stays consistent across the app. Extend it onto a class to expose
+# both methods as class methods.
+module RotationMetadata
+  # Old MP4/MOV containers store rotation in the stream `rotate` tag (clockwise).
+  # Modern files store a displaymatrix in `side_data_list[i].rotation` measured
+  # counter-clockwise — negate it. Returns degrees clockwise in 0..359, 0 when
+  # there's no rotation metadata.
+  def extract_rotation(stream)
+    tag = stream.dig('tags', 'rotate') || stream.dig('tags', 'ROTATE')
+    return normalize_rotation(tag.to_i) if tag
+
+    side = (stream['side_data_list'] || []).find { |sd| sd['rotation'] }
+    return normalize_rotation(-side['rotation'].to_i) if side
+
+    0
+  end
+
+  def normalize_rotation(degrees)
+    ((degrees.to_i % 360) + 360) % 360
+  end
+end

--- a/spec/buttercut/premiere_spec.rb
+++ b/spec/buttercut/premiere_spec.rb
@@ -98,6 +98,48 @@ RSpec.describe ButterCut::Premiere do
     end
   end
 
+  # Real cuts mix orientations — a single timeline can hold rotated and upright clips
+  # in any order. Rotation is per-clip, so each video clipitem must be judged on its own
+  # source flag; the sequence frame, by contrast, follows only the FIRST clip.
+  describe 'a timeline mixing rotated and upright clips' do
+    let(:xml) do
+      described_class.new([
+        { path: rotated_clip_path },    # -90 source -> +90 cw
+        { path: upright_clip_path },    # no rotation
+        { path: cw_rotated_clip_path }  # +90 source -> 270, written the short way as -90
+      ]).to_xml
+    end
+    let(:doc) { Nokogiri::XML(xml) }
+    # Only the sequence's video track carries clipitems with filters; audio clipitems
+    # (under media/audio) and the per-file <media><video> blocks have no <track>.
+    let(:video_clipitems) { doc.xpath('/xmeml/sequence/media/video/track/clipitem') }
+    let(:clipitem_by_name) do
+      video_clipitems.each_with_object({}) { |ci, h| h[ci.at_xpath('name').text] = ci }
+    end
+
+    def baked_rotation(clipitem)
+      clipitem.at_xpath(".//filter/effect[name='Basic Motion']/parameter[parameterid='rotation']/value")&.text
+    end
+
+    it 'judges each clip on its own source flag' do
+      expect(video_clipitems.length).to eq(3)
+      expect(baked_rotation(clipitem_by_name['premiere_rotated'])).to eq('90')
+      expect(baked_rotation(clipitem_by_name['premiere_upright'])).to be_nil
+      expect(baked_rotation(clipitem_by_name['premiere_cw_rotated'])).to eq('-90')
+    end
+
+    it 'writes exactly one Basic Motion filter per rotated clip' do
+      expect(xml.scan('<name>Basic Motion</name>').length).to eq(2)
+    end
+
+    it 'orients the sequence to the first clip regardless of later clips' do
+      format = xml[%r{<format>.*?</format>}m]
+
+      expect(format).to include('<width>2160</width>')
+      expect(format).to include('<height>3840</height>')
+    end
+  end
+
   # Regression guard: the Resolve path must NOT change — it already imports correctly
   # because Resolve reads the source rotation flag itself. If a future change starts
   # injecting rotation into the shared FCP7 output, this fails and warns us we have

--- a/spec/buttercut/premiere_spec.rb
+++ b/spec/buttercut/premiere_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+# Premiere forks the FCP7 XML so it can write rotation explicitly into the timeline.
+#
+# Background: vertical footage is commonly stored as a LANDSCAPE frame (e.g. 3840x2160)
+# with a display-matrix rotation flag of -90. Final Cut and DaVinci Resolve read that
+# flag from the source file on import and auto-correct, so the clip shows upright.
+# Adobe Premiere Pro ignores the source flag and trusts only what the XML declares —
+# so the shared FCP7 output (raw landscape dimensions, no rotation) imports SIDEWAYS.
+#
+# These specs are the failing-first contract for the fix: the Premiere generator must
+# emit the rotation into the XML, and the Resolve (FCP7) path must stay untouched.
+RSpec.describe ButterCut::Premiere do
+  let(:rotated_clip_path)   { '/tmp/premiere_rotated.mov' }
+  let(:upright_clip_path)   { '/tmp/premiere_upright.mov' }
+
+  # `rotation` mirrors ffprobe's modern display-matrix side data: a value of -90 means
+  # the picture must be rotated to display upright (vertical footage in a landscape frame).
+  def build_metadata(duration_seconds:, frame_rate: '30/1', width: 1920, height: 1080,
+                     sample_rate: '48000', rotation: nil)
+    video_stream = {
+      'codec_type'  => 'video',
+      'width'       => width,
+      'height'      => height,
+      'r_frame_rate' => frame_rate,
+      'color_space' => 'bt709'
+    }
+    if rotation
+      video_stream['side_data_list'] = [{ 'side_data_type' => 'Display Matrix', 'rotation' => rotation }]
+    end
+
+    audio_stream = { 'codec_type' => 'audio', 'sample_rate' => sample_rate }
+
+    {
+      'streams' => [video_stream, audio_stream],
+      'format'  => { 'duration' => duration_seconds.to_s, 'tags' => {} }
+    }
+  end
+
+  let(:cw_rotated_clip_path) { '/tmp/premiere_cw_rotated.mov' }
+
+  let(:metadata_by_path) do
+    {
+      # Vertical footage stored landscape with a -90 rotation flag.
+      rotated_clip_path => build_metadata(duration_seconds: 4.0, width: 3840, height: 2160, rotation: -90),
+      # Ordinary landscape footage, no rotation.
+      upright_clip_path => build_metadata(duration_seconds: 3.0, width: 1920, height: 1080),
+      # Vertical footage rotated the other quarter-turn: a +90 display-matrix flag
+      # normalizes to 270 clockwise, which the timeline writes the short way as -90.
+      cw_rotated_clip_path => build_metadata(duration_seconds: 4.0, width: 3840, height: 2160, rotation: 90)
+    }
+  end
+
+  before do
+    allow_any_instance_of(ButterCut::EditorBase).to receive(:extract_metadata_from_ffprobe) do |_instance, path|
+      metadata_by_path.fetch(path)
+    end
+  end
+
+  describe '#to_xml' do
+    it 'writes a Basic Motion rotation filter for a rotated source clip' do
+      xml = described_class.new([{ path: rotated_clip_path }]).to_xml
+
+      expect(xml).to include('<name>Basic Motion</name>')
+      # A -90 display-matrix source must turn +90 clockwise to display upright.
+      expect(xml).to match(%r{<parameterid>rotation</parameterid>.*?<value>90</value>}m)
+    end
+
+    it 'does not add a rotation filter to footage that is already upright' do
+      xml = described_class.new([{ path: upright_clip_path }]).to_xml
+
+      expect(xml).not_to include('<parameterid>rotation</parameterid>')
+    end
+
+    it 'writes the rotation the short way around for a 270-degree source' do
+      xml = described_class.new([{ path: cw_rotated_clip_path }]).to_xml
+
+      expect(xml).to match(%r{<parameterid>rotation</parameterid>.*?<value>-90</value>}m)
+    end
+
+    # The sequence frame follows the first clip's *display* orientation, so a
+    # quarter-turn source must yield a portrait timeline (stored 3840x2160 swapped
+    # to 2160x3840) rather than a landscape one the rotated footage can't fill.
+    it 'swaps the sequence dimensions to portrait for quarter-turn footage' do
+      xml = described_class.new([{ path: rotated_clip_path }]).to_xml
+      format = xml[%r{<format>.*?</format>}m]
+
+      expect(format).to include('<width>2160</width>')
+      expect(format).to include('<height>3840</height>')
+    end
+
+    it 'leaves the sequence dimensions landscape for upright footage' do
+      xml = described_class.new([{ path: upright_clip_path }]).to_xml
+      format = xml[%r{<format>.*?</format>}m]
+
+      expect(format).to include('<width>1920</width>')
+      expect(format).to include('<height>1080</height>')
+    end
+  end
+
+  # Regression guard: the Resolve path must NOT change — it already imports correctly
+  # because Resolve reads the source rotation flag itself. If a future change starts
+  # injecting rotation into the shared FCP7 output, this fails and warns us we have
+  # double-rotated Resolve.
+  describe 'Resolve output is left unchanged' do
+    it 'emits no rotation filter for the same rotated clip' do
+      xml = ButterCut::Resolve.new([{ path: rotated_clip_path }]).to_xml
+
+      expect(xml).not_to include('<parameterid>rotation</parameterid>')
+      expect(xml).not_to include('<name>Basic Motion</name>')
+    end
+  end
+end

--- a/spec/buttercut_spec.rb
+++ b/spec/buttercut_spec.rb
@@ -10,9 +10,14 @@ RSpec.describe ButterCut do
       expect(generator).to be_a(ButterCut::FCPX)
     end
 
-    it 'creates a ButterCut::FCP7 instance when editor is :fcp7' do
-      generator = ButterCut.new(clips, editor: :fcp7)
-      expect(generator).to be_a(ButterCut::FCP7)
+    it 'creates a ButterCut::Resolve instance when editor is :resolve' do
+      generator = ButterCut.new(clips, editor: :resolve)
+      expect(generator).to be_a(ButterCut::Resolve)
+    end
+
+    it 'creates a ButterCut::Premiere instance when editor is :premiere' do
+      generator = ButterCut.new(clips, editor: :premiere)
+      expect(generator).to be_a(ButterCut::Premiere)
     end
 
     it 'requires editor parameter' do
@@ -20,8 +25,8 @@ RSpec.describe ButterCut do
     end
 
     it 'raises error for unsupported editor' do
-      expect { ButterCut.new(clips, editor: :premiere) }.to raise_error(ArgumentError, /Unsupported editor: :premiere/)
-      expect { ButterCut.new(clips, editor: :resolve) }.to raise_error(ArgumentError, /Unsupported editor: :resolve/)
+      # :fcp7 is the shared format base, not a public editor symbol.
+      expect { ButterCut.new(clips, editor: :fcp7) }.to raise_error(ArgumentError, /Unsupported editor: :fcp7/)
       expect { ButterCut.new(clips, editor: :invalid) }.to raise_error(ArgumentError, /Unsupported editor: :invalid/)
     end
   end


### PR DESCRIPTION
## Summary
- Premiere Pro ignores the source rotation flag that Final Cut and DaVinci Resolve honor on import, so vertical footage stored as a rotated landscape frame (e.g. 3840×2160 with a −90 display-matrix flag) imported **sideways**.
- Split the shared FCP7 base into explicit `Resolve` and `Premiere` subclasses: Resolve keeps the plain FCP7 output (it auto-corrects from the source flag), while Premiere writes the rotation into the timeline as a Basic Motion filter and swaps the sequence dimensions to portrait for quarter-turn sources.
- Rotation parsing is centralized in a shared `RotationMetadata` module (used by both the exporters and the contact-sheet pipeline) so orientation handling stays consistent.

## Why
Vertical clips were unusable in Premiere for cameras that don't natively save in vertical format. ie, black magic app on iPhone.  They came in rotated 90° with the wrong frame size. FCP and Resolve were already correct because they read the container rotation flag themselves; only Premiere needs the rotation declared explicitly in the XML. Premiere. Incredible *and* expensive.

## What's in the diff
- `lib/buttercut/rotation_metadata.rb` — shared parser for container rotation (legacy `tags.rotate` and modern display-matrix side data), returning degrees clockwise.
- `lib/buttercut/premiere.rb` — bakes per-clip rotation as a Basic Motion effect (90 / −90 written the short way) and flips the sequence frame to portrait for quarter-turn footage.
- `lib/buttercut/resolve.rb`, `fcp7.rb`, `editor_base.rb`, `export.rb`, `lib/buttercut.rb` — base/subclass split and a `video_rotation` accessor.
- `spec/buttercut/premiere_spec.rb` — rotation contract plus a mixed-orientation multi-clip timeline (rotation baked per-clip; sequence frame follows only the first clip).

## Notes for reviewers
- Rotation is **per-clip**, but the sequence frame follows the **first** clip only.
frame — tracked separately.