### PR TITLE
Rewrite README for developers and split docs into per-topic files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,136 +1,59 @@
 # ButterCut
 
-**Make Claude your Video Editor**
+This is the source code for the core ButterCut XML generator and video editing agent. If you love or hate Docker, have opinions on types, and have a favorite text editor, this is the spot for you. Otherwise, we recommend following the installation instructions on [ButterCut.io](https://buttercut.io).
 
-[buttercut.io](https://buttercut.io)
+## Videos
 
-Give Claude Code your video footage. Claude analyzes it, then builds roughcuts and sequences for Final Cut, Premiere, and Resolve.
-
-Behind the scenes Claude uses ButterCut Skills and a little Ruby library to generate timelines for your editor.
-
-## Watch the Demo
-
-[![I Taught Claude Code to Edit Movies](https://img.youtube.com/vi/FBkfr1yWf_s/maxresdefault.jpg)](https://www.youtube.com/watch?v=FBkfr1yWf_s)
-
-*Click to watch "I Taught Claude Code to Edit Movies" on YouTube*
+<table>
+  <tr>
+    <td align="center"><a href="https://www.youtube.com/watch?v=FBkfr1yWf_s"><img src="https://img.youtube.com/vi/FBkfr1yWf_s/maxresdefault.jpg" alt="I Taught Claude Code to Edit Movies" width="380"></a></td>
+    <td align="center"><a href="https://www.youtube.com/watch?v=BCMQzg-HiTw"><img src="https://img.youtube.com/vi/BCMQzg-HiTw/maxresdefault.jpg" alt="ButterCut Install Video" width="380"></a></td>
+  </tr>
+  <tr>
+    <td align="center"><em>Watch the demo: "I Taught Claude Code to Edit Movies"</em></td>
+    <td align="center"><em>Watch the ButterCut install video</em></td>
+  </tr>
+</table>
 
 ## Getting Started
 
-[![ButterCut Install Video](https://img.youtube.com/vi/BCMQzg-HiTw/maxresdefault.jpg)](https://www.youtube.com/watch?v=BCMQzg-HiTw)
+ButterCut targets Macs with Apple Silicon (M-series chips). If you're technical and don't mind agent churn, you can likely get it working on Windows, Linux, etc. — but until revenue from ButterCut Pro is full time ish (🤞), broad Windows/Linux compatibility isn't a priority and isn't something I'll publicly support for non-technical users.
 
-*Click to watch the ButterCut install video on YouTube*
+Clone this repository and then set it as your active directory.
 
-**Clone ButterCut:**
 ```bash
 git clone https://github.com/barefootford/buttercut.git && cd buttercut
 ```
 
-**Open Claude Code:**
-```bash
-claude
-
-# or skip permission prompts (faster, but riskier):
-claude --dangerously-skip-permissions
-```
-
-**Tell Claude to install ButterCut:**
-```
-> Install ButterCut
-```
-
-Claude will check your system and install any missing dependencies (Ruby, Python, FFmpeg, WhisperX).
-
-For manual installation, see [docs/installation.md](docs/installation.md).
+Call the `/setup` skill to automatically install dependencies, or see [advanced-setup.md](skills/setup/advanced-setup.md) for a custom install. Primary requirements are Ruby, Python, FFmpeg, and WhisperX. Check `.python-version` and `.ruby-version` for specific language versions, and `Gemfile` and `requirements.txt` for their respective dependencies.
 
 ## Usage
 
-First tell Claude to create a **Library**. A library organizes your video footage along with the transcripts, contact sheets, and summaries Claude needs to edit it. Then tell Claude you want to create a **rough cut** or **sequence**.
+ButterCut has two primary abstractions: libraries (where footage goes) and cuts (the agent builds a select, scene, or roughcut with you).
 
-### Creating a Video Library
-
-```plaintext
-You: "I want to build a new library"
-
-Claude: [Guides you through library setup and asks for details]
-
-You:
-  - Library name: "wedding"
-  - Video location: "/path/to/videos"
-  - Language: "English"
-
-Claude: [Automatically processes all videos]
-  ✓ Creates library structure
-  ✓ Transcribes audio
-  ✓ Builds a contact sheet for every clip
-  ✓ Writes a short summary of each clip
-
-Result: Full footage analysis ready for rough cut creation
-```
-
-Claude handles the parallel processing, metadata extraction, and analysis. See the [full walkthrough](docs/example-library-setup.md) for a detailed example of me setting up a library from my wedding footage.
-
-### Creating a Roughcut or Sequence
-
-Once your library is analyzed, Claude can create rough cuts through an interactive conversation:
-
-```plaintext
-You: "Let's create a new roughcut"
-
-Claude: [Loads cut skill and analyzes footage]
-        What should this roughcut focus on?
-        - Full story
-        - Just the meetup coverage
-        - Short teaser sequence
-
-You: "Just the meetup coverage"
-
-Claude: [Asks 3 preference questions]
-        - Narrative structure? (chronological, thematic, hook-based)
-        - Target duration? (1-2 min, 3-5 min, 6-10 min)
-        - Pacing style? (fast & punchy, conversational, cinematic)
-
-You: "Start with presentations (5 sec clips), then interviews,
-      then my closing reflection. 3-5 minutes, conversational pacing."
-
-Claude: [Asks which video editor you want to use]
-        - Final Cut Pro X
-        - Adobe Premiere Pro
-        - DaVinci Resolve
-
-You: "Final Cut Pro X"
-
-Claude: [Creates roughcut with editorial decisions]
-        ✓ Reviewed contact sheets and transcripts
-        ✓ Selected 29 clips (4:32 total)
-        ✓ Exported to FCPXML
-
-Result: Ready-to-import timeline at:
-        libraries/[library]/roughcuts/[name]_[datetime].fcpxml
-```
-
-Claude makes editorial decisions based on transcript analysis and your preferences, then exports a timeline for your editor.
-
-### XML Generation
-
-For direct XML generation without Claude Code, see [docs/basic-xml-generation.md](docs/basic-xml-generation.md).
-
-## Thanks
-
-ButterCut was inspired by ambitious open source work from [Chris Hocking](https://github.com/CommandPost/CommandPost) and [Andrew Arrow](https://github.com/andrewarrow/cutlass/tree/main).
+See [docs/usage.md](docs/usage.md) for working with libraries and cuts.
 
 ## License
 
 ButterCut is open source under the [PolyForm Noncommercial License 1.0.0 with a Commercial Output exception](LICENSE).
 
-- **You can use ButterCut to make videos commercially.** Cut a YouTube video for ad revenue, edit a paid client project, deliver a sponsored brand piece — all fine. The videos are yours, and the licensor claims no rights to them.
+- **You absolutely can use ButterCut to make commercial videos.** Cut a YouTube video for ad revenue, edit a paid client project, deliver a sponsored brand piece — all fine. The videos are yours, and the licensor claims no rights to them.
 - **You can't repackage ButterCut as commercial software.** Selling, hosting, or bundling the tool itself (or a fork of it) into a commercial product, plugin, or SaaS requires a separate commercial license from TubeSalt LLC.
 
-Personal, hobby, research, and educational use of the software is also free under the underlying license. If you'd like a commercial software license, reach out.
+Personal, hobby, research, and educational use of the software is also free under the underlying license. If you'd like a commercial software license, reach out to [Andrew@TubeSalt.com](mailto:Andrew@TubeSalt.com).
+
+## Future features
+
+This is the core (basic) version of ButterCut. ButterCut Pro is also on the way, à la Sidekiq Pro. ButterCut will remain a single-track editing solution with WhisperX transcription. ButterCut Pro will support multiple tracks, faster transcription, and other "pro" features. If you're a developer interested in a reduced-cost Pro license in exchange for bug reports, DM me on the ButterCut Discord linked from [buttercut.io](https://buttercut.io).
 
 ## Contributing
 
-Bug reports and pull requests welcome, with that said...
+### Start with an issue, not a PR
 
-**Guidelines:**
-- Write the body of your pull request or GitHub issue yourself. Don't use an agent (Claude Code, etc) to generate it.
-- Keep pull requests small and limited to a single feature or bugfix at a time. It's a lot easier to write code, I feel like it's just as hard as before to review code.
+Thanks to LLMs, it's really easy to spike a quick change to ButterCut — add a feature, fix a bug, etc. But it's still quite difficult to keep it all cohesive and maintain working XML across three different editors. If you want to contribute, the best way to start is with a GitHub issue. Write a human-generated issue (I know!), and I'll work with you from there to get a commit in. I'm happy to pair, jump on a Google Meet, etc., to provide context and help.
+
+Alternatively, you can always *create your own custom skills* (or fork existing ones) for ButterCut and prefix them with `user-`, e.g. `user-quick-interview-summary`. That skill stays on your own Mac, gitignored automatically, so you can build your own workflows while still staying on the main branch. As I'm sure you know, you can include your own Ruby or Python scripts inside a skill folder to make this really powerful — no need to fork off on your own.
+
+## Thanks
+
+ButterCut was inspired by ambitious open source work from [Chris Hocking](https://github.com/CommandPost/CommandPost) and [Andrew Arrow](https://github.com/andrewarrow/cutlass/tree/main).

--- a/docs/creating-a-cut.md
+++ b/docs/creating-a-cut.md
@@ -1,0 +1,58 @@
+# Creating a Cut
+
+Once your library is processed, Claude builds a cut through an interactive conversation and exports a timeline for your editor. A "cut" can be one of four shapes — Claude asks which one you want:
+
+- **Scene** — one beat or moment, typically 30–60s.
+- **Selects** — a flat reel of clips matching some criteria (best takes, mentions of a topic, B-roll on a theme). Length follows the footage.
+- **Roughcut** — a story-shaped cut, usually 2–8 minutes, with full narrative planning.
+- **Custom** — anything else you describe.
+
+## Example
+
+```plaintext
+You: "Let's create a cut"
+
+Claude: Library is ready (29/29 clips processed).
+        What kind of cut do you want — scene, selects, roughcut, or custom?
+
+You: "A roughcut of just the meetup coverage"
+
+Claude: [Asks a few preference questions]
+        - Narrative structure? (chronological, thematic, hook-based)
+        - Target duration? (1-2 min, 3-5 min, 6-10 min)
+        - Pacing style? (fast & punchy, conversational, cinematic)
+
+You: "Start with presentations (5 sec clips), then interviews,
+      then my closing reflection. 3-5 minutes, conversational pacing."
+
+Claude: [Asks which video editor you want to use]
+        - Final Cut Pro X
+        - Adobe Premiere Pro
+        - DaVinci Resolve
+
+You: "Final Cut Pro X"
+
+Claude: [Makes editorial decisions and builds the cut]
+        ✓ Reviewed contact sheets, summaries, and transcripts
+        ✓ Selected 29 clips (4:32 total)
+        ✓ Exported to FCPXML
+
+Result: Ready-to-import timeline at:
+        libraries/[library]/cuts/[name]_[datetime].fcpxml
+```
+
+Claude makes editorial decisions based on the contact sheets, summaries, and transcript analysis plus your direction, then exports a timeline for your editor.
+
+## Output
+
+Every cut exports a timeline into `libraries/[library-name]/cuts/`:
+
+- **Final Cut Pro X** → `.fcpxml`
+- **Adobe Premiere Pro** → `.xml`
+- **DaVinci Resolve** → `.xml`
+
+If you've enabled it, Claude can also drop a copy on your Desktop and open the file directly in your editor after export.
+
+## Direct XML generation
+
+To generate a timeline in Ruby without going through Claude, see [basic-xml-generation.md](basic-xml-generation.md).

--- a/docs/creating-a-library.md
+++ b/docs/creating-a-library.md
@@ -1,0 +1,40 @@
+# Creating a Video Library
+
+A **library** organizes your video footage along with the transcripts, contact sheets, and summaries Claude needs to edit it. Creating one is the first thing you do with ButterCut — you can't build a cut until a library is processed.
+
+Just tell Claude you want a new library and it walks you through setup:
+
+```plaintext
+You: "I want to build a new library"
+
+Claude: [Guides you through library setup and asks for details]
+
+You:
+  - Library name: "wedding"
+  - Video location: "/path/to/videos"
+  - Language: "English"
+
+Claude: [Automatically processes all videos]
+  ✓ Creates the library structure
+  ✓ Transcribes audio with word-level timing (WhisperX)
+  ✓ Builds a contact sheet for every clip
+  ✓ Writes a short summary of each clip
+
+Result: Full footage analysis, ready to build a cut
+```
+
+Claude handles parallel processing, metadata extraction (via FFmpeg), and analysis. Each library is self-contained under `libraries/[library-name]/`, with `library.yaml` as its source of truth.
+
+## Adding footage or resuming
+
+The same flow handles three cases:
+
+- **New project** — creates the library, gathers project info, runs analysis end to end.
+- **Resume** — reopens an existing library and continues from wherever analysis left off.
+- **Add footage** — appends new clips and analyzes just those.
+
+Just point Claude at the library or the new files and say what you want.
+
+## Walkthrough
+
+See the [full walkthrough](example-library-setup.md) for a detailed example of setting up a library from wedding footage.

--- a/docs/example-library-setup.md
+++ b/docs/example-library-setup.md
@@ -88,26 +88,26 @@ All audio transcription complete (word-level timing preserved)
 ```
 
 ### Step 3: Visual Analysis (Parallel Processing)
-Claude launches 10 more parallel agents to analyze frames:
+Claude launches more parallel agents to build a contact sheet for each clip (evenly spaced frames laid out in one grid image with burned-in timestamps) and write a short summary from it:
 
 ```
-Agent 1: Analyzing frames for MVI_0307.MP4...
-Agent 2: Analyzing frames for MVI_0316.MP4...
+Agent 1: Building contact sheet for MVI_0307.MP4...
+Agent 2: Building contact sheet for MVI_0316.MP4...
 [...extracting frames with ffmpeg]
-[...analyzing visual content with Claude]
+[...summarizing each contact sheet with Claude]
 
-✓ visual_MVI_0307.json - Wedding venue entrance, fairy lights
-✓ visual_MVI_0316.json - Decorated storefront with blue lighting
-✓ visual_MVI_0311.json - Outdoor pavilion with string lights
-✓ visual_MVI_0322.json - Night venue exterior, gold garland
-✓ visual_MVI_0326.json - Champagne glasses on pink table
-✓ visual_MVI_0304.json - Reception area with guests
-✓ visual_MVI_0306.json - Evening reception under light canopy
-✓ visual_MVI_0308.json - Formal dinner table, gold plates
-✓ visual_MVI_0302.json - Guest conversation area
-✓ visual_MVI_0313.json - First-person walking in snow
+✓ MVI_0307 - Wedding venue entrance, fairy lights
+✓ MVI_0316 - Decorated storefront with blue lighting
+✓ MVI_0311 - Outdoor pavilion with string lights
+✓ MVI_0322 - Night venue exterior, gold garland
+✓ MVI_0326 - Champagne glasses on pink table
+✓ MVI_0304 - Reception area with guests
+✓ MVI_0306 - Evening reception under light canopy
+✓ MVI_0308 - Formal dinner table, gold plates
+✓ MVI_0302 - Guest conversation area
+✓ MVI_0313 - First-person walking in snow
 
-All visual analysis complete
+All contact sheets and summaries complete
 ```
 
 ### Step 4: Summary Generated
@@ -139,7 +139,7 @@ Library setup complete! I've successfully processed all 10 wedding video clips:
 **Analysis Complete:**
 - **Total footage:** 1 minute 32 seconds (183MB)
 - **Audio transcription:** All 10 videos transcribed with word-level timing
-- **Visual analysis:** All 10 videos analyzed with frame descriptions
+- **Visual analysis:** Contact sheet and summary built for all 10 videos
 
 **Footage Summary:**
 This is wedding reception footage shot on camcorder at night. The venue features an elegant outdoor pavilion with string light canopies, formal dining tables with gold charger plates and burgundy tablecloths, and a decorated storefront entrance with fairy lights and gold garland. Footage captures casual conversations between guests, a champagne toast scene, and even includes one clip of snowy outdoor conditions. The overall atmosphere is intimate, formal, and celebratory.
@@ -159,11 +159,15 @@ All files are saved in:
 libraries/wedding/
 ├── library.yaml                          # Source of truth for library
 ├── transcripts/
-│   ├── MVI_0307.json                    # Audio transcript
-│   ├── visual_MVI_0307.json             # Visual transcript
+│   ├── MVI_0307.json                    # Audio transcript (word-level timing)
 │   ├── MVI_0316.json
-│   ├── visual_MVI_0316.json
-│   └── [...18 more transcript files]
+│   └── [...8 more transcript files]
+├── contact_sheets/
+│   ├── MVI_0307_full.jpg                # Frame grid with timestamps
+│   └── [...9 more contact sheets]
+├── summaries/
+│   ├── summary_MVI_0307.md              # Short per-clip summary
+│   └── [...9 more summaries]
 └── cuts/                                # Ready for cut creation
 ```
 
@@ -174,7 +178,7 @@ libraries/wedding/
 1. **Automatic Discovery** - Claude found and sorted videos by size
 2. **Parallel Processing** - 10 videos processed simultaneously (4 at a time)
 3. **WhisperX Integration** - Word-level audio transcription with precise timing
-4. **Visual Analysis** - FFmpeg frame extraction + AI visual description
+4. **Visual Analysis** - FFmpeg contact sheets + AI-written per-clip summaries
 5. **Smart Summarization** - Automatic footage summary generation
 6. **No Manual Configuration** - Zero config files to edit
 
@@ -187,9 +191,9 @@ libraries/wedding/
 You: "Create a rough cut showing the best moments from the reception"
 
 Claude: [Uses cut skill]
-  - Reads all visual and audio transcripts
+  - Reviews contact sheets, summaries, and audio transcripts
   - Selects best clips based on your direction
-  - Generates rough cut YAML
+  - Builds the cut YAML
   - Exports to FCPXML format
 
 Result: timeline_2025-11-10.fcpxml ready to import into Final Cut Pro

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,8 @@
+# Usage
+
+First tell Claude to create a **library** — it organizes your footage along with the transcripts, contact sheets, and summaries Claude needs to edit. Once a library is processed, ask Claude to build a **cut** (scene, selects, roughcut, or custom) and it exports a timeline for your editor.
+
+- [Installation](installation.md) — manual setup and dependency versions.
+- [Creating a library](creating-a-library.md) — process footage into a library. ([full walkthrough](example-library-setup.md))
+- [Creating a cut](creating-a-cut.md) — build a scene, selects reel, roughcut, or custom cut and export it.
+- [Basic XML generation](basic-xml-generation.md) — generate timelines in Ruby without Claude Code.


### PR DESCRIPTION
## Summary
- Reframe README.md as a developer-facing entry point (drop the consumer pitch, point readers at buttercut.io for end-user install).
- Split the old monolithic Usage section into per-topic docs: `docs/usage.md` (index), `docs/creating-a-library.md`, and `docs/creating-a-cut.md`.
- Update the wedding walkthrough (`docs/example-library-setup.md`) for the current pipeline: contact sheets + summaries replace the deprecated visual transcripts; output directory is `cuts/` (not `roughcuts/`); file structure shows the actual `Library` namers (`*_full.jpg`, `summary_*.md`).
- Rewrite Contributing: ask for issues before PRs, document the `user-` prefixed local-skill pattern, and add a "Future features" section flagging ButterCut Pro.
- Put the two demo videos side by side in a small HTML table and trim them to fit the standard column width.

## Test plan
- [ ] `grip README.md` and click through every link in the README — Installation, Usage, Creating a library, Creating a cut, Basic XML generation, example walkthrough.
- [ ] Open `docs/usage.md` directly and confirm its four internal links resolve (relative paths within `docs/`).
- [ ] Open `docs/example-library-setup.md` and confirm the updated file-structure block matches the on-disk layout of a real library.
- [ ] Spot-check the README's `mailto:` and `buttercut.io` links.