### PR TITLE
Split process-library into create-library + process-library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,10 @@ Work is organized into **libraries** (video series/projects), each self-containe
 
 ### Workflow Steps
 
-1. **Process Library** → `process-library` skill — set up a new project, resume an existing one, or add new footage.
-2. **Edit** → `cut` skill — build a scene, selects reel, roughcut, or custom task as a timeline from the processed library. Pre-flight with `ruby lib/buttercut/library.rb <name> ready` (exit `0` means yes). The check is legacy-aware: a clip with `summary` + either `transcript` or `visual_transcript` counts as ready, so libraries that predate the contact-sheet pipeline still pass.
-3. **Backup** → `backup-library` skill — compressed archives in `~/Documents/buttercut-video-editor-backups` by default (override via `backups_dir` in `libraries/settings.yaml`). `process-library` triggers this automatically after analysis. "Run a backup" means back up just the library you're working on (`--library <name>`); only back up every library when the user explicitly asks.
+1. **Create Library** → `create-library` skill — start a new project: gather project info and scaffold the library. Hands off to `process-library` to analyze the footage.
+2. **Process Library** → `process-library` skill — analyze footage: process a newly created library, resume an existing one, or add new footage. (Creating a brand-new library is `create-library`, which hands off here.)
+3. **Edit** → `cut` skill — build a scene, selects reel, roughcut, or custom task as a timeline from the processed library. Pre-flight with `ruby lib/buttercut/library.rb <name> ready` (exit `0` means yes). The check is legacy-aware: a clip with `summary` + either `transcript` or `visual_transcript` counts as ready, so libraries that predate the contact-sheet pipeline still pass.
+4. **Backup** → `backup-library` skill — compressed archives in `~/Documents/buttercut-video-editor-backups` by default (override via `backups_dir` in `libraries/settings.yaml`). `process-library` triggers this automatically after analysis. "Run a backup" means back up just the library you're working on (`--library <name>`); only back up every library when the user explicitly asks.
 
 Libraries are the primary abstraction — each is a video series/project self-contained under `/libraries/[library-name]/`. Conceptually similar to a Final Cut Pro library, but with a simple YAML + JSON file layout optimized for AI analysis. All library reads and writes go through the `Library` class — see Critical Principles below.
 

--- a/skills/.gitignore
+++ b/skills/.gitignore
@@ -26,6 +26,8 @@
 !full-transcript/**
 !contact-sheet/
 !contact-sheet/**
+!create-library/
+!create-library/**
 !process-library/
 !process-library/**
 !reprocess-with-contact-sheets/

--- a/skills/analyze-video/SKILL.md
+++ b/skills/analyze-video/SKILL.md
@@ -19,25 +19,40 @@ This is the main thread's playbook for the **Analyze Video** workflow step. Run 
 - Library setup is complete (`library.yaml` exists, schema is current — run migrations from AGENTS.md if not).
 - Read `libraries/settings.yaml` directly for `whisper_model`. For library fields, read the snapshot via `ruby lib/buttercut/library.rb <name> summary` and pull the values you need from the JSON — don't parse library.yaml inline.
 
-At this point, create a todo list, visible to the user, with high-level, non-technical steps so they can follow the overall plan for processing the library, e.g.:
+At this point, create a todo list, visible to the user, with high-level, non-technical steps so they can follow the overall plan for processing the library. Include caffeination steps only if they've opted in. e.g.:
 
 ```
+- [ ] Keep Mac Awake with Caffeinate 
 - [ ] Create transcripts (0/30)
 - [ ] Analyze footage (0/30)
+- [ ] Turn off Mac Caffeinate 
 - [ ] Review the footage together
 ```
 
-These three public todos map onto the steps below: "Create transcripts" covers the mechanical run in Step 1 plus the optional refinement pass in Step 2 (advance its count from Step 1's `[transcript …]` progress lines; hold it in-progress through Step 2 when refinement is on); "Analyze footage" tracks the summaries in Step 3 (advance its count as clips are summarized, *not* after contact sheets); "Review the footage together" is Step 4.
+These public todos map onto the steps below: "Keep Mac Awake with Caffeinate" is Step 1 and "Turn off Mac Caffeinate" is Step 6; "Create transcripts" covers the mechanical run in Step 2 plus the optional refinement pass in Step 3 (advance its count from Step 2's `[transcript …]` progress lines; hold it in-progress through Step 3 when refinement is on); "Analyze footage" tracks the summaries in Step 4 (advance its count as clips are summarized, *not* after contact sheets); "Review the footage together" is Step 5.
 
 In the public chat, refer to these non-technical steps. Keep the technical work (WhisperX, contact-sheet generation, Sonnet summaries) behind the scenes.
 
-## Step 1 — Process footage (transcripts, then contact sheets)
+## Step 1 — Prevent sleep during processing
+
+Before starting analysis, ask the user (via `AskUserQuestion`): "Processing can take a while — want me to keep your computer awake until it's done?" Options: "Yes (Recommended)" and "No".
+
+If yes, start caffeinate in the background:
+
+```bash
+caffeinate -i -w $$ &
+CAFFEINATE_PID=$!
+```
+
+This prevents idle sleep for the lifetime of the shell. Store the PID — you'll kill it in Step 6 once analysis is finished. (Backup is handled by the calling skill — `process-library` — after this skill returns.)
+
+## Step 2 — Process footage (transcripts, then contact sheets)
 
 (If you reached this skill directly rather than via `process-library`, first tell the user: "Found [N] videos ([total size]). Starting footage analysis...")
 
 This is two mechanical commands you run **one after the other** — transcripts first, contact sheets second. **Never run them at once**: WhisperX is RAM-hungry, and overlapping the two is what we're avoiding. Don't hand-roll either with sub-agents; each runs identically every time, ~2 clips at a time, recording each clip into library.yaml the moment it finishes. Both are idempotent — they only touch clips still missing that artifact — so a re-run finishes only what's left. They will run in a minature Sidekiq-like job service. You'll run the command and then watch the log file that will be returned to watch progress.
 
-**Step 1a — Transcripts.** If using Claude Code, run with `run_in_background: true` on the Bash tool.
+**Step 2a — Transcripts.** If using Claude Code, run with `run_in_background: true` on the Bash tool. Otherwise use correct tool/argument to run in background.
 
 ```bash
 ruby lib/buttercut/process_footage.rb transcripts <library-name>
@@ -55,32 +70,32 @@ ruby lib/buttercut/library.rb <name> pending transcript   # JSON list; done = N 
 
 Update "Create transcripts 5/20" ie, number_of_clips_complete/total_number_of_clips as clips finish so the user can see progress. When the background task completes it exits non-zero if any clip failed. On failure, re-run once. If it fails again, investigate and then either create a fix so we handle it elegantlyy or inform the user about the problem with the clip and potentially pull it from the library.
 
-**Wait for 1a to finish before starting 1b.**
+**Wait for 2a to finish before starting 2b.**
 
-**Step 1b — Contact sheets.** Once transcripts are done, build the sheets (a fast ffmpeg pass — foreground is fine):
+**Step 2b — Contact sheets.** Once transcripts are done, build the sheets (a fast ffmpeg pass — foreground is fine):
 
 ```bash
 ruby lib/buttercut/process_footage.rb contact-sheets <library-name>
 ```
 
-Contact sheets stay behind the scenes — don't surface them as a public count. Mark "Create transcripts" done once 1a has finished and any refinement (Step 2) is complete.
+Contact sheets stay behind the scenes — don't surface them as a public count. Mark "Create transcripts" done once 2a has finished and any refinement (Step 3) is complete.
 
 Tuning (optional): both steps read `parallel_jobs` from `libraries/settings.yaml` (default 2); override for one run with `--jobs N`. Each writes a timestamped log under `tmp/logs/processing/<library>/` for after-the-fact review.
 
 **Reprocessing.** Each step skips clips that already have its artifact. To redo one — say a transcript that misheard a name — re-run that step with `--force --clips NAME.mov`. `--force` alone rebuilds every clip.
 
-## Step 2 — Refine transcripts (judgment — only if `transcript_refinement: true`)
+## Step 3 — Refine transcripts (judgment — only if `transcript_refinement: true`)
 
 Refinement is the one part of transcription that's a judgment call — fixing misheard proper nouns from library context — so it stays a model step, run *after* the mechanical pass. **Skip this entire step if the library's `transcript_refinement` is `false`.**
 
-When it's `true`, dispatch refinement sub-agents (2-4 in parallel, rolling) over the transcripts Step 1a just wrote. Inline `skills/transcribe-audio/refine_instructions.md` as each sub-agent's prompt and pass, inline:
+When it's `true`, dispatch refinement sub-agents (2-4 in parallel, rolling) over the transcripts Step 2a just wrote. Inline `skills/transcribe-audio/refine_instructions.md` as each sub-agent's prompt and pass, inline:
 
 - `transcript_path` — absolute path to the clip's transcript JSON under `libraries/<library>/transcripts/`
 - `user_context` and `footage_summary` — current values from `ruby lib/buttercut/library.rb <name> summary` (empty strings are fine; refinement still catches nonsense-token and self-witness fixes)
 
-Sub-agents edit the transcript JSON in place and return a short list of corrections. They do NOT touch library.yaml — Step 1a already set the `transcript` field. Mark the public "Create transcripts" todo done once refinement completes.
+Sub-agents edit the transcript JSON in place and return a short list of corrections. They do NOT touch library.yaml — Step 2a already set the `transcript` field. Mark the public "Create transcripts" todo done once refinement completes.
 
-## Step 3 — Summaries (Sonnet sub-agents, batched, rolling)
+## Step 4 — Summaries (Sonnet sub-agents, batched, rolling)
 
 Dispatch `analyze-video` sub-agents on the **Sonnet model**. Sonnet reads the contact sheet with noticeably more visual specificity than Haiku (catches clothing, architecture, camera framing) — worth it since the summaries feed every later cut decision.
 
@@ -90,8 +105,8 @@ For each sub-agent, pass a list of 10 clip records inline. Each clip record need
 
 - `video_filename` — basename of the video (used in the summary header and reply line)
 - `duration` — duration string from library.yaml (e.g. `00:01:19`); the agent renders it in the summary header
-- `contact_sheet_path` — absolute path to the `_full.jpg` (from step 1)
-- `transcript_path` — absolute path to the audio transcript JSON (from step 1); the sub-agent extracts dialogue on demand via `script_extractor.rb`
+- `contact_sheet_path` — absolute path to the `_full.jpg` (from step 2)
+- `transcript_path` — absolute path to the audio transcript JSON (from step 2); the sub-agent extracts dialogue on demand via `script_extractor.rb`
 - `summary_output_path` — absolute path where the agent should write the summary markdown. Don't hand-build this filename; ask the library for the canonical path: `ruby lib/buttercut/library.rb <name> field_path summary <clip>` (handles the `summaries/summary_<clip>.md` convention for you, with or without the file extension)
 
 As each sub-agent returns its batch, update library.yaml with `summary` for every clip in that batch:
@@ -100,7 +115,7 @@ As each sub-agent returns its batch, update library.yaml with `summary` for ever
 ruby lib/buttercut/library.rb <name> complete summary <filename> [<filename>...]
 ```
 
-The `contact_sheet` field was already populated in step 1, so the sub-agent return only contributes summaries.
+The `contact_sheet` field was already populated in step 2, so the sub-agent return only contributes summaries.
 
 **If a sub-agent returns summaries inline instead of writing them to disk** (sometimes Sonnet hallucinates "the Write tool is blocked" and dumps the markdown into its reply), don't retry blindly — just extract each summary from the agent's response and `Write` it to the matching `summary_output_path` from the parent thread. Then run the `complete summary` command as usual. Faster than redispatching, and the content is already there.
 
@@ -108,7 +123,7 @@ The `contact_sheet` field was already populated in step 1, so the sub-agent retu
 
 Don't move forward until summaries are complete. Advance the "Analyze footage" count as clips are summarized; mark it done when finished.
 
-## Step 4 — Confirm footage understanding with the user
+## Step 5 — Confirm footage understanding with the user
 
 (This is the "Review the footage together" todo.) Once every summary is written, talk through what the footage actually shows — confirm character names, locations, the narrative through-line, any stray or off-thesis clips, and the user's creative intent for this library. Use plain conversation; only reach for `AskUserQuestion` when offering a discrete choice. As you learn things, update:
 
@@ -117,13 +132,17 @@ Don't move forward until summaries are complete. Advance the "Analyze footage" c
 
 This is the one place to do this thorough pass. Every later roughcut planning run inherits the resulting context rather than re-interrogating the library.
 
-## Step 5 — Backup
+## Step 6 — Stop caffeinate
 
-After all analysis completes, automatically create a backup using the `backup-library` skill.
+If you started caffeinate in Step 1, kill it now:
+
+```bash
+kill $CAFFEINATE_PID 2>/dev/null
+```
 
 ## Parallel sub-agent pattern (reference)
 
-Used in steps 2 and 3.
+Used in steps 3 and 4.
 
 **Parent agent responsibilities:**
 - Read `library.yaml` and `settings.yaml` once to gather all values needed by sub-agents.
@@ -133,7 +152,7 @@ Used in steps 2 and 3.
 
 **Child agent responsibilities:**
 - Process its assigned clip(s) using only the inputs passed inline by the parent.
-- Refine a transcript JSON in place (refinement) or read the pre-generated contact sheet, extract dialogue from the transcript via `script_extractor.rb`, and write the summary markdown in one Write call (analyze-video). (WhisperX is no longer a sub-agent — `process_footage.rb transcripts` runs it in Step 1a.)
+- Refine a transcript JSON in place (refinement) or read the pre-generated contact sheet, extract dialogue from the transcript via `script_extractor.rb`, and write the summary markdown in one Write call (analyze-video). (WhisperX is no longer a sub-agent — `process_footage.rb transcripts` runs it in Step 2a.)
 - Return a short structured response with file paths.
 
 Each skill's `agent_prompt.md` documents its own IO contract — including whether the sub-agent reads or writes library.yaml. (Spoiler: it never writes library.yaml. Only the parent writes, via the `Library` API.)

--- a/skills/create-library/SKILL.md
+++ b/skills/create-library/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: create-library
+description: Create a new ButterCut library. Gather library info (name, footage location, language, transcript proofreading) and scaffold the library. Use when the user wants to start a **new** library. Libraries are containers of footage and footage analysis (transcripts, contact sheets, etc). User's may also refer to Libraries as "projects" or similiar. Ask them to confirm if they want a new Library (footage container) or just a new cut (roughcut, select, etc) if unsure.
+---
+
+# Skill: Create Library (parent brief)
+
+This skill is performed in the main thread.
+
+## Step 1 — Initialize settings (one-time)
+
+Before any library setup, check if `libraries/settings.yaml` exists. If not, copy from template:
+
+```bash
+cp templates/settings_template.yaml libraries/settings.yaml
+```
+
+If no previous `settings.yaml` was present, use `AskUserQuestion` to ask the user to confirm or change their defaults (editor and `whisper_model`).
+
+Editor options (label shown to user → value to save):
+- Final Cut Pro X → `fcpx`
+- Adobe Premiere Pro → `premiere`
+- DaVinci Resolve → `resolve`
+
+`whisper_model` options:
+- Small (recommended — pairs well with per-library `transcript_refinement`)
+- Medium
+- Turbo (Large)
+
+Save the shortcode (`fcpx` / `premiere` / `resolve`) to `libraries/settings.yaml`.
+
+## Step 2 — Gather project information
+
+First, guard against clobbering an existing library. Once you have a candidate name (after question 1 below), check:
+
+```bash
+ruby lib/buttercut/library.rb <name> exists   # exits 0 if it does, 1 if not
+```
+
+If it already exists, stop creating — the user is really resuming or adding footage. Switch to the `process-library` skill instead.
+
+Ask the user these questions one at a time — never all at once.
+
+1. **What do you want to call this project library?**
+   - Examples: "bike-locking-video-series", "raiders-2025-highlights", "yo-yo-techniques"
+   - Normalize the name: replace spaces with dashes, lowercase, drop special characters (keep alphanumeric and dashes).
+
+2. **Where are the video files located?**
+   - Ask: "Where are your video files? You can drag folders or individual files directly into the chat."
+   - Verify all files exist before proceeding.
+   - Inform the user of what was found: "Found 5 video files totaling 2.3GB."
+
+3. **What language is spoken in these videos?**
+   - `AskUserQuestion` with options: "English", "Spanish", and a free-text fallback for other languages.
+   - Save the language name (e.g. "English") to library.yaml.
+   - Map to a language code (e.g. `en`, `es`, `fr`) behind the scenes when needed for transcription.
+
+4. **Can I proofread the transcripts after they're generated?**
+   - `AskUserQuestion` with this exact question: "Can I proofread the transcripts after they're generated? I'll use the video's context to fix mistakes."
+   - Options: "Yes — Recommended (Use Claude to refine video understanding)" and "No".
+   - Save the boolean to `transcript_refinement` in library.yaml (true for Yes, false for No). Default to `true` if the user skips.
+
+Read the `editor` from `libraries/settings.yaml` — you'll pass it into the create call next.
+
+## Step 3 — Create the library
+
+`Library.create` is the one operation that doesn't have a plain CLI form (kwarg-heavy). Run it via `ruby -e`. It creates the directory tree (transcripts/, contact_sheets/, summaries/, cuts/, plans/), ffprobes each video for duration, and writes library.yaml in one call:
+
+```bash
+ruby -e "require_relative 'lib/buttercut/library'; \
+  Library.create('my-library', \
+    language: 'en', \
+    editor: 'fcpx', \
+    transcript_refinement: true, \
+    video_paths: ['/abs/foo.mov', '/abs/bar.mov'])"
+```
+
+Each video entry starts with empty `transcript`, `contact_sheet`, and `summary` — empty means "todo", filename presence means "done."
+
+## Step 4 — Hand off to process-library
+
+The library now exists but no footage has been analyzed. Continue straight into the `process-library` skill to analyze the footage end-to-end. Read that skill and continue processing the library.
+
+Tell the user: "Library setup complete. Found [N] videos ([55 minutes of footage]). Starting footage analysis..." then proceed with `process-library` against the library you just created.
+
+## Notes
+
+- Migrations: creating a fresh library always writes the current schema, so no migration is needed for the new one. But if you touched any pre-existing library here, check its schema against `templates/library_template.yaml` and run `ruby lib/buttercut/library.rb migrate` if anything's missing or renamed. See AGENTS.md → Critical Principles.
+- Terminology: user-facing, this is "setting up a project" or "creating a library."

--- a/skills/process-library/SKILL.md
+++ b/skills/process-library/SKILL.md
@@ -1,64 +1,40 @@
 ---
 name: process-library
-description: Skill for processing footage (video clips, sounds, photos, etc). Use this when creating a new library, adding new footage (videos) to an existing library, or resuming processing on an existing library.
+description: Process the footage in a library — run analysis (transcripts, contact sheets, summaries) on a new library, resume processing on an existing one, or add and analyze new footage. Use when footage needs analyzing.
 ---
 
 # Skill: Process Library (parent brief)
 
-This skill is the main thread's playbook for the **Setup** and **Analyze Video** workflow steps. Use it whenever the user wants to:
+This skill is the main thread's playbook for the **Analyze Video** workflow step — processing the footage in a library that already exists. Use it whenever the user wants to:
 
-- Start a new project (creates a library, gathers project info, runs analysis end-to-end).
-- Return to an existing library to process (loads it and continues from wherever analysis left off).
-- Add new footage to an existing library (appends clips, runs analysis just on the new ones).
+- Analyze a newly created library (this is where `create-library` hands off after scaffolding).
+- Return to an existing library and continue from wherever analysis left off.
+- Add new footage to an existing library and analyze just the new clips.
 
 It orchestrates the full `transcribe-audio` → contact sheets → summaries pipeline. The mechanics of each analysis step live in `skills/analyze-video/SKILL.md`; this skill calls into them.
 
-## Step 1 — Initialize settings (one-time)
+## Step 1 — Locate the library
 
-Before any library setup, check if `libraries/settings.yaml` exists. If not, copy from template:
-
-```bash
-cp templates/settings_template.yaml libraries/settings.yaml
-```
-
-If no previous `settings.yaml` was present, use `AskUserQuestion` to ask the user to confirm or change their defaults (editor and `whisper_model`).
-
-Editor options (label shown to user → value to save):
-- Final Cut Pro X → `fcpx`
-- Adobe Premiere Pro → `premiere`
-- DaVinci Resolve → `resolve`
-
-`whisper_model` options:
-- Small (recommended — pairs well with per-library `transcript_refinement`)
-- Medium
-- Turbo (Large)
-
-Save the shortcode (`fcpx` / `premiere` / `resolve`) to `libraries/settings.yaml`, not the long-form name — downstream export expects the shortcode.
-
-Note: `transcript_refinement` is a **per-library** setting, not global. Ask about it during library setup (Step 3 below), not here.
-
-## Step 2 — Resume or create
-
-Check if a library already exists:
+You need an existing library to process. Confirm which one:
 
 ```bash
 ruby lib/buttercut/library.rb <name> exists   # exits 0 if it does, 1 if not
 ```
 
 **If it exists:**
-- Skip setup entirely — the library is already configured.
-- Read the snapshot first — one call gives you top-level metadata plus the clip-completion breakdown (`video_count`, `incomplete_count`, and the list of incomplete clips with their missing fields):
+- Read the snapshot — one call gives you top-level metadata plus the clip-completion breakdown (`video_count`, `incomplete_count`, and the list of incomplete clips with their missing fields):
   ```bash
   ruby lib/buttercut/library.rb <name> summary
   ```
-- User is returning to existing work; continue from whatever step is incomplete.
+- Run any schema migrations from AGENTS.md → Critical Principles before touching anything else.
+- Continue from whatever step is incomplete.
 
 **If the directory exists but `exists` returns 1** (library.yaml missing):
 - Check what files are present (`transcripts/`, `cuts/`, etc.) and inform the user of the current state.
-- Proceed with creating library.yaml to restore consistency.
+- The library needs scaffolding — use `create-library` to restore consistency, then return here.
 
 **If no library directory exists:**
-- Proceed to Step 3 to gather project information and create a new library.
+- There's nothing to process. The user wants to start a new project — use the `create-library` skill first, which will hand back here once the library is scaffolded.
 
 To find libraries by recency (for "the library I was just working on" / "resume a recent one" prompts):
 
@@ -66,72 +42,23 @@ To find libraries by recency (for "the library I was just working on" / "resume 
 ruby lib/buttercut/library.rb recent [N]   # N most-recently-touched libraries (default 10)
 ```
 
-## Step 3 — Gather project information (new libraries)
+## Step 2 — Add new footage
 
-Ask the user these questions one at a time — never all at once.
-
-1. **What do you want to call this project library?**
-   - Examples: "bike-locking-video-series", "raiders-2025-highlights", "yo-yo-techniques"
-   - Normalize the name: replace spaces with dashes, lowercase, drop special characters (keep alphanumeric and dashes).
-
-2. **Where are the video files located?**
-   - Ask: "Where are your video files? You can drag folders or individual files directly into the chat."
-   - Verify all files exist before proceeding.
-   - Inform the user of what was found: "Found 5 video files totaling 2.3GB."
-
-3. **What language is spoken in these videos?**
-   - `AskUserQuestion` with options: "English", "Spanish", and a free-text fallback for other languages.
-   - Save the language name (e.g. "English") to library.yaml.
-   - Map to a language code (e.g. `en`, `es`, `fr`) behind the scenes when needed for transcription.
-
-4. **Can I proofread the transcripts after they're generated?**
-   - `AskUserQuestion` with this exact question: "Can I proofread the transcripts after they're generated? I'll use the video's context to fix mistakes."
-   - Options: "Yes — Recommended (Use Claude to refine video understanding)" and "No".
-   - Save the boolean to `transcript_refinement` in library.yaml (true for Yes, false for No). Default to `true` if the user skips.
-
-Read the `editor` from `libraries/settings.yaml` — you'll pass it into the create call next.
-
-## Step 4 — Create the library
-
-`Library.create` is the one operation that doesn't have a plain CLI form (kwarg-heavy). Run it via `ruby -e`. It creates the directory tree (transcripts/, contact_sheets/, summaries/, cuts/, plans/), ffprobes each video for duration, and writes library.yaml in one call:
-
-```bash
-ruby -e "require_relative 'lib/buttercut/library'; \
-  Library.create('my-library', \
-    language: 'en', \
-    editor: 'fcpx', \
-    transcript_refinement: true, \
-    video_paths: ['/abs/foo.mov', '/abs/bar.mov'])"
-```
-
-Each video entry starts with empty `transcript`, `contact_sheet`, and `summary` — empty means "todo", a filename means "done."
-
-If the user later wants to add in more clips, use this:
+If the user is adding footage new footage to an existing library, append the clips first:
 
 ```bash
 ruby lib/buttercut/library.rb <name> add_videos /abs/new1.mov /abs/new2.mov
 ```
 
-Then re-run the analyze steps for just the new clips.
+Each new entry starts with empty `transcript`, `contact_sheet`, and `summary` — empty means "todo." The analysis steps below are idempotent and only touch clips missing an artifact, so they'll process just the new clips.
 
-## Step 5 — Prevent sleep during processing
+If you're simply resuming or processing a freshly created library, skip this step.
 
-Before starting analysis, ask the user (via `AskUserQuestion`): "Processing can take a while — want me to keep your computer awake until it's done?" Options: "Yes (Recommended)" and "No".
+## Step 3 — Analyze footage
 
-If yes, start caffeinate in the background:
+Inform the user: "Found [N] videos ([total size]). Starting footage analysis..."
 
-```bash
-caffeinate -i -w $$ &
-CAFFEINATE_PID=$!
-```
-
-This prevents idle sleep for the lifetime of the shell. Store the PID — you'll kill it in Step 9 after processing and backup are finished.
-
-## Step 6 — Analyze footage
-
-Inform the user: "Library setup complete. Found [N] videos ([total size]). Starting footage analysis..."
-
-Follow `skills/analyze-video/SKILL.md` end-to-end. That skill covers footage processing (transcripts then contact sheets, two deterministic `process_footage.rb` runs), optional transcript refinement, summaries (Sonnet sub-agents, batched + rolling), and the post-analysis footage-understanding pass.
+Follow `skills/analyze-video/SKILL.md` end-to-end. That skill covers keeping the Mac awake during processing (caffeinate), footage processing (transcripts then contact sheets, two deterministic `process_footage.rb` runs), optional transcript refinement, summaries (Sonnet sub-agents, batched + rolling), and the post-analysis footage-understanding pass.
 
 Progressively update `footage_summary` as transcripts come in — 1-3 sentences covering subjects, locations, activities, visual style:
 
@@ -143,7 +70,7 @@ The full understanding pass at the end of analyze-video is where this gets refin
 
 Analyze ALL videos before offering to create rough cuts.
 
-## Step 7 — Verify readiness
+## Step 4 — Verify readiness
 
 Before reporting analysis complete, confirm the library passes the same gate the `cut` skill uses:
 
@@ -153,21 +80,12 @@ ruby lib/buttercut/library.rb <name> ready
 
 If it exits non-zero, run `ruby lib/buttercut/library.rb <name> summary` to list the incomplete clips, finish the missing artifacts (loop back into whichever analyze-video step owns them), and re-run `ready` until it passes. Don't claim analysis is done while `Library.ready?` is false.
 
-## Step 8 — Backup
+## Step 5 — Backup
 
 After all analysis completes, automatically create a backup using the `backup-library` skill, scoped to just the library you processed: `ruby lib/buttercut/backup_libraries.rb --library <library-name>`. This writes a single archive under `~/Documents/buttercut-video-editor-backups/<library-name>/` (or wherever `backups_dir` in `libraries/settings.yaml` points). If `backups_dir` isn't set yet, the script silently uses the default — don't prompt during process-library.
-
-## Step 9 — Stop caffeinate
-
-If you started caffeinate in Step 5, kill it now:
-
-```bash
-kill $CAFFEINATE_PID 2>/dev/null
-```
 
 ## Notes
 
 - A single `tmp/` directory inside the buttercut project root is used for all temporary files. Create subdirectories as needed and delete after use.
-- Reprocessing footage: `process_footage.rb` only handles clips missing an artifact. To rebuild ones that already exist, re-run the relevant step (`transcripts` or `contact-sheets`) with `--force` (optionally `--clips a.mov,b.mov`). See analyze-video Step 1.
+- Reprocessing footage: `process_footage.rb` only handles clips missing an artifact. To rebuild ones that already exist, re-run the relevant step (`transcripts` or `contact-sheets`) with `--force` (optionally `--clips a.mov,b.mov`). See analyze-video Step 2.
 - Migrations: every time you read a library.yaml, check its schema against `templates/library_template.yaml`. If anything's missing or renamed, run `ruby lib/buttercut/library.rb migrate` to migrate all libraries at once. See AGENTS.md → Critical Principles for the migration trigger list.
-- Terminology: user-facing, call it "footage analysis" or "analyzing footage." Internally (library.yaml fields, file names), it's "transcription."

--- a/skills/reprocess-with-contact-sheets/SKILL.md
+++ b/skills/reprocess-with-contact-sheets/SKILL.md
@@ -42,11 +42,11 @@ One command wipes contact sheets, summaries, and legacy visual transcripts and c
 ruby lib/buttercut/library.rb <name> reset_all_except_audio_transcripts
 ```
 
-If a clip is missing its audio transcript (some libraries predate even that), the analyze-video skill's step 1 will fill it in on the next step — no special handling here.
+If a clip is missing its audio transcript (some libraries predate even that), the analyze-video skill's footage-processing step (transcripts) will fill it in on the next step — no special handling here.
 
 ## Step 5 — Re-run analysis
 
-Hand off to `skills/analyze-video/SKILL.md` end-to-end. Skip step 1 (audio transcripts) for any clip that already has `transcript` set in the snapshot; run steps 2 (contact sheets) and 3 (summaries) for every clip. Step 4 (confirm footage understanding) is still worth doing — the new summaries may surface details the old visual_transcripts missed.
+Hand off to `skills/analyze-video/SKILL.md` end-to-end. Skip the audio-transcript pass for any clip that already has `transcript` set in the snapshot; run contact sheets and summaries for every clip. The confirm-footage-understanding pass is still worth doing — the new summaries may surface details the old visual_transcripts missed.
 
 Verify readiness before reporting done:
 

--- a/skills/transcribe-audio/SKILL.md
+++ b/skills/transcribe-audio/SKILL.md
@@ -5,7 +5,7 @@ description: Transcribes video audio using WhisperX, preserving original timesta
 
 # Skill: Transcribe Audio (parent brief)
 
-> **Note:** In the library pipeline, transcription runs mechanically via `ruby lib/buttercut/process_footage.rb transcripts <library>` (using `TranscribeJob`), not by dispatching this sub-agent — so footage analysis comes out identical across models. The WhisperX command lives in exactly one place, `lib/buttercut/transcribe_job.rb`, which also runs standalone: `ruby lib/buttercut/transcribe_job.rb <video_path> <output_dir> <language_code> <whisper_model>`. `refine_instructions.md` remains the playbook for the separate (judgment) refinement step that `analyze-video` Step 2 dispatches.
+> **Note:** In the library pipeline, transcription runs mechanically via `ruby lib/buttercut/process_footage.rb transcripts <library>` (using `TranscribeJob`), not by dispatching this sub-agent — so footage analysis comes out identical across models. The WhisperX command lives in exactly one place, `lib/buttercut/transcribe_job.rb`, which also runs standalone: `ruby lib/buttercut/transcribe_job.rb <video_path> <output_dir> <language_code> <whisper_model>`. `refine_instructions.md` remains the playbook for the separate (judgment) refinement step that `analyze-video` Step 3 dispatches.
 
 Transcribes video audio using WhisperX and produces a clean JSON transcript with word-level timing.
 


### PR DESCRIPTION
Splits the `process-library` skill into two skills along the create/process seam:

- **`create-library`** (new): one-time settings init, gather project info (name, footage location, language, transcript proofreading), and `Library.create`. On completion it hands off to `process-library` to analyze the footage, so a new user's experience stays one continuous flow.
- **`process-library`** (rewritten): locate/resume an existing library, optionally add footage, then caffeinate → analyze-video → readiness check → backup → stop caffeinate.

`process-library` was doing two genuinely independent jobs — *creating/scaffolding* a new library and *processing footage*. They have different entry points (start a new project vs. resume/add footage/analyze) and bundling them made the skill harder to trigger precisely and longer than it needed to be. Splitting them mirrors the pattern the rest of the codebase already follows.

## Also changed

- `AGENTS.md` workflow steps: now Create Library → Process Library → Edit → Backup.
- `skills/.gitignore` allowlist: adds the shipped `create-library` skill (both the `/` and `/**` entries).