### PR TITLE
Raise a clear error when ffmpeg/ffprobe is missing everywhere

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ Writes (`add_videos`, `complete`, `update_metadata`), destructive resets, legacy
 - `skills/` - Skills for AI-powered workflow (symlinked from `.claude/skills/` so Claude Code, Codex, and other agents that read top-level `skills/` natively all find them)
 - `spec/` - RSpec test suite
 - `templates/` - Library and project templates
-- `dependencies/` - Optional static ffmpeg/ffprobe binaries (gitignored). `lib/buttercut/media_tools.rb` resolves binaries here first, then falls back to PATH.
+- `dependencies/` - Optional static ffmpeg/ffprobe binaries (gitignored). `lib/buttercut/media_tools.rb` resolves binaries here first, then falls back to PATH; if a binary is in neither place it raises a clear error pointing at the `setup` skill.
 - `libraries/` - Working directory for user's video projects (gitignored)
 - `libraries/settings.yaml` - User settings (editor, whisper_model, backups_dir) — created from template on first library setup
 - Library backups default to `~/Documents/buttercut-video-editor-backups` (outside the repo, override with `backups_dir` in `libraries/settings.yaml`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- A missing ffmpeg/ffprobe now fails fast with a clear "run the setup skill" error instead of a cryptic command-not-found buried in subprocess output. The contact-sheet skill's repair instructions point at the `setup` skill accordingly.
 - Setup now pins WhisperX to the tested combination (`whisperx==3.4.2`, `pyannote-audio==3.4.0` — matching `requirements.txt`), so fresh installs can't drift onto untested releases (`pyannote-audio` 4.x breaks whisperx 3.4.2).
 - ffmpeg/ffprobe calls now resolve through `MediaTools`: static builds placed in the gitignored `dependencies/` directory take precedence, falling back to PATH. Nothing changes if you don't use `dependencies/` — existing installs keep their PATH ffmpeg.
 

--- a/lib/buttercut/media_tools.rb
+++ b/lib/buttercut/media_tools.rb
@@ -5,8 +5,12 @@
 # root; when a binary is there it wins over PATH, so a ButterCut folder can be
 # self-contained with no shell-profile edits for ffmpeg. Machines that rely on
 # a suitable ffmpeg on PATH (and have no dependencies/ download) keep using it
-# via the bare-name fallback.
+# via the bare-name fallback. When a binary is in neither place, resolution
+# raises MissingBinary up front — a clear "run the setup skill" instead of a
+# cryptic command-not-found buried in subprocess output.
 module MediaTools
+  class MissingBinary < StandardError; end
+
   DEPENDENCIES_DIR = File.expand_path('../../dependencies', __dir__)
 
   def self.ffmpeg = resolve('ffmpeg')
@@ -14,6 +18,16 @@ module MediaTools
 
   def self.resolve(name)
     local = File.join(DEPENDENCIES_DIR, name)
-    File.executable?(local) ? local : name
+    return local if File.executable?(local)
+    return name if on_path?(name)
+
+    raise MissingBinary,
+          "#{name} not found in ButterCut's dependencies/ directory or on PATH — run the setup skill to install it"
+  end
+
+  def self.on_path?(name)
+    ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).any? do |dir|
+      !dir.empty? && File.executable?(File.join(dir, name))
+    end
   end
 end

--- a/lib/buttercut/transcribe_job.rb
+++ b/lib/buttercut/transcribe_job.rb
@@ -46,7 +46,10 @@ class TranscribeJob < Job
     # WhisperX decodes audio by running a bare `ffmpeg` from PATH (see
     # whisperx/audio.py load_audio), so the subprocess gets MediaTools'
     # dependencies-first precedence via PATH — without this, installs whose
-    # only ffmpeg is the dependencies/ static build can't transcribe.
+    # only ffmpeg is the dependencies/ static build can't transcribe. The
+    # resolve call is a preflight: no ffmpeg anywhere raises MediaTools'
+    # clear error here instead of a cryptic decode failure inside whisperx.
+    MediaTools.ffmpeg
     env = { 'PATH' => [MediaTools::DEPENDENCIES_DIR, ENV.fetch('PATH', '')].join(':') }
     output, status = Open3.capture2e(
       env,

--- a/skills/contact-sheet/SKILL.md
+++ b/skills/contact-sheet/SKILL.md
@@ -9,22 +9,7 @@ Builds a contact sheet from a slice of a video clip: 16 evenly spaced frames lai
 
 ## Prerequisite: ffmpeg with drawtext
 
-This skill burns timestamps onto frames with ffmpeg's `drawtext` filter. The stock Homebrew `ffmpeg` formula frequently ships without it — runs fail with `No such filter: 'drawtext'`. If you hit that error, or want to check up front:
-
-```bash
-ffmpeg -hide_banner -filters 2>/dev/null | grep ' drawtext '
-```
-
-If nothing prints, replace ffmpeg with the full build from the `homebrew-ffmpeg/ffmpeg` tap so it becomes the only ffmpeg on the machine through brew:
-
-```bash
-brew list ffmpeg >/dev/null 2>&1 && brew uninstall --ignore-dependencies ffmpeg || true
-brew tap homebrew-ffmpeg/ffmpeg
-brew install homebrew-ffmpeg/ffmpeg/ffmpeg
-brew link --overwrite homebrew-ffmpeg/ffmpeg/ffmpeg
-```
-
-Re-run the grep above to confirm `drawtext` is present, then retry the contact sheet.
+This skill burns timestamps onto frames with ffmpeg's `drawtext` filter. ButterCut resolves ffmpeg from the repo's `dependencies/` directory first, then PATH, and raises a clear error when it's in neither place. If a run fails with that missing-ffmpeg error, or with `No such filter: 'drawtext'` (some PATH builds, notably the stock Homebrew formula, omit drawtext), run the `setup` skill to install a suitable ffmpeg, then retry the contact sheet.
 
 ## Run
 

--- a/spec/buttercut/media_tools_spec.rb
+++ b/spec/buttercut/media_tools_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+require_relative '../../lib/buttercut/media_tools'
+
+RSpec.describe MediaTools do
+  before do
+    @root = Dir.mktmpdir('bc-media-tools')
+    @deps_dir = File.join(@root, 'dependencies')
+    @path_dir = File.join(@root, 'bin')
+    Dir.mkdir(@deps_dir)
+    Dir.mkdir(@path_dir)
+    stub_const('MediaTools::DEPENDENCIES_DIR', @deps_dir)
+
+    @original_path = ENV['PATH']
+    ENV['PATH'] = @path_dir
+  end
+
+  after do
+    ENV['PATH'] = @original_path
+    FileUtils.remove_entry(@root)
+  end
+
+  def install(dir, name)
+    path = File.join(dir, name)
+    File.write(path, "#!/bin/sh\n")
+    File.chmod(0o755, path)
+    path
+  end
+
+  it 'prefers an executable in dependencies/ over PATH' do
+    local = install(@deps_dir, 'ffmpeg')
+    install(@path_dir, 'ffmpeg')
+
+    expect(MediaTools.ffmpeg).to eq(local)
+  end
+
+  it 'falls back to the bare name when the binary is only on PATH' do
+    install(@path_dir, 'ffprobe')
+
+    expect(MediaTools.ffprobe).to eq('ffprobe')
+  end
+
+  it 'raises MissingBinary pointing at setup when the binary is nowhere' do
+    expect { MediaTools.ffmpeg }
+      .to raise_error(MediaTools::MissingBinary, /ffmpeg.*setup skill/)
+  end
+
+  it 'ignores a non-executable file in dependencies/' do
+    File.write(File.join(@deps_dir, 'ffmpeg'), '')
+    install(@path_dir, 'ffmpeg')
+
+    expect(MediaTools.ffmpeg).to eq('ffmpeg')
+  end
+end


### PR DESCRIPTION
Follow-up to #103.

- `MediaTools.resolve` raises `MissingBinary` ("run the setup skill to install it") when a binary is in neither `dependencies/` nor on PATH — previously it returned the bare name and the failure surfaced later as a cryptic command-not-found.
- `TranscribeJob` preflights via `MediaTools.ffmpeg` so a missing ffmpeg raises the clear error instead of an opaque decode failure inside WhisperX (which shells out to ffmpeg itself).
- The contact-sheet skill's repair instructions shrink to "run the setup skill" — edition-neutral, so the file no longer needs to diverge in ButterCut Pro.

244 examples, 0 failures.