### PR TITLE
Make footage processing deterministic with an in-process job layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,8 @@ The user is a video editor, not a programmer. User-facing chat stays in the lang
 
 Editor vocabulary that's always fine: rough cut, sequence, scene, beat, timeline, B-roll, cutaway, shot, take, transcript, footage, library, clip, splice, Final Cut, Premiere, Resolve.
 
+**Important** When talking about a library, remove the dashes that are in the library name. Keeping the dashes looks like computer programmer talk. You are talking to a video editor. If you're working in a library called "hacky-sack-competition-24", refer to it in chat as Hacky Sack Competition 24. If you have another library called "wedding-94" refer to it as the Wedding 94 library. Do not include the dashes. Capitalizes the words.
+
 ## Development Commands
 
 ### Testing

--- a/lib/buttercut/contact_sheet.rb
+++ b/lib/buttercut/contact_sheet.rb
@@ -342,6 +342,20 @@ class ContactSheet
     self.class.format_hms(seconds)
   end
 
+  # Inverse of format_hms, shared with ContactSheetJob and the CLI. Accepts a
+  # Numeric, bare seconds ("12.5"), MM:SS, or HH:MM:SS — returns seconds as a Float.
+  def self.parse_hms(value)
+    return value.to_f if value.is_a?(Numeric)
+    return value.to_f unless value.to_s.include?(':')
+
+    parts = value.to_s.split(':').map(&:to_f)
+    case parts.length
+    when 3 then (parts[0] * 3600) + (parts[1] * 60) + parts[2]
+    when 2 then (parts[0] * 60) + parts[1]
+    else parts[0]
+    end
+  end
+
   def report(range)
     puts "Contact sheet written to #{@output_path}"
     puts "  #{@frames} frames (#{@cols}x#{@rows}) covering #{format_hms(@start_time)}-#{format_hms(@end_time)} (#{format_hms(range)})"
@@ -354,18 +368,6 @@ class ContactSheet
 end
 
 if __FILE__ == $PROGRAM_NAME
-  parse_time = lambda do |value|
-    next value.to_f if value.is_a?(Numeric)
-    next value.to_f unless value.to_s.include?(':')
-
-    parts = value.to_s.split(':').map(&:to_f)
-    case parts.length
-    when 3 then parts[0] * 3600 + parts[1] * 60 + parts[2]
-    when 2 then parts[0] * 60 + parts[1]
-    else parts[0]
-    end
-  end
-
   options = { library: nil, output: nil }
 
   parser = OptionParser.new do |opts|
@@ -391,8 +393,8 @@ if __FILE__ == $PROGRAM_NAME
   begin
     ContactSheet.extract(
       video_path,
-      start_arg && parse_time.call(start_arg),
-      end_arg && parse_time.call(end_arg),
+      start_arg && ContactSheet.parse_hms(start_arg),
+      end_arg && ContactSheet.parse_hms(end_arg),
       library_dir: options[:library],
       output_path: options[:output]
     )

--- a/lib/buttercut/contact_sheet_job.rb
+++ b/lib/buttercut/contact_sheet_job.rb
@@ -1,84 +1,40 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Build contact sheets for an explicit list of clips in a library. Drives the
-# contact-sheet skill directly — no agent in the loop. Each clip gets a `_full`
-# sheet; clips longer than 10 minutes also get per-segment sheets covering
-# successive 10-minute slices. Existing sheets are overwritten.
+# Build contact sheets for ONE clip: a `_full` sheet covering the whole clip,
+# plus a per-segment sheet for each successive 10-minute slice of clips longer
+# than 10 minutes. Pure ffmpeg via ContactSheet — no LLM, no library.yaml writes.
 #
-# Single-threaded by design. The parent agent decides how many invocations to
-# run in parallel based on machine headroom.
-#
-# Usage:
-#   ruby contact_sheet_job.rb <library_name> <clip> [<clip> ...]
-#
-#   <library_name>  e.g. my-library
-#   <clip>          clip filename including extension, e.g. P1055016.MP4
+# This is the per-clip job. Orchestration — which clips, how many at once,
+# recording completion — lives in JobRunner, driven by process_footage.rb's
+# contact-sheets step.
 
-require 'fileutils'
-
+require_relative 'job'
 require_relative 'contact_sheet'
-require_relative 'library'
 
-class ContactSheetJob
+class ContactSheetJob < Job
+  def self.field = 'contact_sheet'
+
   CHUNK_LENGTH_SECONDS = 600.0
 
-  def self.perform(library_name, clips:)
-    new(library_name, clips: clips).perform
-  end
-
-  def initialize(library_name, clips:)
-    raise ArgumentError, 'clips must be a non-empty array' if !clips.is_a?(Array) || clips.empty?
-
-    clips = clips.map(&:to_s)
-    missing_extension_clips = clips.select { |c| File.extname(c).length <= 1 }
-    raise ArgumentError, "clip filenames must include an extension: #{missing_extension_clips.join(', ')}" if missing_extension_clips.any?
-
-    @library = Library.find(library_name)
-    @videos = resolve_videos(clips)
+  def initialize(library_name:, clip:, video_path:, duration:, library_dir:)
+    super(library_name: library_name, clip: clip)
+    @video_path = video_path
+    @duration = duration
+    @library_dir = library_dir
   end
 
   def perform
-    FileUtils.mkdir_p(File.join(@library.dir, 'contact_sheets'))
+    raise "video file missing on disk: #{@video_path.inspect}" unless File.exist?(@video_path.to_s)
 
-    @videos.each_with_index do |video, idx|
-      process_clip(video, idx + 1, @videos.size)
+    ContactSheet.extract(@video_path, library_dir: @library_dir)
+    chunk_ranges(ContactSheet.parse_hms(@duration)).each do |range_start, range_end|
+      ContactSheet.extract(@video_path, range_start, range_end, library_dir: @library_dir)
     end
-
-    @library.complete!('contact_sheet', @videos.map { |v| File.basename(v['path']) })
-    puts "\nDone. Built sheets for #{@videos.size} clip#{'s' unless @videos.size == 1}."
+    self
   end
 
   private
-
-  def resolve_videos(requested)
-    by_filename = @library.videos.each_with_object({}) do |video, acc|
-      acc[File.basename(video['path'].to_s)] = video
-    end
-
-    requested.map do |filename|
-      video = by_filename[filename]
-      raise ArgumentError, "clip not found in library: #{filename}" unless video
-
-      path = video['path']
-      raise ArgumentError, "video file missing on disk: #{path.inspect}" unless File.exist?(path)
-
-      video
-    end
-  end
-
-  def process_clip(video, index, total)
-    path = video['path']
-    clipname = File.basename(path, '.*')
-    duration = parse_duration(video['duration'])
-    puts "[#{index}/#{total}] build #{clipname} (#{video['duration']})"
-
-    ContactSheet.extract(path, library_dir: @library.dir)
-    chunk_ranges(duration).each do |range_start, range_end|
-      puts "  + chunk #{ContactSheet.format_hms(range_start)}–#{ContactSheet.format_hms(range_end)}"
-      ContactSheet.extract(path, range_start, range_end, library_dir: @library.dir)
-    end
-  end
 
   def chunk_ranges(duration)
     return [] if duration <= CHUNK_LENGTH_SECONDS
@@ -91,27 +47,5 @@ class ContactSheetJob
       start = stop
     end
     ranges
-  end
-
-  def parse_duration(hms)
-    h, m, s = hms.split(':').map(&:to_f)
-    h * 3600 + m * 60 + s
-  end
-end
-
-if __FILE__ == $PROGRAM_NAME
-  library_name = ARGV.shift
-  clips = ARGV.dup
-
-  if library_name.nil? || library_name.empty? || clips.empty?
-    warn 'Usage: ruby contact_sheet_job.rb <library_name> <clip> [<clip> ...]'
-    exit 1
-  end
-
-  begin
-    ContactSheetJob.perform(library_name, clips: clips)
-  rescue StandardError => e
-    warn "contact_sheet_job: #{e.message}"
-    exit 1
   end
 end

--- a/lib/buttercut/footage_processor.rb
+++ b/lib/buttercut/footage_processor.rb
@@ -1,0 +1,126 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'library'
+require_relative 'settings'
+require_relative 'job_runner'
+require_relative 'transcribe_job'
+require_relative 'contact_sheet_job'
+
+# Shared mechanics behind process_footage.rb's two subcommands — `transcripts`
+# (#transcribe) and `contact-sheets` (#build_contact_sheets). Each builds one
+# flat list of jobs (the clips still missing that artifact) and runs them through
+# JobRunner, ~2 at a time, recording each into library.yaml as it lands.
+#
+# There is no combined "process everything" entry point and no phase/ordering
+# logic here: the agent runs the transcripts subcommand to completion, then the
+# contact-sheets one. Keeping them apart is what guarantees the slow step
+# (whisperx) never overlaps the fast one (ffmpeg) and total concurrency stays at
+# the cap, not double it.
+#
+# Idempotent and resumable: the work list comes from the library's pending state,
+# so a crash leaves library.yaml as the ledger and a re-run finishes only what's
+# left. Judgment steps — transcript refinement, summaries — are NOT here; they
+# stay Claude steps that run after these commands exit.
+class FootageProcessor
+  # Common language names → ISO 639-1. WhisperX wants the code; library.yaml may
+  # store either the name ("English") or the code ("en"). Mapping it here is one
+  # more decision moved out of the prompt and into code.
+  LANGUAGE_CODES = {
+    'english' => 'en', 'spanish' => 'es', 'french' => 'fr', 'german' => 'de',
+    'italian' => 'it', 'portuguese' => 'pt', 'dutch' => 'nl', 'japanese' => 'ja',
+    'chinese' => 'zh', 'korean' => 'ko', 'russian' => 'ru'
+  }.freeze
+
+  def initialize(library_name, jobs: nil, force: false, clips: nil, io: $stdout)
+    @library = Library.find(library_name)
+    @jobs = jobs # explicit --jobs override; nil → JobRunner reads settings.yaml
+    @force = force
+    @clips = clips && Array(clips)
+    @io = io
+    validate_clips!
+  end
+
+  # Transcribe every candidate clip with WhisperX. Returns true if all succeeded.
+  def transcribe
+    code = language_code(@library.language)
+    model = settings.whisper_model
+    output_dir = File.join(@library.dir, 'transcripts')
+    jobs = candidates('transcript').map do |clip|
+      TranscribeJob.new(
+        library_name: @library.name, clip: clip['filename'],
+        video_path: clip['path'], output_dir: output_dir,
+        language_code: code, whisper_model: model
+      )
+    end
+    process(jobs, 'transcript')
+  end
+
+  # Build a contact sheet for every candidate clip. Returns true if all succeeded.
+  def build_contact_sheets
+    jobs = candidates('contact_sheet').map do |clip|
+      ContactSheetJob.new(
+        library_name: @library.name, clip: clip['filename'],
+        video_path: clip['path'], duration: clip['duration'], library_dir: @library.dir
+      )
+    end
+    process(jobs, 'contact sheet')
+  end
+
+  private
+
+  def settings = @settings ||= Settings.load
+
+  def process(jobs, noun)
+    if jobs.empty?
+      @io.puts "Nothing to do — every clip already has a #{noun}."
+      @io.puts '(Use --force, optionally with --clips, to rebuild ones that already exist.)' unless @force
+      return true
+    end
+
+    @io.puts "Processing #{noun}s for #{@library.name}: #{jobs.size} clip(s)."
+    results = JobRunner.new(@library, concurrency: @jobs, io: @io).run(jobs)
+    report_summary(results, noun)
+    results.all?(&:ok)
+  end
+
+  # Clips to (re)process for one field. Default: only those still missing the
+  # artifact. With --force: every clip, so existing artifacts get rebuilt.
+  # --clips narrows either set to the named clips.
+  def candidates(field)
+    records = @force ? @library.clip_records : @library.pending(field)
+    return records unless @clips
+
+    records.select { |r| @clips.include?(r['filename']) }
+  end
+
+  def validate_clips!
+    return unless @clips
+
+    known = @library.videos.map { |v| File.basename(v['path'].to_s) }
+    unknown = @clips - known
+    raise "clip(s) not in library: #{unknown.join(', ')}" unless unknown.empty?
+  end
+
+  def report_summary(results, noun)
+    @io.puts
+    failed = results.reject(&:ok)
+    mark = failed.empty? ? '✓' : "✗ #{failed.size} failed"
+    @io.puts "#{noun}: #{results.size - failed.size}/#{results.size} #{mark}"
+    return if failed.empty?
+
+    @io.puts "\nFailures:"
+    failed.each { |r| @io.puts "  #{r.clip}: #{r.error.message}" }
+  end
+
+  def language_code(language)
+    raw = language.to_s.strip
+    return 'en' if raw.empty?
+    return raw.downcase if raw.length == 2 # already an ISO code
+
+    LANGUAGE_CODES.fetch(raw.downcase) do
+      raise "Unknown language #{language.inspect}. Add it to LANGUAGE_CODES or " \
+            'store a 2-letter ISO code as `language` in library.yaml.'
+    end
+  end
+end

--- a/lib/buttercut/job.rb
+++ b/lib/buttercut/job.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Base class for ButterCut's mechanical processing jobs.
+#
+# These are the deterministic, shell-out steps of footage analysis — running
+# WhisperX, building contact sheets with ffmpeg — that used to be orchestrated
+# from a skill prompt, and so came out differently depending on which model read
+# the prompt (different ordering, parallelism, batching). Moving them into Jobs
+# makes the work identical on every run, whichever agent kicks it off.
+#
+# Modeled on Active Job / Sidekiq so the shape is familiar to people and agents:
+#
+#   * one job == one unit of work (one clip), done in #perform
+#   * idempotent: safe to run again; re-running only rebuilds its own artifact
+#   * never touches library.yaml — JobRunner owns concurrency and every write
+#
+# A job is a pure function of the inputs handed to its constructor. It does NOT
+# read library.yaml or settings.yaml; the runner resolves those once up front
+# and passes concrete values in. That keeps jobs trivial to test and removes any
+# reader/writer race against the runner's library.yaml writes.
+#
+# Subclass contract:
+#   .field   — the library.yaml field a successful run completes ('transcript')
+#   #perform — do the work for one clip; return self; raise on failure
+class Job
+  # The library.yaml field a successful run marks complete. Subclasses override.
+  def self.field = raise(NotImplementedError, "#{self} must define .field")
+
+  # Sidekiq-style synchronous entry point: Job.perform_now(**kwargs).
+  def self.perform_now(...) = new(...).perform
+
+  attr_reader :library_name, :clip
+
+  def initialize(library_name:, clip:)
+    raise ArgumentError, 'library_name is required' if library_name.to_s.strip.empty?
+    raise ArgumentError, 'clip is required' if clip.to_s.strip.empty?
+
+    @library_name = library_name
+    @clip = clip
+  end
+
+  def field = self.class.field
+
+  # Do the work for one clip. Must be idempotent. Return self; raise on failure.
+  def perform = raise(NotImplementedError, "#{self.class} must implement #perform")
+
+  # Label used in the runner's progress output.
+  def to_s = "#{self.class.name}(#{clip})"
+end

--- a/lib/buttercut/job_runner.rb
+++ b/lib/buttercut/job_runner.rb
@@ -1,0 +1,141 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Runs a list of Jobs over a small thread pool and records each success to
+# library.yaml.
+#
+# This is ButterCut's in-process stand-in for a Sidekiq worker pool. It owns the
+# two things a Job must never touch: concurrency and library.yaml. Jobs are pure
+# (see job.rb). The runner records each success through `Library#complete!`,
+# whose flock-guarded transaction serializes writes across both these worker
+# threads and any other process (e.g. the agent updating footage_summary while
+# this run records transcripts) — so the runner needs no write mutex of its own.
+#
+# Why threads, not processes: the real work is in subprocesses (whisperx,
+# ffmpeg), so Ruby releases the GIL while they run — a thread pool gets full
+# parallelism with none of the fork/IPC overhead.
+#
+# Scope is deliberately small: one `run(jobs)` call drains one flat list of
+# same-kind jobs, a couple at a time. The runner knows nothing about ordering —
+# that's the caller's job. process_footage.rb runs the transcripts step to
+# completion, then the contact-sheets step, as two separate `run` calls, so the
+# slow step (whisperx) never overlaps the fast one and total concurrency stays
+# at the cap, not double it.
+#
+# Backend seam: today the "queue" is an in-memory array drained by threads. The
+# shape is deliberately Sidekiq-ish so a future Solid Queue / Sidekiq adapter
+# (e.g. ButterCut Pro's background service) could slot in behind it without
+# changing callers. library.yaml stays the one ledger of done/not-done.
+#
+# Concurrency comes from one knob: settings.yaml's `parallel_jobs` (default 2).
+# A caller can override per-run via `run(jobs, concurrency:)`, or pin a default
+# via `JobRunner.new(library, concurrency:)`.
+require 'fileutils'
+require_relative 'settings'
+
+class JobRunner
+  ACTIVE_ROOT = File.expand_path('../../tmp/active', __dir__)
+  Result = Struct.new(:job, :ok, :error, keyword_init: true) do
+    def field = job.field
+    def clip = job.clip
+  end
+
+  def initialize(library, concurrency: nil, io: $stdout)
+    @library = library
+    @explicit_concurrency = concurrency
+    @io = io
+    @io_mutex = Mutex.new
+  end
+
+  # Run every job through a pool of at most `concurrency` workers — falling back
+  # to the runner's configured cap, then settings.yaml's `parallel_jobs`
+  # (default 2). Returns a flat array of Results in completion order. Never
+  # raises for a failed job — failures come back as Results with ok: false so
+  # the caller can summarize and set an exit code.
+  def run(jobs, concurrency: nil)
+    jobs = Array(jobs)
+    return [] if jobs.empty?
+
+    cap = concurrency || @explicit_concurrency || settings_concurrency
+    raise ArgumentError, 'concurrency must be >= 1' if cap < 1
+
+    queue = Thread::Queue.new
+    jobs.each { |job| queue << job }
+    sink = Thread::Queue.new # thread-safe, so workers append without a mutex
+
+    workers = Array.new([cap, jobs.size].min) do
+      Thread.new do
+        while (job = next_job(queue))
+          log('start', job)
+          result = run_one(job)
+          sink << result
+          result.ok ? log('done', job) : log('error', job, result.error.message)
+        end
+      end
+    end
+    workers.each(&:join)
+    clear_active
+    drain(sink)
+  end
+
+  private
+
+  def settings_concurrency = @settings_concurrency ||= Settings.load.parallel_jobs
+
+  def next_job(queue)
+    queue.pop(true)
+  rescue ThreadError # queue empty, non-blocking pop
+    nil
+  end
+
+  # Empty a queue into an array. Called after every worker has joined, so there
+  # are no concurrent pushes to race with.
+  def drain(queue)
+    results = []
+    results << queue.pop until queue.empty?
+    results
+  end
+
+  # Perform the job, then — on success — record it to library.yaml. The write is
+  # serialized by Library's flock transaction and counts as part of the job: if
+  # recording fails, the job fails.
+  def run_one(job)
+    mark_active(job)
+    job.perform
+    @library.complete!(job.field, [job.clip], announce: false)
+    Result.new(job: job, ok: true)
+  rescue StandardError => e
+    Result.new(job: job, ok: false, error: e)
+  ensure
+    unmark_active(job)
+  end
+
+  def active_path(job)
+    File.join(ACTIVE_ROOT, @library.name, job.field, job.clip)
+  end
+
+  def mark_active(job)
+    path = active_path(job)
+    FileUtils.mkdir_p(File.dirname(path))
+    FileUtils.touch(path)
+  end
+
+  def unmark_active(job)
+    path = active_path(job)
+    File.delete(path) if File.exist?(path)
+  end
+
+  def clear_active
+    dir = File.join(ACTIVE_ROOT, @library.name)
+    FileUtils.rm_rf(dir) if Dir.exist?(dir)
+  end
+
+  # One line per job event — start, done, or error — naming the job by its own
+  # class and clip (both intrinsic to the job). The runner still tracks no batch
+  # totals and carries none of the orchestrator's step framing.
+  def log(event, job, detail = nil)
+    line = "#{job.class.name}  #{event.ljust(5)}  #{job.clip}"
+    line = "#{line} — #{detail}" if detail
+    @io_mutex.synchronize { @io.puts line }
+  end
+end

--- a/lib/buttercut/library.md
+++ b/lib/buttercut/library.md
@@ -62,9 +62,19 @@ Use `summary` when you want to look at *what's* missing; use `ready` when you on
 ### Add and update
 ```bash
 ruby lib/buttercut/library.rb <name> add_videos /abs/a.mov /abs/b.mov
-ruby lib/buttercut/library.rb <name> update_metadata footage_summary "subjects, locations, activities"
-ruby lib/buttercut/library.rb <name> update_metadata user_context   "creative intent, characters"
+ruby lib/buttercut/library.rb <name> update_metadata footage_summary       "subjects, locations, activities"
+ruby lib/buttercut/library.rb <name> update_metadata user_context          "creative intent, characters"
+ruby lib/buttercut/library.rb <name> update_metadata language              english
+ruby lib/buttercut/library.rb <name> update_metadata editor                fcpx        # fcpx | premiere | resolve
+ruby lib/buttercut/library.rb <name> update_metadata transcript_refinement false       # true | false
 ```
+
+`update_metadata` edits one field per call. Beyond the two free-text fields
+(`footage_summary`, `user_context`) it can also set the setup choices
+(`language`, `editor`, `transcript_refinement`) — handy when resuming a
+library whose config was never filled in. `editor` is validated against
+`fcpx|premiere|resolve` and `transcript_refinement` is coerced to a real
+boolean.
 
 ### Mark files done
 ```bash
@@ -92,6 +102,15 @@ ruby lib/buttercut/library.rb <name> remove_visual_transcripts   # legacy cleanu
 `reset` deletes every file in each named field's subdir and clears the
 field on every video. The `transcripts/` sweep leaves `visual_*.json`
 alone — that's what `remove_visual_transcripts` is for.
+
+`reset_all` is a **factory reset**: on top of wiping all three artifact
+fields it also clears library-level metadata — the setup choices
+(`language`, `editor`, `transcript_refinement`) and the analysis-derived
+context (`footage_summary`, `user_context`). Strings go blank and
+`transcript_refinement` goes nil ("unset"), so a re-run starts setup and
+footage analysis from scratch. Video records and dates are kept.
+`reset_all_except_audio_transcripts` does **not** touch metadata — it stays
+a narrow artifact reset.
 
 ### Creating a new library
 

--- a/lib/buttercut/library.rb
+++ b/lib/buttercut/library.rb
@@ -25,6 +25,20 @@ class Library
 
   SUBDIRS = %w[transcripts contact_sheets summaries cuts plans].freeze
 
+  # Library-level metadata cleared by `reset_all`, returning a library to its
+  # pre-setup, pre-analysis state: the setup choices (language, editor,
+  # transcript_refinement) and the analysis-derived context (footage_summary,
+  # user_context). Strings go blank; transcript_refinement goes nil ("unset", so
+  # setup re-asks rather than assuming off). nil still serializes the key, so the
+  # 002 migration sees it as already-present and won't re-default it on `migrate`.
+  CLEARED_METADATA = {
+    'user_context'          => '',
+    'footage_summary'       => '',
+    'language'              => '',
+    'editor'                => '',
+    'transcript_refinement' => nil
+  }.freeze
+
   def self.find(library_name) = new(library_name)
 
   def self.exists?(library_name)
@@ -108,6 +122,11 @@ class Library
     }
   end
 
+  # The basename used everywhere to refer to a clip. Derived from the full
+  # `path` and never stored in library.yaml — one owner so reads, lookups, and
+  # the `videos` reader all agree on what a clip is called.
+  def self.filename_of(video) = File.basename(video['path'].to_s)
+
   def self.probe_duration(path)
     output = `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 #{Shellwords.escape(path)} 2>&1`
     raise ArgumentError, "ffprobe failed for #{path}: #{output.strip}" unless $CHILD_STATUS.success?
@@ -164,41 +183,51 @@ class Library
 
   def dir = @library_dir
 
+  # Canonical on-disk path for one clip's artifact in a given field — the single
+  # owner of the per-field filename convention (e.g. summary → `summaries/
+  # summary_<clip>.md`). Accepts a clip name with or without extension; the
+  # extension is stripped before the namer runs, so `field_path('summary',
+  # 'P1055017.mov')` and `field_path('summary', 'P1055017')` both resolve to
+  # `.../summaries/summary_P1055017.md`.
   def field_path(field, clipname)
     spec = field_spec(field)
-    File.join(@library_dir, spec[:subdir], spec[:namer].call(clipname))
+    File.join(@library_dir, spec[:subdir], spec[:namer].call(File.basename(clipname, '.*')))
   end
 
   def add_videos(video_paths)
-    library = load_library
-    existing = library['videos'].map { |v| v['path'] }
     records = Array(video_paths).map { |path| self.class.video_record(path) }
-    records.each do |record|
-      raise ArgumentError, "video already in library: #{record['path']}" if existing.include?(record['path'])
+    mutate do |library|
+      existing = library['videos'].map { |v| v['path'] }
+      records.each do |record|
+        raise ArgumentError, "video already in library: #{record['path']}" if existing.include?(record['path'])
+      end
+      library['videos'].concat(records)
     end
-
-    library['videos'].concat(records)
-    write_library(library)
     self
   end
 
   # Mark `video_filenames` complete for one field. Validates each file exists
   # on disk before writing — atomicity is preserved by building the full plan
   # first and only mutating the YAML once every check passes.
-  def complete!(field, video_filenames)
-    spec = field_spec(field)
-    library = load_library
-    pairs = Array(video_filenames).map do |filename|
-      video = find_video!(library, filename)
-      stored_filename = spec[:namer].call(File.basename(filename, '.*'))
-      path = File.join(@library_dir, spec[:subdir], stored_filename)
-      raise ArgumentError, "#{field} file does not exist: #{path}" unless File.exist?(path)
+  #
+  # `announce:` prints a one-line summary (default). JobRunner passes
+  # `announce: false` because it owns its own progress output and calls this
+  # once per finished job.
+  def complete!(field, video_filenames, announce: true)
+    field_spec(field) # validate the field name up front
+    count = 0
+    mutate do |library|
+      pairs = Array(video_filenames).map do |filename|
+        video = find_video!(library, filename)
+        path = field_path(field, filename)
+        raise ArgumentError, "#{field} file does not exist: #{path}" unless File.exist?(path)
 
-      [video, stored_filename]
+        [video, File.basename(path)]
+      end
+      pairs.each { |video, stored_filename| video[field] = stored_filename }
+      count = pairs.size
     end
-    pairs.each { |video, stored_filename| video[field] = stored_filename }
-    write_library(library)
-    puts "#{@name}: #{field} set for #{pairs.size} #{pluralize(pairs.size, 'video')}"
+    puts "#{@name}: #{field} set for #{count} #{pluralize(count, 'video')}" if announce
     self
   end
 
@@ -208,6 +237,16 @@ class Library
   # `remove_visual_transcripts!` stays the explicit tool for legacy cleanup.
   def reset!(*fields)
     fields.each { |f| reset_field!(f) }
+    self
+  end
+
+  # Destructive: clear library-level metadata back to an unconfigured state —
+  # both the setup choices and the analysis-derived context (see
+  # CLEARED_METADATA). Video records and dates are kept. Part of `reset_all`'s
+  # factory reset, so a re-run starts setup and footage analysis from scratch.
+  def reset_metadata!
+    mutate { |library| CLEARED_METADATA.each { |key, value| library[key] = value } }
+    puts "#{@name}: metadata reset (#{CLEARED_METADATA.keys.join(', ')})"
     self
   end
 
@@ -233,34 +272,41 @@ class Library
       end
     end
 
-    library = load_library
     cleared = 0
-    library['videos'].each do |video|
-      next unless present?(video['visual_transcript'])
+    mutate do |library|
+      library['videos'].each do |video|
+        next unless present?(video['visual_transcript'])
 
-      video['visual_transcript'] = ''
-      cleared += 1
+        video['visual_transcript'] = ''
+        cleared += 1
+      end
     end
-    write_library(library) if cleared.positive?
 
     puts format_reset_summary('visual_transcript removed', cleared, swept, errors)
     self
   end
 
-  def videos = load_library['videos']
+  # Each record carries the stored fields plus a derived `filename` (basename of
+  # `path`). The merge returns copies, so the convenience key never reaches the
+  # write path — mutations load and persist via `load_library` directly.
+  def videos = load_library['videos'].map { |v| v.merge('filename' => self.class.filename_of(v)) }
   def language = load_library['language']
   def transcript_refinement = load_library['transcript_refinement']
   def user_context = load_library['user_context'].to_s
   def footage_summary = load_library['footage_summary'].to_s
   def editor = load_library['editor']
 
-  # Update one or both free-text metadata fields. Omitted fields are left
-  # alone; pass `''` to clear.
-  def update_metadata!(footage_summary: nil, user_context: nil)
-    library = load_library
-    library['footage_summary'] = footage_summary unless footage_summary.nil?
-    library['user_context'] = user_context unless user_context.nil?
-    write_library(library)
+  # Update any subset of the editable metadata fields. Omitted (nil) fields are
+  # left alone; pass `''` to clear a string field. `transcript_refinement` takes
+  # a real boolean — the CLI coerces "true"/"false" before calling here.
+  def update_metadata!(footage_summary: nil, user_context: nil, language: nil, editor: nil, transcript_refinement: nil)
+    mutate do |library|
+      library['footage_summary'] = footage_summary unless footage_summary.nil?
+      library['user_context'] = user_context unless user_context.nil?
+      library['language'] = language unless language.nil?
+      library['editor'] = editor unless editor.nil?
+      library['transcript_refinement'] = transcript_refinement unless transcript_refinement.nil?
+    end
     self
   end
 
@@ -290,6 +336,32 @@ class Library
   end
 
   def incomplete_videos = incomplete_from(videos)
+
+  # Clips still missing one specific artifact, as records the JobRunner can turn
+  # straight into jobs. Unlike `incomplete_videos` (missing ANY field), this is
+  # scoped to a single field so the runner can build one independent batch per
+  # phase — transcripts and contact sheets don't depend on each other.
+  def pending(field)
+    field_spec(field) # validate the field name up front
+    videos.filter_map { |video| clip_record(video) unless present?(video[field]) }
+  end
+
+  # Every clip as a job-ready record, in the same shape as `pending` but
+  # unfiltered. FootageProcessor's --force path uses this to rebuild artifacts
+  # that already exist; keeping it here means the record shape has one owner.
+  def clip_records = videos.map { |video| clip_record(video) }
+
+  # Per-clip artifact status for the live "follow along" view: every clip with a
+  # boolean per field (transcript, contact_sheet, summary). Read-only, so it's
+  # safe to poll from a separate process (the status server) while the JobRunner
+  # records progress — atomic writes keep each read whole.
+  def clip_statuses
+    videos.map do |video|
+      FIELDS.keys.each_with_object('filename' => self.class.filename_of(video)) do |field, row|
+        row[field] = present?(video[field])
+      end
+    end
+  end
 
   # Snapshot for picking up a library: top-level metadata plus a
   # clip-completion breakdown. `incomplete_count == 0` means ready for roughcut.
@@ -329,38 +401,46 @@ class Library
       missing = FIELDS.keys.reject { |f| present?(video[f]) }
       next if missing.empty?
 
-      {
-        'filename' => File.basename(video['path'].to_s),
-        'path' => video['path'],
-        'duration' => video['duration'],
-        'missing' => missing
-      }
+      clip_record(video).merge('missing' => missing)
     end
+  end
+
+  # The job-ready shape of one clip: just what a Job constructor (and the
+  # JobRunner / status callers) need. Single owner of this hash so `pending`,
+  # `clip_records`, and `incomplete_from` stay in lockstep.
+  def clip_record(video)
+    {
+      'filename' => self.class.filename_of(video),
+      'path' => video['path'],
+      'duration' => video['duration']
+    }
   end
 
   def reset_field!(field)
     spec = field_spec(field)
     dir = File.join(@library_dir, spec[:subdir])
-    library = load_library
     cleared = 0
+    orphans = 0
     errors = []
 
-    library['videos'].each do |video|
-      filename = video[field]
-      next unless present?(filename)
+    mutate do |library|
+      library['videos'].each do |video|
+        filename = video[field]
+        next unless present?(filename)
 
-      begin
-        path = File.join(dir, filename)
-        File.delete(path) if File.file?(path)
-        video[field] = ''
-        cleared += 1
-      rescue StandardError => e
-        errors << "#{filename}: #{e.message}"
+        begin
+          path = File.join(dir, filename)
+          File.delete(path) if File.file?(path)
+          video[field] = ''
+          cleared += 1
+        rescue StandardError => e
+          errors << "#{filename}: #{e.message}"
+        end
       end
+
+      orphans = sweep_orphans(dir, spec[:keep], errors)
     end
 
-    orphans = sweep_orphans(dir, spec[:keep], errors)
-    write_library(library)
     puts format_reset_summary("#{field} reset", cleared, orphans, errors)
   end
 
@@ -397,10 +477,43 @@ class Library
     data
   end
 
-  def write_library(library) = File.write(@library_yaml_path, library.to_yaml)
+  # The one path every library.yaml mutation takes. An exclusive flock on a
+  # sidecar lockfile makes the whole read-modify-write atomic ACROSS PROCESSES —
+  # the background `process_footage.rb` run recording completions vs. the agent
+  # updating footage_summary "as transcripts come in" — so neither clobbers the
+  # other's changes. The lock also serializes the JobRunner's own worker threads
+  # (each call opens its own fd, so flock contends within a process too), which
+  # is why the runner needs no separate write mutex.
+  #
+  # The block receives the freshly-loaded library hash, mutates it in place, and
+  # the persisted result is written atomically on a clean return. A raise inside
+  # the block skips the write and still releases the lock. The lockfile is a
+  # never-renamed sidecar on purpose: flock follows the inode, and write_library
+  # renames a new inode into place, so locking library.yaml itself would strand
+  # the lock on the old file. The atomic temp+rename inside still gives lockless
+  # readers (status_server, `library.rb pending` polls) a whole file.
+  def mutate
+    File.open("#{@library_yaml_path}.lock", File::CREAT | File::RDWR, 0o644) do |lock|
+      lock.flock(File::LOCK_EX)
+      library = load_library
+      yield library
+      write_library(library)
+    end
+  end
+
+  # Atomic write: render to a sibling temp file, then rename into place.
+  # rename(2) is atomic within a filesystem, so a concurrent reader — e.g. an
+  # external `library.rb pending` poll running while a JobRunner records
+  # progress — always sees a complete file, the old one or the new one, never a
+  # half-written torn read.
+  def write_library(library)
+    tmp = "#{@library_yaml_path}.tmp.#{Process.pid}"
+    File.write(tmp, library.to_yaml)
+    File.rename(tmp, @library_yaml_path)
+  end
 
   def find_video!(library, video_filename)
-    library['videos'].find { |v| File.basename(v['path'].to_s) == video_filename } ||
+    library['videos'].find { |v| self.class.filename_of(v) == video_filename } ||
       raise(ArgumentError, "video not found in library.yaml: #{video_filename}")
   end
 end
@@ -418,20 +531,23 @@ if __FILE__ == $PROGRAM_NAME
       <name> exists                                   — exits 0 if library exists, 1 otherwise
       <name> summary                                  — JSON snapshot
       <name> incomplete_videos                        — JSON array of incomplete clips
+      <name> pending <field>                          — JSON array of clips still missing one field
       <name> ready                                    — exits 0 if every video is ready for roughcut, 1 otherwise
+      <name> field_path <field> <clip>                — canonical path for a clip's artifact (e.g. summary → summaries/summary_<clip>.md)
 
     Writes:
       <name> add_videos <video_path>...               — append video records
-      <name> update_metadata <key> <value...>         — set footage_summary or user_context
+      <name> update_metadata <key> <value...>         — set footage_summary, user_context, language, editor, or transcript_refinement
       <name> complete <field> <files>                 — mark files done for one field
       <name> reset <field> [<field>...]               — wipe one or more phases
-      <name> reset_all                                — wipe every field (incl. legacy visual_transcripts)
+      <name> reset_all                                — factory reset: wipe every field (incl. legacy visual_transcripts) + clear metadata (language, editor, transcript_refinement, footage_summary, user_context)
       <name> reset_all_except_audio_transcripts       — wipe everything except audio transcripts
       <name> remove_visual_transcripts                — sweep legacy visual_*.json + clear field
 
     <field>: transcript | contact_sheet | summary
     <files>: space- and/or comma-separated
-    <key>:   footage_summary | user_context
+    <key>:   footage_summary | user_context | language | editor | transcript_refinement
+             (editor: fcpx|premiere|resolve; transcript_refinement: true|false)
 
     Library.create is not exposed via the CLI (kwarg-heavy). From bash:
       ruby -e "require_relative 'lib/buttercut/library'; \\
@@ -490,8 +606,18 @@ if __FILE__ == $PROGRAM_NAME
       puts JSON.pretty_generate(library.summary)
     when 'incomplete_videos'
       puts JSON.pretty_generate(library.incomplete_videos)
+    when 'pending'
+      field, = rest
+      raise ArgumentError, 'pending requires <field>' if field.nil?
+
+      puts JSON.pretty_generate(library.pending(field))
     when 'ready'
       exit(library.ready? ? 0 : 1)
+    when 'field_path'
+      field, clip = rest
+      raise ArgumentError, 'field_path requires <field> <clip>' if field.nil? || clip.nil?
+
+      puts library.field_path(field, clip)
     when 'add_videos'
       raise ArgumentError, 'add_videos requires <video_path>...' if rest.empty?
 
@@ -499,9 +625,23 @@ if __FILE__ == $PROGRAM_NAME
     when 'update_metadata'
       key, *value_parts = rest
       raise ArgumentError, 'update_metadata requires <key> <value>' if key.nil? || value_parts.empty?
-      raise ArgumentError, "unknown metadata key: #{key} (expected footage_summary or user_context)" unless %w[footage_summary user_context].include?(key)
 
-      library.update_metadata!(key.to_sym => value_parts.join(' '))
+      allowed_keys = %w[footage_summary user_context language editor transcript_refinement]
+      raise ArgumentError, "unknown metadata key: #{key} (expected #{allowed_keys.join(', ')})" unless allowed_keys.include?(key)
+
+      value = value_parts.join(' ')
+      case key
+      when 'transcript_refinement'
+        value = case value.strip.downcase
+                when 'true', 'yes', '1' then true
+                when 'false', 'no', '0' then false
+                else raise ArgumentError, "transcript_refinement expects true/false, got: #{value}"
+                end
+      when 'editor'
+        raise ArgumentError, "editor expects fcpx, premiere, or resolve, got: #{value}" unless %w[fcpx premiere resolve].include?(value)
+      end
+
+      library.update_metadata!(key.to_sym => value)
     when 'complete'
       field, *files = rest
       raise ArgumentError, 'complete requires <field> <files>' if field.nil? || files.empty?
@@ -514,6 +654,7 @@ if __FILE__ == $PROGRAM_NAME
     when 'reset_all'
       library.reset!(*Library::FIELDS.keys)
       library.remove_visual_transcripts!
+      library.reset_metadata!
     when 'reset_all_except_audio_transcripts'
       library.reset!('contact_sheet', 'summary')
       library.remove_visual_transcripts!

--- a/lib/buttercut/process_footage.rb
+++ b/lib/buttercut/process_footage.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require_relative 'footage_processor'
+require_relative 'run_log'
+
+# The two mechanical footage steps, as one dispatcher with two subcommands the
+# agent runs back-to-back — transcripts first, then contact-sheets:
+#
+#   ruby lib/buttercut/process_footage.rb transcripts    <library> [opts]
+#   ruby lib/buttercut/process_footage.rb contact-sheets <library> [opts]
+#
+# There's no "do both" mode on purpose: the agent waits for transcripts to finish
+# before starting contact-sheets, so the slow whisperx pass never overlaps the
+# fast ffmpeg one and total concurrency stays at the cap (settings.yaml
+# `parallel_jobs`, default 2), not double it. Each step runs the clips still
+# missing that artifact, ~2 at a time, recording each into library.yaml as it
+# lands. Idempotent: safe to re-run; --force rebuilds artifacts that exist.
+ACTIONS = {
+  'transcripts'    => :transcribe,
+  'contact-sheets' => :build_contact_sheets
+}.freeze
+
+BANNER = 'Usage: ruby process_footage.rb <transcripts|contact-sheets> <library_name> ' \
+         '[--jobs N] [--force] [--clips a.mov,b.mov]'
+
+options = { jobs: nil, force: false, clips: nil }
+parser = OptionParser.new do |opts|
+  opts.banner = BANNER
+  opts.on('--jobs N', Integer, 'Clips to run at once (overrides settings.yaml parallel_jobs; default 2)') { |n| options[:jobs] = n }
+  opts.on('--force', 'Rebuild artifacts even if they already exist (for reprocessing)') { options[:force] = true }
+  opts.on('--clips a.mov,b.mov', Array, 'Limit work to these clip filenames') { |c| options[:clips] = c }
+end
+parser.parse!
+
+command = ARGV.shift
+action = ACTIONS[command.to_s]
+unless action
+  warn "Unknown step #{command.inspect}. Expected: #{ACTIONS.keys.join(' | ')}"
+  warn parser.banner
+  exit 1
+end
+
+library = ARGV.shift
+if library.to_s.empty?
+  warn parser.banner
+  exit 1
+end
+
+log = RunLog.new(library)
+log.puts "Logging to #{log.path}"
+begin
+  ok = FootageProcessor.new(library, **options, io: log).public_send(action)
+  exit(ok ? 0 : 1)
+rescue StandardError => e
+  warn "#{command}: #{e.message}"
+  exit 1
+ensure
+  log.close
+end

--- a/lib/buttercut/run_log.rb
+++ b/lib/buttercut/run_log.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'fileutils'
+
+# Tees process_footage.rb's progress to both the console and a daily file under
+# tmp/, so an unattended run (e.g. while the Mac is locked) leaves a reviewable
+# record of what ran when. The console gets the plain lines; the file gets each
+# line stamped with a wall-clock time — which is exactly what makes job ordering
+# and timing legible after the fact ("did sheets run during transcripts?").
+#
+# ONE file per library per day: tmp/logs/processing/<library>/<YYYY-MM-DD>.log
+# (tmp/ is gitignored). Every run APPENDS, so the transcripts and contact-sheets
+# steps — and any re-runs that day — land in the same file, separated by a blank
+# line. RunLog is a dumb tee: it stays out of *what* is being processed. The
+# caller (process_footage.rb / FootageProcessor) logs the orchestration header
+# ("Processing transcripts: 30 clip(s).") that names each step; JobRunner logs
+# the individual job events. Quacks like an IO enough for both: it answers #puts
+# and #sync=.
+class RunLog
+  ROOT = File.expand_path('../../tmp/logs/processing', __dir__)
+
+  attr_reader :path
+
+  def initialize(library_name, console: $stdout, root: ROOT, now: Time.now)
+    dir = File.join(root, sanitize(library_name))
+    FileUtils.mkdir_p(dir)
+    @path = File.join(dir, "#{now.strftime('%Y-%m-%d')}.log")
+    appending = File.size?(@path) # truthy only if the day's file already has content
+    @file = File.open(@path, 'a')
+    @file.sync = true
+    @file.puts if appending # blank line separates this run from the previous one
+    @console = console
+  end
+
+  def puts(message = '')
+    line = message.to_s
+    @console.puts(line)
+    @file.puts(line.empty? ? '' : "#{Time.now.strftime('%H:%M:%S')}  #{line}")
+  end
+
+  # status_server and other callers may flip sync on their stream; forward it.
+  def sync=(flag)
+    @console.sync = flag if @console.respond_to?(:sync=)
+  end
+
+  def close
+    @file.close unless @file.closed?
+  end
+
+  private
+
+  def sanitize(name) = name.to_s.gsub(%r{[/\\\s]+}, '_')
+end

--- a/lib/buttercut/settings.rb
+++ b/lib/buttercut/settings.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'yaml'
+
+# Read-only accessor for libraries/settings.yaml — the user's global ButterCut
+# preferences (editor, whisper model, parallelism, …). Centralizes the path so
+# callers don't re-parse the file.
+#
+# settings.yaml is hand-edited and always present once setup has run. Values
+# that ship in the template (whisper_model) are read straight from it with no
+# code-side default — a blank/missing one is a broken file worth surfacing, not
+# something to paper over with a different value than the user configured.
+# parallel_jobs is newer and may be absent from an already-created settings.yaml
+# (git pull doesn't touch libraries/), so it alone carries a fallback default.
+class Settings
+  PATH = File.expand_path('../../libraries/settings.yaml', __dir__)
+
+  DEFAULT_PARALLEL_JOBS = 2 # WhisperX is RAM-hungry; 2 is the safe default.
+
+  def self.load(path: PATH) = new(path: path)
+
+  def initialize(path: PATH)
+    @data = File.exist?(path) ? (YAML.safe_load_file(path) || {}) : {}
+  end
+
+  # How many mechanical jobs (transcription, contact sheets) to run in parallel.
+  # Blank / missing / non-positive / non-numeric → DEFAULT_PARALLEL_JOBS.
+  def parallel_jobs
+    n = Integer(@data['parallel_jobs'], exception: false)
+    n && n >= 1 ? n : DEFAULT_PARALLEL_JOBS
+  end
+
+  # WhisperX model size, straight from settings.yaml — no code default. The
+  # template ships `whisper_model` and setup writes it, so a blank/missing value
+  # means a broken settings.yaml.
+  def whisper_model
+    value = @data['whisper_model'].to_s.strip
+    raise 'whisper_model is not set in libraries/settings.yaml (expected tiny/base/small/medium/turbo)' if value.empty?
+
+    value
+  end
+end

--- a/lib/buttercut/transcribe_job.rb
+++ b/lib/buttercut/transcribe_job.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'English'
+require 'fileutils'
+require 'json'
+require 'open3'
+require_relative 'job'
+
+# Transcribe one clip's audio with WhisperX, then slim the JSON with
+# prepare_audio_script.rb. Pure mechanics — the exact commands that used to live
+# in the transcribe-audio sub-agent prompt, now in code so every run is
+# identical regardless of which model started it.
+#
+# Transcript *refinement* (fixing misheard proper nouns from library context) is
+# deliberately NOT here. That step is judgment, not mechanics, so it stays a
+# Claude step that runs after these jobs finish — see analyze-video/SKILL.md.
+class TranscribeJob < Job
+  def self.field = 'transcript'
+
+  PREPARE_SCRIPT = File.expand_path('prepare_audio_script.rb', __dir__)
+
+  def initialize(library_name:, clip:, video_path:, output_dir:, language_code:, whisper_model:)
+    super(library_name: library_name, clip: clip)
+    @video_path = video_path
+    @output_dir = output_dir
+    @language_code = language_code
+    @whisper_model = whisper_model
+  end
+
+  def perform
+    if run_whisperx
+      prepare_transcript
+    end
+    self
+  end
+
+  private
+
+  NO_SPEECH_MARKER = 'No active speech found in audio'
+
+  # Returns true if whisperx produced a real transcript, false if it rescued a
+  # silent clip by writing an empty one. Raises on any other failure.
+  def run_whisperx
+    output, status = Open3.capture2e(
+      'whisperx', @video_path,
+      '--language', @language_code,
+      '--model', @whisper_model,
+      '--compute_type', 'float32',
+      '--device', 'cpu',
+      '--output_format', 'json',
+      '--output_dir', @output_dir
+    )
+    return true if status.success?
+
+    if output.include?(NO_SPEECH_MARKER)
+      rescue_silent_clip
+      return false
+    end
+
+    raise "whisperx failed for #{clip} (exit #{status.exitstatus})"
+  end
+
+  def rescue_silent_clip
+    path = File.join(@output_dir, "#{File.basename(@video_path, '.*')}.json")
+    FileUtils.mkdir_p(@output_dir)
+    File.write(path, JSON.pretty_generate(
+      '_note'        => 'no dialogue',
+      'segments'     => [],
+      'word_segments' => [],
+      'video_path'   => @video_path
+    ))
+  end
+
+  def prepare_transcript
+    json = File.join(@output_dir, "#{File.basename(@video_path, '.*')}.json")
+    raise "whisperx produced no transcript at #{json}" unless File.exist?(json)
+
+    ok = system('ruby', PREPARE_SCRIPT, json, @video_path)
+    raise "prepare_audio_script failed for #{clip}" unless ok
+  end
+end
+
+# Single source of truth for the WhisperX command. `process_footage.rb` drives
+# this class for whole-library work; this CLI handles one-off / outside-a-library
+# transcription so the command never gets copied into a skill prompt.
+if __FILE__ == $PROGRAM_NAME
+  video_path, output_dir, language_code, whisper_model = ARGV
+  if [video_path, output_dir, language_code, whisper_model].any? { |arg| arg.to_s.empty? }
+    warn 'Usage: ruby transcribe_job.rb <video_path> <output_dir> <language_code> <whisper_model>'
+    exit 1
+  end
+
+  begin
+    TranscribeJob.new(
+      library_name: 'standalone', clip: File.basename(video_path),
+      video_path: video_path, output_dir: output_dir,
+      language_code: language_code, whisper_model: whisper_model
+    ).perform
+    puts "✓ #{File.basename(video_path)} transcribed → #{File.join(output_dir, "#{File.basename(video_path, '.*')}.json")}"
+  rescue StandardError => e
+    warn "transcribe_job: #{e.message}"
+    exit 1
+  end
+end

--- a/skills/analyze-video/SKILL.md
+++ b/skills/analyze-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze-video
-description: Full footage analysis pipeline — audio transcripts, contact sheets, and Sonnet-written summaries. Produces every artifact the cut skill reads. Orchestrated from the main thread.
+description: Internal sub-procedure (not a standalone entry point) — the shared footage-analysis pipeline that produces audio transcripts, contact sheets, and Sonnet-written summaries. Invoked end-to-end by the process-library and reprocess-with-contact-sheets skills; don't trigger it on its own.
 ---
 
 # Skill: Analyze Video (parent brief)
@@ -19,32 +19,66 @@ This is the main thread's playbook for the **Analyze Video** workflow step. Run 
 - Library setup is complete (`library.yaml` exists, schema is current — run migrations from AGENTS.md if not).
 - Read `libraries/settings.yaml` directly for `whisper_model`. For library fields, read the snapshot via `ruby lib/buttercut/library.rb <name> summary` and pull the values you need from the JSON — don't parse library.yaml inline.
 
-## Step 1 — Audio transcripts (parallel sub-agents)
+At this point, create a todo list, visible to the user, with high-level, non-technical steps so they can follow the overall plan for processing the library, e.g.:
 
-Inform the user: "Library setup complete. Found [N] videos ([total size]). Starting footage analysis..."
-
-Launch `transcribe-audio` Task agents. Pass these values **inline** in each agent's prompt:
-
-- `video_path`, `transcript_output_dir`, `language_code`, `whisper_model`
-- `transcript_refinement` (boolean). If `true`, also pass the current `user_context` and `footage_summary` strings (empty strings are fine — refinement still catches nonsense-token and self-witness fixes).
-
-As each agent completes, update library.yaml with `transcript` (filename only, not full path):
-
-```bash
-ruby lib/buttercut/library.rb <name> complete transcript <filename> [<filename>...]
+```
+- [ ] Create transcripts (0/30)
+- [ ] Analyze footage (0/30)
+- [ ] Review the footage together
 ```
 
-**Refinement note:** When `transcript_refinement: true`, each `transcribe-audio` agent reviews and corrects its transcript in place before returning, using the `user_context` and `footage_summary` the parent passed in. Empty context strings are fine. The parent still only writes `transcript: <filename>.json` to library.yaml after the agent completes.
+These three public todos map onto the steps below: "Create transcripts" covers the mechanical run in Step 1 plus the optional refinement pass in Step 2 (advance its count from Step 1's `[transcript …]` progress lines; hold it in-progress through Step 2 when refinement is on); "Analyze footage" tracks the summaries in Step 3 (advance its count as clips are summarized, *not* after contact sheets); "Review the footage together" is Step 4.
 
-## Step 2 — Contact sheets (deterministic, no agent)
+In the public chat, refer to these non-technical steps. Keep the technical work (WhisperX, contact-sheet generation, Sonnet summaries) behind the scenes.
 
-Run from the project root:
+## Step 1 — Process footage (transcripts, then contact sheets)
+
+(If you reached this skill directly rather than via `process-library`, first tell the user: "Found [N] videos ([total size]). Starting footage analysis...")
+
+This is two mechanical commands you run **one after the other** — transcripts first, contact sheets second. **Never run them at once**: WhisperX is RAM-hungry, and overlapping the two is what we're avoiding. Don't hand-roll either with sub-agents; each runs identically every time, ~2 clips at a time, recording each clip into library.yaml the moment it finishes. Both are idempotent — they only touch clips still missing that artifact — so a re-run finishes only what's left. They will run in a minature Sidekiq-like job service. You'll run the command and then watch the log file that will be returned to watch progress.
+
+**Step 1a — Transcripts.** If using Claude Code, run with `run_in_background: true` on the Bash tool.
 
 ```bash
-ruby lib/buttercut/contact_sheet_job.rb <library-name> <clip> [<clip> ...]
+ruby lib/buttercut/process_footage.rb transcripts <library-name>
 ```
 
-Takes an explicit list of clip filenames (including extension, e.g. `P1055016.MP4`). Runs single-threaded — launch multiple invocations in parallel from the main thread when machine headroom allows (a 2-3 split across cores is usually safe on an M-series Mac). Always rebuilds every sheet for the clips it's given; for clips longer than 10 minutes that includes per-segment sheets covering successive 10-minute slices. Updates library.yaml's `contact_sheet` field for every clip it processes. No LLM — pure ffmpeg.
+Immediately after launching, set up a `Monitor` or equivalent on the log file to receive a notification for each completed or failed clip:
+
+```bash
+tail -f tmp/logs/processing/<library-name>/$(date +%Y-%m-%d).log | grep --line-buffered -E "TranscribeJob  (done|error)|transcript: [0-9]+/[0-9]+|Error|error:|failed|Traceback"
+```
+
+```bash
+ruby lib/buttercut/library.rb <name> pending transcript   # JSON list; done = N − its length
+```
+
+Update "Create transcripts 5/20" ie, number_of_clips_complete/total_number_of_clips as clips finish so the user can see progress. When the background task completes it exits non-zero if any clip failed. On failure, re-run once. If it fails again, investigate and then either create a fix so we handle it elegantlyy or inform the user about the problem with the clip and potentially pull it from the library.
+
+**Wait for 1a to finish before starting 1b.**
+
+**Step 1b — Contact sheets.** Once transcripts are done, build the sheets (a fast ffmpeg pass — foreground is fine):
+
+```bash
+ruby lib/buttercut/process_footage.rb contact-sheets <library-name>
+```
+
+Contact sheets stay behind the scenes — don't surface them as a public count. Mark "Create transcripts" done once 1a has finished and any refinement (Step 2) is complete.
+
+Tuning (optional): both steps read `parallel_jobs` from `libraries/settings.yaml` (default 2); override for one run with `--jobs N`. Each writes a timestamped log under `tmp/logs/processing/<library>/` for after-the-fact review.
+
+**Reprocessing.** Each step skips clips that already have its artifact. To redo one — say a transcript that misheard a name — re-run that step with `--force --clips NAME.mov`. `--force` alone rebuilds every clip.
+
+## Step 2 — Refine transcripts (judgment — only if `transcript_refinement: true`)
+
+Refinement is the one part of transcription that's a judgment call — fixing misheard proper nouns from library context — so it stays a model step, run *after* the mechanical pass. **Skip this entire step if the library's `transcript_refinement` is `false`.**
+
+When it's `true`, dispatch refinement sub-agents (2-4 in parallel, rolling) over the transcripts Step 1a just wrote. Inline `skills/transcribe-audio/refine_instructions.md` as each sub-agent's prompt and pass, inline:
+
+- `transcript_path` — absolute path to the clip's transcript JSON under `libraries/<library>/transcripts/`
+- `user_context` and `footage_summary` — current values from `ruby lib/buttercut/library.rb <name> summary` (empty strings are fine; refinement still catches nonsense-token and self-witness fixes)
+
+Sub-agents edit the transcript JSON in place and return a short list of corrections. They do NOT touch library.yaml — Step 1a already set the `transcript` field. Mark the public "Create transcripts" todo done once refinement completes.
 
 ## Step 3 — Summaries (Sonnet sub-agents, batched, rolling)
 
@@ -56,9 +90,9 @@ For each sub-agent, pass a list of 10 clip records inline. Each clip record need
 
 - `video_filename` — basename of the video (used in the summary header and reply line)
 - `duration` — duration string from library.yaml (e.g. `00:01:19`); the agent renders it in the summary header
-- `contact_sheet_path` — absolute path to the `_full.jpg` (from step 2)
+- `contact_sheet_path` — absolute path to the `_full.jpg` (from step 1)
 - `transcript_path` — absolute path to the audio transcript JSON (from step 1); the sub-agent extracts dialogue on demand via `script_extractor.rb`
-- `summary_output_path` — absolute path where the agent should write the summary markdown
+- `summary_output_path` — absolute path where the agent should write the summary markdown. Don't hand-build this filename; ask the library for the canonical path: `ruby lib/buttercut/library.rb <name> field_path summary <clip>` (handles the `summaries/summary_<clip>.md` convention for you, with or without the file extension)
 
 As each sub-agent returns its batch, update library.yaml with `summary` for every clip in that batch:
 
@@ -66,15 +100,17 @@ As each sub-agent returns its batch, update library.yaml with `summary` for ever
 ruby lib/buttercut/library.rb <name> complete summary <filename> [<filename>...]
 ```
 
-The `contact_sheet` field was already populated in step 2, so the sub-agent return only contributes summaries.
+The `contact_sheet` field was already populated in step 1, so the sub-agent return only contributes summaries.
 
 **If a sub-agent returns summaries inline instead of writing them to disk** (sometimes Sonnet hallucinates "the Write tool is blocked" and dumps the markdown into its reply), don't retry blindly — just extract each summary from the agent's response and `Write` it to the matching `summary_output_path` from the parent thread. Then run the `complete summary` command as usual. Faster than redispatching, and the content is already there.
 
 (Per-segment contact sheets generated for long clips live alongside the `_full` sheet on disk and are discoverable by convention — they aren't listed in library.yaml.)
 
+Don't move forward until summaries are complete. Advance the "Analyze footage" count as clips are summarized; mark it done when finished.
+
 ## Step 4 — Confirm footage understanding with the user
 
-Once every summary is written, talk through what the footage actually shows — confirm character names, locations, the narrative through-line, any stray or off-thesis clips, and the user's creative intent for this library. Use plain conversation; only reach for `AskUserQuestion` when offering a discrete choice. As you learn things, update:
+(This is the "Review the footage together" todo.) Once every summary is written, talk through what the footage actually shows — confirm character names, locations, the narrative through-line, any stray or off-thesis clips, and the user's creative intent for this library. Use plain conversation; only reach for `AskUserQuestion` when offering a discrete choice. As you learn things, update:
 
 - `footage_summary` and `user_context` via `ruby lib/buttercut/library.rb <name> update_metadata footage_summary "..."` (and the same with `user_context`)
 - individual `summary_*.md` files when a summary mislabels someone or misses a key detail (e.g., "a man in a tan jacket" → the user's name)
@@ -87,7 +123,7 @@ After all analysis completes, automatically create a backup using the `backup-li
 
 ## Parallel sub-agent pattern (reference)
 
-Used in steps 1 and 3.
+Used in steps 2 and 3.
 
 **Parent agent responsibilities:**
 - Read `library.yaml` and `settings.yaml` once to gather all values needed by sub-agents.
@@ -97,7 +133,7 @@ Used in steps 1 and 3.
 
 **Child agent responsibilities:**
 - Process its assigned clip(s) using only the inputs passed inline by the parent.
-- Run WhisperX (transcribe-audio) or read the pre-generated contact sheet, extract dialogue from the transcript via `script_extractor.rb`, and write the summary markdown in one Write call (analyze-video).
+- Refine a transcript JSON in place (refinement) or read the pre-generated contact sheet, extract dialogue from the transcript via `script_extractor.rb`, and write the summary markdown in one Write call (analyze-video). (WhisperX is no longer a sub-agent — `process_footage.rb transcripts` runs it in Step 1a.)
 - Return a short structured response with file paths.
 
 Each skill's `agent_prompt.md` documents its own IO contract — including whether the sub-agent reads or writes library.yaml. (Spoiler: it never writes library.yaml. Only the parent writes, via the `Library` API.)

--- a/skills/process-library/SKILL.md
+++ b/skills/process-library/SKILL.md
@@ -60,10 +60,10 @@ ruby lib/buttercut/library.rb <name> exists   # exits 0 if it does, 1 if not
 **If no library directory exists:**
 - Proceed to Step 3 to gather project information and create a new library.
 
-To list libraries by recency (for "find a recent library to resume" prompts):
+To find libraries by recency (for "the library I was just working on" / "resume a recent one" prompts):
 
 ```bash
-ruby lib/buttercut/library.rb list
+ruby lib/buttercut/library.rb recent [N]   # N most-recently-touched libraries (default 10)
 ```
 
 ## Step 3 — Gather project information (new libraries)
@@ -106,7 +106,7 @@ ruby -e "require_relative 'lib/buttercut/library'; \
 
 Each video entry starts with empty `transcript`, `contact_sheet`, and `summary` — empty means "todo", a filename means "done."
 
-If the user later drags in more clips:
+If the user later wants to add in more clips, use this:
 
 ```bash
 ruby lib/buttercut/library.rb <name> add_videos /abs/new1.mov /abs/new2.mov
@@ -131,7 +131,7 @@ This prevents idle sleep for the lifetime of the shell. Store the PID — you'll
 
 Inform the user: "Library setup complete. Found [N] videos ([total size]). Starting footage analysis..."
 
-Follow `skills/analyze-video/SKILL.md` end-to-end. That skill covers audio transcripts (parallel sub-agents), contact sheets (deterministic), summaries (Sonnet sub-agents, batched + rolling), and the post-analysis footage-understanding pass.
+Follow `skills/analyze-video/SKILL.md` end-to-end. That skill covers footage processing (transcripts then contact sheets, two deterministic `process_footage.rb` runs), optional transcript refinement, summaries (Sonnet sub-agents, batched + rolling), and the post-analysis footage-understanding pass.
 
 Progressively update `footage_summary` as transcripts come in — 1-3 sentences covering subjects, locations, activities, visual style:
 
@@ -168,5 +168,6 @@ kill $CAFFEINATE_PID 2>/dev/null
 ## Notes
 
 - A single `tmp/` directory inside the buttercut project root is used for all temporary files. Create subdirectories as needed and delete after use.
+- Reprocessing footage: `process_footage.rb` only handles clips missing an artifact. To rebuild ones that already exist, re-run the relevant step (`transcripts` or `contact-sheets`) with `--force` (optionally `--clips a.mov,b.mov`). See analyze-video Step 1.
 - Migrations: every time you read a library.yaml, check its schema against `templates/library_template.yaml`. If anything's missing or renamed, run `ruby lib/buttercut/library.rb migrate` to migrate all libraries at once. See AGENTS.md → Critical Principles for the migration trigger list.
 - Terminology: user-facing, call it "footage analysis" or "analyzing footage." Internally (library.yaml fields, file names), it's "transcription."

--- a/skills/transcribe-audio/SKILL.md
+++ b/skills/transcribe-audio/SKILL.md
@@ -5,6 +5,8 @@ description: Transcribes video audio using WhisperX, preserving original timesta
 
 # Skill: Transcribe Audio (parent brief)
 
+> **Note:** In the library pipeline, transcription runs mechanically via `ruby lib/buttercut/process_footage.rb transcripts <library>` (using `TranscribeJob`), not by dispatching this sub-agent — so footage analysis comes out identical across models. The WhisperX command lives in exactly one place, `lib/buttercut/transcribe_job.rb`, which also runs standalone: `ruby lib/buttercut/transcribe_job.rb <video_path> <output_dir> <language_code> <whisper_model>`. `refine_instructions.md` remains the playbook for the separate (judgment) refinement step that `analyze-video` Step 2 dispatches.
+
 Transcribes video audio using WhisperX and produces a clean JSON transcript with word-level timing.
 
 `SKILL.md` is the parent's dispatch brief. The sub-agent's working prompt lives in `agent_prompt.md` — inline its contents when launching the Task agent. Don't pass `SKILL.md`.

--- a/skills/transcribe-audio/agent_prompt.md
+++ b/skills/transcribe-audio/agent_prompt.md
@@ -16,33 +16,21 @@ You are a sub-agent. Transcribe one video file using WhisperX and produce a clea
 
 Do NOT read `library.yaml` or `settings.yaml`. If a required input is missing from your prompt, stop and ask the parent rather than inferring from the filesystem.
 
-## 1. Run WhisperX
+## 1. Transcribe (WhisperX + prepare)
+
+One command runs WhisperX and prepares the JSON (adds the video source path, drops unneeded fields, prettifies it):
 
 ```bash
-whisperx "<video_path>" \
-  --language <language_code> \
-  --model <whisper_model> \
-  --compute_type float32 \
-  --device cpu \
-  --output_format json \
-  --output_dir <transcript_output_dir>
+ruby lib/buttercut/transcribe_job.rb <video_path> <transcript_output_dir> <language_code> <whisper_model>
 ```
 
-## 2. Prepare audio transcript
+This is the single source of truth for the transcription command — don't hand-write a raw `whisperx` invocation.
 
-```bash
-ruby lib/buttercut/prepare_audio_script.rb \
-  <transcript_output_dir>/<video_basename>.json \
-  <video_path>
-```
-
-This script adds the video source path as metadata, removes unnecessary fields, and prettifies the JSON.
-
-## 3. (Optional) Refine the transcript
+## 2. (Optional) Refine the transcript
 
 If `transcript_refinement: true`, follow `skills/transcribe-audio/refine_instructions.md`, using the `user_context` and `footage_summary` strings the parent supplied inline. Do NOT open `library.yaml`. Skip if `transcript_refinement` is missing or `false`.
 
-## 4. Return success response
+## 3. Return success response
 
 ```
 ✓ <video_basename.mov> transcribed successfully

--- a/spec/buttercut/job_runner_spec.rb
+++ b/spec/buttercut/job_runner_spec.rb
@@ -1,0 +1,156 @@
+require 'spec_helper'
+require_relative '../../lib/buttercut/job'
+require_relative '../../lib/buttercut/job_runner'
+
+# In-memory stand-in for Library: records completions thread-safely so we can
+# assert what the runner wrote without touching disk or library.yaml.
+class RunnerFakeLibrary
+  attr_reader :completed
+
+  def initialize
+    @completed = []
+    @mutex = Mutex.new
+  end
+
+  def name = 'fake-lib'
+
+  def complete!(field, clips, announce: true)
+    @mutex.synchronize { Array(clips).each { |c| @completed << [field, c] } }
+    self
+  end
+end
+
+# Tracks how many jobs are running at once, so a cap can be asserted.
+class RunnerConcurrencyTracker
+  attr_reader :max
+
+  def initialize
+    @current = 0
+    @max = 0
+    @mutex = Mutex.new
+  end
+
+  def enter = @mutex.synchronize { @current += 1; @max = [@max, @current].max }
+  def leave = @mutex.synchronize { @current -= 1 }
+end
+
+# Test job: no shelling out. Optionally sleeps (to force overlap) and/or fails.
+class RunnerFakeJob < Job
+  def self.field = 'transcript'
+
+  def initialize(clip:, field: 'transcript', tracker: nil, fail: false, sleep_for: 0.0)
+    super(library_name: 'fake-lib', clip: clip)
+    @field = field
+    @tracker = tracker
+    @fail = fail
+    @sleep_for = sleep_for
+  end
+
+  def field = @field
+
+  def perform
+    @tracker&.enter
+    sleep(@sleep_for) if @sleep_for.positive?
+    raise "boom #{clip}" if @fail
+
+    self
+  ensure
+    @tracker&.leave
+  end
+end
+
+RSpec.describe JobRunner do
+  let(:library) { RunnerFakeLibrary.new }
+  let(:devnull) { File.open(File::NULL, 'w') }
+  subject(:runner) { described_class.new(library, io: devnull) }
+
+  after { devnull.close }
+
+  def jobs(*clips, **opts)
+    clips.map { |c| RunnerFakeJob.new(clip: c, **opts) }
+  end
+
+  it 'records every successful job to the library exactly once' do
+    results = runner.run(jobs('a.mov', 'b.mov', 'c.mov'), concurrency: 2)
+
+    expect(results.map(&:ok)).to all(be(true))
+    expect(library.completed).to contain_exactly(
+      %w[transcript a.mov], %w[transcript b.mov], %w[transcript c.mov]
+    )
+  end
+
+  it 'never exceeds the concurrency cap' do
+    tracker = RunnerConcurrencyTracker.new
+    clips = Array.new(12) { |i| "clip#{i}.mov" }
+    runner.run(jobs(*clips, tracker: tracker, sleep_for: 0.03), concurrency: 3)
+
+    expect(tracker.max).to be <= 3
+    expect(tracker.max).to be > 1 # proves it actually ran in parallel
+  end
+
+  it 'isolates failures: other jobs still run, failed ones are not recorded' do
+    batch = [
+      RunnerFakeJob.new(clip: 'ok1.mov'),
+      RunnerFakeJob.new(clip: 'bad.mov', fail: true),
+      RunnerFakeJob.new(clip: 'ok2.mov')
+    ]
+    results = runner.run(batch, concurrency: 3)
+
+    expect(results.size).to eq(3)
+    failed = results.reject(&:ok)
+    expect(failed.map(&:clip)).to eq(['bad.mov'])
+    expect(failed.first.error.message).to eq('boom bad.mov')
+    expect(library.completed).to contain_exactly(%w[transcript ok1.mov], %w[transcript ok2.mov])
+  end
+
+  it 'accumulates across successive run() calls (transcripts, then sheets)' do
+    # Mirrors process_footage.rb: one step finishes before the next starts.
+    transcripts = runner.run(jobs('a.mov', 'b.mov', field: 'transcript'), concurrency: 2)
+    sheets = runner.run(jobs('a.mov', 'b.mov', field: 'contact_sheet'), concurrency: 2)
+
+    expect(transcripts.map(&:field)).to all(eq('transcript'))
+    expect(sheets.map(&:field)).to all(eq('contact_sheet'))
+    expect(library.completed).to contain_exactly(
+      %w[transcript a.mov], %w[transcript b.mov],
+      %w[contact_sheet a.mov], %w[contact_sheet b.mov]
+    )
+  end
+
+  it 'treats a recording failure as a job failure' do
+    allow(library).to receive(:complete!).and_raise(ArgumentError, 'transcript file does not exist')
+    results = runner.run(jobs('a.mov'), concurrency: 1)
+
+    expect(results.first.ok).to be(false)
+    expect(results.first.error.message).to eq('transcript file does not exist')
+  end
+
+  it 'is a no-op when there are no jobs to run' do
+    expect(runner.run([])).to eq([])
+    expect(library.completed).to be_empty
+  end
+
+  describe 'concurrency from settings.yaml' do
+    it 'falls back to Settings#parallel_jobs when run omits a cap' do
+      allow(Settings).to receive(:load).and_return(instance_double(Settings, parallel_jobs: 1))
+      tracker = RunnerConcurrencyTracker.new
+      clips = Array.new(5) { |i| "clip#{i}.mov" }
+
+      # No concurrency passed anywhere → runner reads settings (1) → fully serial.
+      runner.run(jobs(*clips, tracker: tracker, sleep_for: 0.02))
+
+      expect(tracker.max).to eq(1)
+    end
+
+    it 'prefers an explicit constructor concurrency over settings' do
+      allow(Settings).to receive(:load).and_return(instance_double(Settings, parallel_jobs: 1))
+      pinned = described_class.new(library, concurrency: 3, io: devnull)
+      tracker = RunnerConcurrencyTracker.new
+      clips = Array.new(9) { |i| "clip#{i}.mov" }
+
+      pinned.run(jobs(*clips, tracker: tracker, sleep_for: 0.03))
+
+      expect(tracker.max).to be > 1
+      expect(tracker.max).to be <= 3
+    end
+  end
+end

--- a/spec/buttercut/library_spec.rb
+++ b/spec/buttercut/library_spec.rb
@@ -314,6 +314,13 @@ RSpec.describe Library do
       expect(lib.field_path('summary', 'DJI_0123')).to eq(File.join(library_dir, 'summaries', 'summary_DJI_0123.md'))
     end
 
+    it 'strips the clip extension so a basename with or without it resolves identically' do
+      lib = Library.find(library_name)
+      expect(lib.field_path('summary', 'P1055017.mov'))
+        .to eq(lib.field_path('summary', 'P1055017'))
+        .and eq(File.join(library_dir, 'summaries', 'summary_P1055017.md'))
+    end
+
     it 'raises for unknown fields' do
       expect { Library.find(library_name).field_path('bogus', 'x') }
         .to raise_error(ArgumentError, /unknown field/)
@@ -325,6 +332,14 @@ RSpec.describe Library do
       write_library(videos: [video_entry('a.mov'), video_entry('b.mov')])
       videos = Library.find(library_name).videos
       expect(videos.map { |v| v['path'] }).to eq(['/tmp/a.mov', '/tmp/b.mov'])
+    end
+
+    it 'exposes a derived filename without persisting it to library.yaml' do
+      write_library(videos: [video_entry('a.mov')])
+      library = Library.find(library_name)
+
+      expect(library.videos.first['filename']).to eq('a.mov')
+      expect(YAML.safe_load_file(library_yaml_path)['videos'].first).not_to have_key('filename')
     end
 
     it 'returns an empty array when there are no videos' do
@@ -390,6 +405,21 @@ RSpec.describe Library do
       lib = Library.find(library_name)
       expect(lib.update_metadata!(footage_summary: 'x')).to be(lib)
     end
+
+    it 'updates the config fields (language, editor, transcript_refinement)' do
+      write_library(videos: [], language: '', editor: '', transcript_refinement: nil)
+      Library.find(library_name).update_metadata!(language: 'english', editor: 'fcpx', transcript_refinement: false)
+      reloaded = load_yaml
+      expect(reloaded['language']).to eq('english')
+      expect(reloaded['editor']).to eq('fcpx')
+      expect(reloaded['transcript_refinement']).to be(false)
+    end
+
+    it 'writes transcript_refinement: false without treating it as "omitted"' do
+      write_library(videos: [], transcript_refinement: true)
+      Library.find(library_name).update_metadata!(transcript_refinement: false)
+      expect(load_yaml['transcript_refinement']).to be(false)
+    end
   end
 
   describe '#incomplete_videos' do
@@ -424,6 +454,34 @@ RSpec.describe Library do
                     ])
       expect(Library.find(library_name).incomplete_videos.first['missing'])
         .to eq(%w[transcript contact_sheet])
+    end
+  end
+
+  describe '#pending' do
+    it 'returns records only for clips missing the named field' do
+      write_library(videos: [
+                      video_entry('a.mov', transcript: 'a.json'),
+                      video_entry('b.mov', transcript: ''),
+                      video_entry('c.mov', transcript: 'c.json')
+                    ])
+      result = Library.find(library_name).pending('transcript')
+      expect(result.map { |r| r['filename'] }).to eq(['b.mov'])
+      expect(result.first).to include('path' => '/tmp/b.mov', 'duration' => '00:00:05')
+    end
+
+    it 'is independent per field' do
+      write_library(videos: [
+                      video_entry('a.mov', transcript: 'a.json', contact_sheet: ''),
+                      video_entry('b.mov', transcript: '', contact_sheet: 'b_full.jpg')
+                    ])
+      library = Library.find(library_name)
+      expect(library.pending('transcript').map { |r| r['filename'] }).to eq(['b.mov'])
+      expect(library.pending('contact_sheet').map { |r| r['filename'] }).to eq(['a.mov'])
+    end
+
+    it 'raises on an unknown field' do
+      write_library(videos: [])
+      expect { Library.find(library_name).pending('nonsense') }.to raise_error(ArgumentError, /unknown field/)
     end
   end
 
@@ -596,6 +654,37 @@ RSpec.describe Library do
     end
   end
 
+  describe '#reset_metadata!' do
+    before do
+      write_library(
+        videos: [video_entry('a.mov')],
+        created_date: '2026-05-30', last_updated: '2026-05-30',
+        language: 'english', editor: 'fcpx', transcript_refinement: true,
+        footage_summary: 'A vlog about Ruby meetups.', user_context: 'Subject is named Andrew.'
+      )
+    end
+
+    it 'clears setup choices and analysis-derived context to an unconfigured state' do
+      Library.find(library_name).reset_metadata!
+      yaml = load_yaml
+      expect(yaml.values_at('language', 'editor', 'footage_summary', 'user_context')).to eq(['', '', '', ''])
+      expect(yaml['transcript_refinement']).to be_nil
+      expect(yaml.key?('transcript_refinement')).to be(true) # key kept so 002 migration treats it as set
+    end
+
+    it 'keeps video records and dates' do
+      Library.find(library_name).reset_metadata!
+      yaml = load_yaml
+      expect(yaml['videos'].map { |v| v['path'] }).to eq(['/tmp/a.mov'])
+      expect(yaml.values_at('created_date', 'last_updated')).to eq(['2026-05-30', '2026-05-30'])
+    end
+
+    it 'returns self for chaining' do
+      lib = Library.find(library_name)
+      expect(lib.reset_metadata!).to be(lib)
+    end
+  end
+
   describe '#remove_visual_transcripts!' do
     before do
       write_library(videos: [
@@ -635,6 +724,50 @@ RSpec.describe Library do
     it 'returns self for chaining' do
       lib = Library.find(library_name)
       expect(lib.remove_visual_transcripts!).to be(lib)
+    end
+  end
+
+  describe 'concurrent writers (#mutate flock transaction)' do
+    # The real-world scenario this guards: `process_footage.rb` runs in the
+    # background recording transcripts via complete!, while the agent updates
+    # footage_summary "as transcripts come in" — two separate OS processes each
+    # doing a full read-modify-write of library.yaml. Without a lock spanning the
+    # whole RMW, the later rename silently drops the other process's change.
+    it 'loses no updates when two processes write library.yaml at once' do
+      skip 'fork unavailable on this platform' unless Process.respond_to?(:fork)
+
+      n = 30
+      clips = Array.new(n) { |i| "clip#{i}.mov" }
+      write_library(videos: clips.map { |c| video_entry(c) }, footage_summary: '')
+      clips.each { |c| touch(File.join(library_dir, 'transcripts', "#{File.basename(c, '.*')}.json")) }
+
+      # Child: record each clip's transcript as its own complete! call.
+      child = fork do
+        clips.each do |c|
+          Library.find(library_name).complete!('transcript', [c], announce: false)
+          sleep(0.001)
+        end
+        exit!(0)
+      end
+
+      # Parent: hammer footage_summary in parallel. Its last write must survive —
+      # complete! reads-and-preserves footage_summary under the same lock, so a
+      # concurrent transcript write can never revert it.
+      n.times do |i|
+        Library.find(library_name).update_metadata!(footage_summary: "summary-#{i}")
+        sleep(0.001)
+      end
+      Library.find(library_name).update_metadata!(footage_summary: 'FINAL')
+
+      _, status = Process.wait2(child)
+      expect(status.success?).to be(true)
+
+      yaml = load_yaml
+      # Every transcript landed (child's writes weren't clobbered by the parent)...
+      expect(yaml['videos'].map { |v| v['transcript'] }).to all(satisfy { |t| !t.to_s.empty? })
+      # ...and the parent's final metadata write survived (not reverted by a
+      # concurrent complete!).
+      expect(yaml['footage_summary']).to eq('FINAL')
     end
   end
 

--- a/spec/buttercut/settings_spec.rb
+++ b/spec/buttercut/settings_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'yaml'
+require_relative '../../lib/buttercut/settings'
+
+RSpec.describe Settings do
+  def with_settings(contents)
+    Dir.mktmpdir('settings-spec-') do |dir|
+      path = File.join(dir, 'settings.yaml')
+      File.write(path, contents) unless contents.nil?
+      yield Settings.load(path: path)
+    end
+  end
+
+  describe '#parallel_jobs' do
+    it 'reads a positive integer' do
+      with_settings("parallel_jobs: 4\n") { |s| expect(s.parallel_jobs).to eq(4) }
+    end
+
+    it 'defaults to 2 when the key is absent' do
+      with_settings("whisper_model: small\n") { |s| expect(s.parallel_jobs).to eq(2) }
+    end
+
+    it 'defaults to 2 when the value is blank' do
+      with_settings("parallel_jobs:\n") { |s| expect(s.parallel_jobs).to eq(2) }
+    end
+
+    it 'defaults to 2 for non-numeric or non-positive values' do
+      with_settings("parallel_jobs: lots\n") { |s| expect(s.parallel_jobs).to eq(2) }
+      with_settings("parallel_jobs: 0\n") { |s| expect(s.parallel_jobs).to eq(2) }
+      with_settings("parallel_jobs: -3\n") { |s| expect(s.parallel_jobs).to eq(2) }
+    end
+
+    it 'defaults to 2 when the file is missing entirely' do
+      with_settings(nil) { |s| expect(s.parallel_jobs).to eq(2) }
+    end
+  end
+
+  describe '#whisper_model' do
+    it 'reads the configured model straight from settings.yaml' do
+      with_settings("whisper_model: turbo\n") { |s| expect(s.whisper_model).to eq('turbo') }
+    end
+
+    it 'raises when blank or missing — settings.yaml is the source of truth, no code default' do
+      with_settings("whisper_model:\n") { |s| expect { s.whisper_model }.to raise_error(/whisper_model is not set/) }
+      with_settings("editor: fcpx\n") { |s| expect { s.whisper_model }.to raise_error(/whisper_model is not set/) }
+    end
+  end
+end

--- a/templates/settings_template.yaml
+++ b/templates/settings_template.yaml
@@ -9,6 +9,11 @@ editor: fcpx
 # Recommended: `small` paired with transcript_refinement (set per-library in library.yaml)
 whisper_model: small
 
+# How many footage-processing jobs (transcription, contact sheets) to run in
+# parallel per phase. 2 is the safe default — WhisperX is memory-hungry, so
+# higher values can exhaust RAM on smaller machines. Leave blank to use 2.
+parallel_jobs: 2
+
 # After exporting a roughcut, also drop a copy of the XML on the Desktop for easy import
 save_to_desktop_after_export: true
 


### PR DESCRIPTION
The mechanical half of footage analysis — transcription (WhisperX) and contact-sheet generation (ffmpeg) — is just shelling out to subprocesses. But its *orchestration* lived in a skill prompt, so different Claude versions (4.6/4.7/4.8, Sonnet/Opus) interpreted it differently: ordering, parallelism, and batching varied, and steps occasionally got skipped.

This moves that orchestration out of the prompt and into code, so footage processing produces the same result on every run regardless of which model kicks it off.

- **Code** owns anything that shells out to a subprocess (WhisperX, ffmpeg) — the agent just *calls* it.
- **Claude** keeps everything requiring judgment or taste: transcript refinement, footage summaries, cut decisions.

### New:
A small in-process job layer:

- `Job` base class + `TranscribeJob` / `ContactSheetJob`
- `JobRunner` — owns concurrency and is the single writer to `library.yaml`
- `FootageProcessor`, driven by one deterministic entrypoint: `process_footage.rb`

The Sidekiq-shaped interface also leaves a clean seam: a future need (e.g. a ButterCut Pro background service) could slot a real queue backend in behind the same interface without changing how the skills call it.