### PR TITLE
Fix correctness bugs in shipped skills

### DIFF
--- a/skills/contact-sheet/SKILL.md
+++ b/skills/contact-sheet/SKILL.md
@@ -45,7 +45,7 @@ ruby lib/buttercut/contact_sheet.rb <video-path> <start> <end> --library librari
 
 Options: `--library DIR`, `--output PATH` (exact path; overrides `--library`).
 
-Frame count is chosen automatically: 16 frames in a 4x4 grid for clips longer than 10 seconds, 4 frames in a 2x2 grid for clips of 10 seconds or less (avoids duplicates).
+Frame count is chosen automatically: 16 frames in a 4x4 grid for clips longer than 10 seconds, 8 frames in a 4x2 grid for clips of 10 seconds or less (avoids duplicates).
 
 Portrait clips (iPhone, etc.) are auto-rotated using the source's container rotation metadata so timestamps land right-side-up. Variable-frame-rate sources (screen recordings, some action cams) are detected and routed through the slower seek-and-grab path automatically.
 

--- a/skills/cut/roughcut_planning.md
+++ b/skills/cut/roughcut_planning.md
@@ -1,6 +1,6 @@
 # Planning a Roughcut
 
-This is the planning flow for the **Roughcut** path of the `cut` skill. By the time you're here, the user has already chosen "Roughcut" as the task type and the editor is already resolved — your job is to shape the editorial direction with them and save an approved plan markdown file at `libraries/[library-name]/plans/plan_[short-name]_[YYYYMMDD_HHMMSS].md`. Step 4 of SKILL.md hands that plan to the build sub-agent.
+This is the planning flow for the **Roughcut** path of the `cut` skill. By the time you're here, the user has already chosen "Roughcut" as the task type and the editor is already resolved — your job is to shape the editorial direction with them and save an approved plan markdown file at `libraries/[library-name]/plans/plan_[short-name]_[YYYYMMDD_HHMMSS].md`. Step 2 of roughcut_path.md hands that plan to the build sub-agent.
 
 The library's `footage_summary`, `user_context`, and individual summaries already capture the broad creative context — those are filled in during footage analysis (see "Start Footage Analysis" in AGENTS.md).
 
@@ -28,4 +28,4 @@ Ask questions one at a time so you don't end up asking the user questions that d
 8. **Save the plan** — only after the explicit yes. Copy `templates/plan_template.md` to `libraries/[library-name]/plans/plan_[short-name]_[YYYYMMDD_HHMMSS].md` and fill it in.
 
 ## Complete the planning
-Return to step 4 of `SKILL.md` and launch the build sub-agent with the saved plan.
+Return to step 2 of `roughcut_path.md` and launch the build sub-agent with the saved plan.

--- a/skills/full-transcript/SKILL.md
+++ b/skills/full-transcript/SKILL.md
@@ -9,19 +9,23 @@ Exports all spoken dialogue from a library's audio transcripts into a single `fu
 
 ## Run
 
+This pulls each clip's audio transcript, so run it after the library's footage has been processed. Clips without a transcript are skipped, so on an unprocessed library you'll get an empty file.
+
 ```bash
 ruby lib/buttercut/full_transcript.rb <library-name>
 ```
 
 ## Output
 
-`libraries/<library-name>/full_transcript.txt` — one block per clip:
+`libraries/<library-name>/full_transcript.txt` — one block per clip: the filename, an optional `// summary:` line (the clip's one-line overview, present only when the clip has been summarized), then the dialogue.
 
 ```
 filename.mov
+// summary: One-line overview of the clip.
 Dialogue text from that clip.
 
 filename2.mov
+// summary: One-line overview of the next clip.
 More dialogue from the next clip.
 ```
 

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -60,15 +60,13 @@ class ButterCut
 end
 ```
 
-### 5. Update Gemfile.lock
+### 5. Refresh Gemfile.lock
 
-Run `bundle install` so `Gemfile.lock` reflects the new version:
+Run `bundle install` to keep the lock file in sync. The app version lives only in `lib/buttercut/version.rb` — the `buttercut` gem is no longer published, so there's no version entry in `Gemfile.lock` to check.
 
 ```bash
 bundle install
 ```
-
-Verify the version updated in `Gemfile.lock` before proceeding.
 
 ### 6. Gather Changelog Notes
 


### PR DESCRIPTION
Five docs/commands in the shipped (non `user-`) skills disagreed with the actual `lib/buttercut` behavior. Each was verified against source before changing. No behavior change — these are doc/command corrections only.

## Fixes

| Skill | Bug | Source check |
|---|---|---|
| **contact-sheet** | Said short clips get "4 frames in a 2x2 grid." | `contact_sheet.rb:16-17` → `SHORT_CLIP_FRAMES=8`, `SHORT_CLIP_COLS=4` → **8 frames, 4x2**. |
| **cut / roughcut_planning** | Pointed the build sub-agent launch at "step 4 of SKILL.md" (×2). | Step 4 of `cut/SKILL.md` is editor resolution; the launch is `roughcut_path.md` **step 2**. |
| **release** | "Verify the version updated in `Gemfile.lock`." | `VERSION` lives only in `lib/buttercut/version.rb`; the gem was unpublished in 0.7.1, so `Gemfile.lock` has **no buttercut entry** to check. |
| **full-transcript** | Output example omitted the `// summary:` line. | `full_transcript.rb:42` emits `// summary: <overview>` when the clip has a summary. |
| **full-transcript** | No note that it silently skips un-transcribed clips. | `full_transcript.rb:30-35` skips clips without a `transcript`; on an unprocessed library that yields an empty file. |

## How this was found
Multi-agent review of all 11 shipped skills (per-skill reviewers + cross-cutting correctness/redundancy/vocabulary/density analysts), with every command claim re-checked against `lib/`.

## Note
This is the first of two stacked PRs. The follow-up (`chore/skills-density-pass`, branched off this one) is the behavior-preserving density + jargon trim (~190 lines).