### PR TITLE
MediaTools resolution for ffmpeg/ffprobe + WhisperX version pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 /backups
 /spec/assets
 
+# Optional static binaries (ffmpeg/ffprobe) — resolved first by MediaTools
+/dependencies
+
 # Ruby
 *.gem
 .bundle/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ Writes (`add_videos`, `complete`, `update_metadata`), destructive resets, legacy
 - `skills/` - Skills for AI-powered workflow (symlinked from `.claude/skills/` so Claude Code, Codex, and other agents that read top-level `skills/` natively all find them)
 - `spec/` - RSpec test suite
 - `templates/` - Library and project templates
+- `dependencies/` - Optional static ffmpeg/ffprobe binaries (gitignored). `lib/buttercut/media_tools.rb` resolves binaries here first, then falls back to PATH.
 - `libraries/` - Working directory for user's video projects (gitignored)
 - `libraries/settings.yaml` - User settings (editor, whisper_model, backups_dir) — created from template on first library setup
 - Library backups default to `~/Documents/buttercut-video-editor-backups` (outside the repo, override with `backups_dir` in `libraries/settings.yaml`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- ffmpeg/ffprobe calls now resolve through `MediaTools`: static builds placed in the gitignored `dependencies/` directory take precedence, falling back to PATH. Nothing changes if you don't use `dependencies/` — existing installs keep their PATH ffmpeg.
+
 ## [0.7.2] - 2026-06-02
 
 Processing your footage now uses less of your account, your Mac stays awake while it works, and we've fixed a bug in Premiere files so vertical clips export to Premiere right side up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Setup now pins WhisperX to the tested combination (`whisperx==3.4.2`, `pyannote-audio==3.4.0` — matching `requirements.txt`), so fresh installs can't drift onto untested releases (`pyannote-audio` 4.x breaks whisperx 3.4.2).
 - ffmpeg/ffprobe calls now resolve through `MediaTools`: static builds placed in the gitignored `dependencies/` directory take precedence, falling back to PATH. Nothing changes if you don't use `dependencies/` — existing installs keep their PATH ffmpeg.
 
 ## [0.7.2] - 2026-06-02

--- a/lib/buttercut/contact_sheet.rb
+++ b/lib/buttercut/contact_sheet.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'english'
+require 'English'
 require 'json'
 require 'optparse'
 require 'shellwords'

--- a/lib/buttercut/contact_sheet.rb
+++ b/lib/buttercut/contact_sheet.rb
@@ -5,6 +5,7 @@ require 'English'
 require 'json'
 require 'optparse'
 require 'shellwords'
+require_relative 'media_tools'
 require_relative 'rotation_metadata'
 
 class ContactSheet
@@ -117,7 +118,7 @@ class ContactSheet
   # codec/pix_fmt for #clip_class, frame-rate fields for VFR detection, and rotation
   # (legacy `tags.rotate` or modern displaymatrix side_data) for orientation correction.
   def probe
-    cmd = "ffprobe -v error -select_streams v:0 -show_format -show_streams -of json " \
+    cmd = "#{Shellwords.escape(MediaTools.ffprobe)} -v error -select_streams v:0 -show_format -show_streams -of json " \
           "#{Shellwords.escape(@video_path)}"
     data = JSON.parse(`#{cmd}`)
     stream = (data['streams'] || []).first || {}
@@ -324,7 +325,7 @@ class ContactSheet
   end
 
   def run_ffmpeg(args)
-    full = ['ffmpeg', '-hide_banner', '-loglevel', 'error', '-nostdin', '-y'] + args
+    full = [MediaTools.ffmpeg, '-hide_banner', '-loglevel', 'error', '-nostdin', '-y'] + args
     stderr = `#{full.map { |a| Shellwords.escape(a) }.join(' ')} 2>&1 >/dev/null`
     raise "ffmpeg failed:\n  cmd: #{full.join(' ')}\n  stderr: #{stderr.strip}" unless $CHILD_STATUS.success?
 

--- a/lib/buttercut/editor_base.rb
+++ b/lib/buttercut/editor_base.rb
@@ -3,7 +3,9 @@ require 'pathname'
 require 'cgi'
 require 'json'
 require 'digest'
+require 'shellwords'
 require_relative 'rotation_metadata'
+require_relative 'media_tools'
 
 class ButterCut
   # Shared functionality for editor-specific generators.
@@ -440,7 +442,7 @@ class ButterCut
     protected
 
     def extract_metadata_from_ffprobe(video_path)
-      json_output = `ffprobe -v quiet -print_format json -show_format -show_streams "#{video_path}" 2>&1`
+      json_output = `#{Shellwords.escape(MediaTools.ffprobe)} -v quiet -print_format json -show_format -show_streams "#{video_path}" 2>&1`
 
       if $?.exitstatus != 0
         raise "Failed to extract metadata from #{video_path}: #{json_output}"

--- a/lib/buttercut/library.rb
+++ b/lib/buttercut/library.rb
@@ -11,6 +11,8 @@ require 'json'
 require 'shellwords'
 require 'yaml'
 
+require_relative 'media_tools'
+
 class Library
   LIBRARIES_ROOT = File.expand_path('../../libraries', __dir__)
 
@@ -128,7 +130,7 @@ class Library
   def self.filename_of(video) = File.basename(video['path'].to_s)
 
   def self.probe_duration(path)
-    output = `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 #{Shellwords.escape(path)} 2>&1`
+    output = `#{Shellwords.escape(MediaTools.ffprobe)} -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 #{Shellwords.escape(path)} 2>&1`
     raise ArgumentError, "ffprobe failed for #{path}: #{output.strip}" unless $CHILD_STATUS.success?
 
     Time.at(Float(output.strip).to_i).utc.strftime('%H:%M:%S')

--- a/lib/buttercut/media_tools.rb
+++ b/lib/buttercut/media_tools.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Resolves the ffmpeg/ffprobe binaries ButterCut shells out to. Static builds
+# may be installed into the gitignored dependencies/ directory at the repo
+# root; when a binary is there it wins over PATH, so a ButterCut folder can be
+# self-contained with no shell-profile edits for ffmpeg. Machines that rely on
+# a suitable ffmpeg on PATH (and have no dependencies/ download) keep using it
+# via the bare-name fallback.
+module MediaTools
+  DEPENDENCIES_DIR = File.expand_path('../../dependencies', __dir__)
+
+  def self.ffmpeg = resolve('ffmpeg')
+  def self.ffprobe = resolve('ffprobe')
+
+  def self.resolve(name)
+    local = File.join(DEPENDENCIES_DIR, name)
+    File.executable?(local) ? local : name
+  end
+end

--- a/lib/buttercut/transcribe_job.rb
+++ b/lib/buttercut/transcribe_job.rb
@@ -6,6 +6,7 @@ require 'fileutils'
 require 'json'
 require 'open3'
 require_relative 'job'
+require_relative 'media_tools'
 
 # Transcribe one clip's audio with WhisperX, then slim the JSON with
 # prepare_audio_script.rb. Pure mechanics — the exact commands that used to live
@@ -42,7 +43,13 @@ class TranscribeJob < Job
   # Returns true if whisperx produced a real transcript, false if it rescued a
   # silent clip by writing an empty one. Raises on any other failure.
   def run_whisperx
+    # WhisperX decodes audio by running a bare `ffmpeg` from PATH (see
+    # whisperx/audio.py load_audio), so the subprocess gets MediaTools'
+    # dependencies-first precedence via PATH — without this, installs whose
+    # only ffmpeg is the dependencies/ static build can't transcribe.
+    env = { 'PATH' => [MediaTools::DEPENDENCIES_DIR, ENV.fetch('PATH', '')].join(':') }
     output, status = Open3.capture2e(
+      env,
       'whisperx', @video_path,
       '--language', @language_code,
       '--model', @whisper_model,

--- a/skills/setup/advanced-setup.md
+++ b/skills/setup/advanced-setup.md
@@ -107,7 +107,7 @@ mkdir -p ~/.buttercut
 python3 -m venv ~/.buttercut/venv
 source ~/.buttercut/venv/bin/activate
 pip install --upgrade pip
-pip install whisperx
+pip install 'whisperx==3.4.2' 'pyannote-audio==3.4.0'
 deactivate
 
 # Create wrapper script
@@ -128,7 +128,7 @@ echo 'export PATH="$HOME/.buttercut:$PATH"' >> ~/.zshrc
 If you manage Python environments yourself and want whisperx globally available:
 
 ```bash
-pip install whisperx
+pip install 'whisperx==3.4.2' 'pyannote-audio==3.4.0'
 ```
 
 Ensure `whisperx` is in your PATH.

--- a/skills/setup/simple-setup.md
+++ b/skills/setup/simple-setup.md
@@ -160,9 +160,11 @@ fi
 
 source ~/.buttercut/venv/bin/activate
 pip install --upgrade pip
-pip install whisperx
+pip install 'whisperx==3.4.2' 'pyannote-audio==3.4.0'
 deactivate
 ```
+
+(The versions are pinned to the combination ButterCut is tested against — `pyannote-audio` 4.x breaks whisperx 3.4.2, so don't install newer versions even if pip suggests them.)
 
 ## Step 7: WhisperX Wrapper Script
 

--- a/spec/buttercut/contact_sheet_spec.rb
+++ b/spec/buttercut/contact_sheet_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe ContactSheet, 'codec coverage', :fixtures do
       sheet = build_sheet('hevc_portrait_native.mov', :portrait_native)
       output = sheet.extract
       expect(sheet.rotation).to eq(0)
-      width, height = `ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0 #{Shellwords.escape(output)}`.strip.split(',').map(&:to_i)
+      width, height = `#{Shellwords.escape(MediaTools.ffprobe)} -v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0 #{Shellwords.escape(output)}`.strip.split(',').map(&:to_i)
       expect(height).to be > width
     end
 

--- a/spec/buttercut/transcribe_job_spec.rb
+++ b/spec/buttercut/transcribe_job_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require_relative '../../lib/buttercut/transcribe_job'
+
+RSpec.describe TranscribeJob do
+  let(:job) do
+    described_class.new(
+      library_name: 'test-lib', clip: 'clip.mov',
+      video_path: '/footage/clip.mov', output_dir: '/tmp/out',
+      language_code: 'en', whisper_model: 'small'
+    )
+  end
+
+  # WhisperX resolves a bare `ffmpeg` from PATH internally, so the subprocess
+  # must see dependencies/ first — the env equivalent of MediaTools' precedence.
+  it 'runs whisperx with dependencies/ leading the subprocess PATH' do
+    captured_env = nil
+    allow(Open3).to receive(:capture2e) do |env, *|
+      captured_env = env
+      ['', instance_double(Process::Status, success?: true)]
+    end
+    allow(job).to receive(:prepare_transcript)
+
+    job.perform
+
+    expect(captured_env['PATH'].split(':').first).to eq(MediaTools::DEPENDENCIES_DIR)
+    expect(captured_env['PATH']).to include(ENV.fetch('PATH'))
+  end
+end


### PR DESCRIPTION
## Summary

Core groundwork extracted from ButterCut Pro install work.  No behavior change for existing installs.

- **New `MediaTools` module** resolves the ffmpeg/ffprobe binaries every script shells out to: a static build in the gitignored `dependencies/` directory wins over PATH, with a bare-name PATH fallback. Nothing populates `dependencies/` in this repo, so existing installs keep their PATH ffmpeg exactly as before.
- **All ffmpeg/ffprobe call sites** (`contact_sheet.rb`, `editor_base.rb`, `library.rb`, specs) migrated to `MediaTools.ffmpeg` / `MediaTools.ffprobe`.
- **`TranscribeJob` prepends `dependencies/` to the WhisperX subprocess PATH** — WhisperX decodes audio by running a bare `ffmpeg` itself (whisperx/audio.py `load_audio`), which MediaTools can't intercept; the env gives the subprocess the same precedence.
- **WhisperX install pinned** to the tested combination (`whisperx==3.4.2`, `pyannote-audio==3.4.0`, matching `requirements.txt`) instead of floating to PyPI latest — pyannote-audio 4.x breaks whisperx 3.4.2.
- `require 'English'` casing fix (lowercase only works on case-insensitive filesystems).

240 examples, 0 failures locally.