### PR TITLE
Add image support to libraries (videos: → media:)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,11 +42,16 @@ Known migration triggers (match each to a `scripts/NNN_migrate_*.rb` script via 
 - video entries with `summary` missing (added in 0.5.0; missing means "todo", default to empty string)
 - video entries with `transcript_path` / `visual_transcript_path` (renamed to `transcript` / `visual_transcript` in 0.3.0)
 - video entries with `file_size_mb` (removed in 0.3.0)
+- top-level `videos:` key present (renamed to `media:` in 0.8.0, when libraries gained image support). The rename of that one key is the whole migration — every pre-existing entry is a video by definition (type is inferred from the file extension). `Library` refuses to load a `videos:`-keyed library and tells you to migrate, so this trigger is impossible to miss.
 - library has a `roughcuts/` directory (renamed to `cuts/` when the `roughcut` skill became `cut`). This trigger is layout, not YAML — check the directory listing, not the schema.
 
 A missing field is not the same as a field set to the template default — the template default only applies to freshly created libraries. If you see a schema issue not on this list, still check CHANGELOG.md; the list may be behind. After running migrations, re-read the library.yaml and continue with whatever the user asked for.
 
 **`visual_transcript` is deprecated for new analysis.** Don't generate them on new libraries — `transcript` + `contact_sheet` + `summary` is the current pipeline. Dialogue is extracted from the audio transcript JSON on demand via `ruby lib/buttercut/script_extractor.rb <transcript>`; there is no separate script file on disk. Older libraries may still carry `visual_transcript` entries with matching `transcripts/visual_*.json` files; those are fine to use as additional planning context where they exist.
+
+**Images are first-class media.** A library's `media:` array holds videos *and* still images (photos, screenshots, title cards, graphics). The type is inferred from each file's extension — never stored — so there's nothing to set. Images are deliberately lightweight: an image entry carries only a `summary` (3–4 greppable sentences), no `transcript`, no `contact_sheet`, no `duration`. They never go through WhisperX or the contact-sheet pipeline (`pending`/`ready?`/`complete!` only ever hand the processing jobs videos). In a cut, an image is a clip with a `duration:` (the export defaults to 5s, or `still_duration` in `libraries/settings.yaml`); on the timeline it's a held still for that long, and — because ButterCut is single-track — when you cut to a still you cut to silence unless the next clip's audio carries it. To add images to a library, use `add_media` exactly like video (`ruby lib/buttercut/library.rb <name> add_media /path/to/photo.jpg …`).
+
+**Supported media formats.** The add-media allowlist is closed and small on purpose: it's the **intersection** of what Final Cut, Premiere, and Resolve all import natively, so anything ButterCut accepts is guaranteed to open in whichever editor the library targets. Videos: `mov`, `mp4`, `mts`, `m2ts`, `mxf`, `avi`. Images: `jpg`, `jpeg`, `png`. Notable exclusions and why: `mkv`/`webm` (no native Final Cut import), `m4v` (DRM-ambiguous, spotty across editors), `braw`/`r3d`/other camera-raw (need vendor plugins), `heic`/`tiff`/`gif` (inconsistent still support). Remember container ≠ codec: a `.mov` wrapping a codec an editor can't decode still imports as offline media — the allowlist gates containers, not codecs. `add_media` (and `create`) reject an unsupported extension with a message naming the supported sets; **reads stay lenient** — a library that predates the allowlist may hold an odd extension, which reads as video so existing work isn't blocked. Surface those with `ruby lib/buttercut/library.rb <name> unsupported_media`, then offer the user the detect-tell-convert-swap path: tell them which clips are unsupported, offer to `ffmpeg`-convert each to a supported container (remux when the codec is already editor-friendly — fast, lossless; re-encode only when it isn't), `add_media` the converted file, and `remove_media` the original entry (which never touches their source file).
 
 **Read smallest first; grep the rest.** When scanning a library for candidate clips, start with the per-clip summary files in `summaries/` — they're a few paragraphs each and safe to read whole, even across 90+ clips. Contact sheet images are similarly cheap and fine to read for clips you're considering. Transcripts are the heavy ones: a single interview transcript can outweigh every summary in the library combined. Grep into them (`rg "claude code" libraries/<name>/transcripts/`) instead of reading them whole. Direct user requests ("show me transcript X") are fine — the rule is about routine scanning.
 
@@ -73,14 +78,15 @@ ruby lib/buttercut/library.rb migrate                    # runs every scripts/NN
 
 # Status (call summary when picking up a library; ready as the pre-flight before any cut)
 ruby lib/buttercut/library.rb <name> summary             # JSON: metadata + clip-completion breakdown
-ruby lib/buttercut/library.rb <name> incomplete_videos   # JSON: clips still missing artifacts, with which fields are missing
+ruby lib/buttercut/library.rb <name> incomplete_media    # JSON: clips still missing artifacts, with which fields are missing
+ruby lib/buttercut/library.rb <name> unsupported_media   # JSON: entries whose extension no editor imports natively (legacy footage to convert-and-swap)
 ruby lib/buttercut/library.rb <name> ready               # exit 0 = ready to build a cut, 1 = not. Raises if a migration script should be run.
 
 # Understand
 ruby lib/buttercut/script_extractor.rb libraries/<name>/transcripts/<clip>.json   # clean dialogue to stdout: one transcript segment per line, no timing — cheap to skim when you want to know what's said in a clip. Generally these are small, but if editing a podcast or a speech they can be longer.
 ```
 
-Writes (`add_videos`, `complete`, `update_metadata`), destructive resets, legacy cleanup, and `Library.create` via `ruby -e`: see `lib/buttercut/library.md` for full documentation.
+Writes (`add_media`, `remove_media`, `complete`, `update_metadata`), destructive resets, legacy cleanup, and `Library.create` via `ruby -e`: see `lib/buttercut/library.md` for full documentation.
 
 **Daily update-check gate.** Once a day, the first real-work `library.rb` command exits with `library: it's been over a day since ButterCut last checked for updates…`. When you see that: check GitHub (`git fetch origin main` then `git log --oneline HEAD..origin/main`); if `main` is ahead and you're in auto mode, run the `update-buttercut` skill. If you're not in auto mode, ask the user permission to update buttercut using that skill. Either way, run `ruby lib/buttercut/library.rb update_checked` to record it, then re-run your command. Discovery commands (`list`, `recent`, `exists`) are never gated.
 
@@ -107,9 +113,9 @@ Writes (`add_videos`, `complete`, `update_metadata`), destructive resets, legacy
 
 ButterCut is designed to be geared toward working with non technical people using ButterCut via a client, Claude Cowork or Claude Code.
 
-- **Input**: Array of full file paths to video files
+- **Input**: Array of full file paths to media files — videos and still images (see "Supported media formats")
 - **Output**: Working XML file ready to import into the non-technical user's video editor (Final Cut, Premiere, Resolve)
-- **Metadata Extraction**: Uses FFmpeg internally to extract video properties (duration, resolution, frame rate, audio rate, etc.)
+- **Metadata Extraction**: Uses FFmpeg internally to extract video properties (duration, resolution, frame rate, audio rate, etc.); for images only the dimensions are probed (stills are timeless)
 
 ### Vocabulary — talk like an editor, not a developer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### New & Improved
+- **Add photos to your libraries.** Libraries now hold still images (JPEG and PNG) alongside your video footage. Drop them into the same library, give them a quick summary like any clip, and use them in a cut. Add them when you create a library or to an existing one.
+- **Put stills in your cuts.** Drop a photo, screenshot, or title card into any cut and set how long it holds on screen (five seconds by default). It exports to Final Cut, Premiere, and Resolve right alongside your video, sized and placed correctly even when the photo is a different shape than your timeline.
+- **Set your timeline's frame rate and size.** A cut can now spell out the frame rate and resolution it should export at, which matters for a cut made entirely of photos (where there is no video to copy those settings from). For normal cuts nothing changes: the settings still follow your footage.
+
 ### Changed
 - A missing ffmpeg/ffprobe now fails fast with a clear "run the setup skill" error instead of a cryptic command-not-found buried in subprocess output. The contact-sheet skill's repair instructions point at the `setup` skill accordingly.
 - Setup now pins WhisperX to the tested combination (`whisperx==3.4.2`, `pyannote-audio==3.4.0` — matching `requirements.txt`), so fresh installs can't drift onto untested releases (`pyannote-audio` 4.x breaks whisperx 3.4.2).

--- a/lib/buttercut.rb
+++ b/lib/buttercut.rb
@@ -25,7 +25,10 @@ require_relative 'buttercut/premiere'
 class ButterCut
   SUPPORTED_EDITORS = [:fcpx, :resolve, :premiere].freeze
 
-  def self.new(clips, editor:)
+  # `timeline:` is an optional explicit output format ({frame_rate:, width:,
+  # height:}, any subset) — written by the cut skill into the cut YAML and
+  # passed through Export. Without it the format follows the first video clip.
+  def self.new(clips, editor:, timeline: nil)
     raise ArgumentError, "editor: parameter is required" if editor.nil?
 
     unless SUPPORTED_EDITORS.include?(editor)
@@ -34,11 +37,11 @@ class ButterCut
 
     case editor
     when :fcpx
-      ButterCut::FCPX.new(clips)
+      ButterCut::FCPX.new(clips, timeline: timeline)
     when :resolve
-      ButterCut::Resolve.new(clips)
+      ButterCut::Resolve.new(clips, timeline: timeline)
     when :premiere
-      ButterCut::Premiere.new(clips)
+      ButterCut::Premiere.new(clips, timeline: timeline)
     else
       raise ArgumentError, "Editor #{editor.inspect} is not yet implemented."
     end

--- a/lib/buttercut/editor_base.rb
+++ b/lib/buttercut/editor_base.rb
@@ -1,11 +1,13 @@
 require 'securerandom'
 require 'pathname'
 require 'cgi'
+require 'erb'
 require 'json'
 require 'digest'
 require 'shellwords'
 require_relative 'rotation_metadata'
 require_relative 'media_tools'
+require_relative 'library'
 
 class ButterCut
   # Shared functionality for editor-specific generators.
@@ -18,7 +20,11 @@ class ButterCut
 
     attr_reader :clips, :initial_offset, :volume_adjustment
 
-    def initialize(clips)
+    # `timeline:` is an optional explicit output format (from the cut YAML's
+    # `timeline:` block): frame_rate (fraction string or number), width,
+    # height. Anything not given falls back to the first video clip, and —
+    # for image-only timelines — to 24fps 1920×1080.
+    def initialize(clips, timeline: nil)
       raise ArgumentError, "No clips provided" if clips.nil? || clips.empty?
 
       clips.each_with_index do |clip, index|
@@ -28,15 +34,19 @@ class ButterCut
         unless clip.key?(:path)
           raise ArgumentError, "Clip at index #{index} must have a 'path' key"
         end
+        if image_clip?(clip) && clip[:duration].nil?
+          raise ArgumentError, "Image clip at index #{index} (#{clip[:path]}) must have a 'duration' key — stills are timeless"
+        end
       end
 
       relative_paths = clips.select { |clip| !Pathname.new(clip[:path]).absolute? }
       unless relative_paths.empty?
         paths = relative_paths.map { |clip| clip[:path] }.join(', ')
-        raise ArgumentError, "All video file paths must be absolute paths. Relative paths found: #{paths}"
+        raise ArgumentError, "All media file paths must be absolute paths. Relative paths found: #{paths}"
       end
 
       @clips = clips
+      @timeline = normalize_timeline(timeline)
       @initial_offset = DEFAULT_INITIAL_OFFSET
       @volume_adjustment = DEFAULT_VOLUME_ADJUSTMENT
 
@@ -46,6 +56,15 @@ class ButterCut
         @metadata_cache[path] = extract_metadata_from_ffprobe(path)
       end
     end
+
+    # A clip's media type: explicit :type wins (Export sets it), otherwise
+    # inferred from the extension via the registry's one owner. Unknown
+    # extensions read as video, matching Library's lenient-read rule.
+    def clip_type(clip)
+      (clip[:type] || Library.media_type_of(clip[:path]) || 'video').to_s
+    end
+
+    def image_clip?(clip) = clip_type(clip) == 'image'
 
     def save(filename)
       File.write(filename, to_xml)
@@ -96,8 +115,10 @@ class ButterCut
       "#{denominator}/#{numerator}s"
     end
 
+    # nil when the source has no audio stream (stills, video-only recordings) —
+    # callers fall back to the 48000 default.
     def audio_sample_rate(video_path)
-      audio_stream(video_path)['sample_rate']
+      audio_stream(video_path)&.fetch('sample_rate', nil)
     end
 
     def nominal_frame_rate(video_path)
@@ -208,32 +229,71 @@ class ButterCut
       "#{duration_num / divisor}/#{duration_denom / divisor}s"
     end
 
+    # The first video (not image) clip on the timeline — the source the output
+    # format is derived from when the cut YAML doesn't pin one explicitly.
+    # nil for image-only timelines.
+    def first_video_path
+      @first_video_path ||= @clips.find { |clip| !image_clip?(clip) }&.fetch(:path)
+    end
+
+    # Output format resolution, three tiers: explicit `timeline:` block from
+    # the cut YAML → first video clip → image-only defaults (24fps, 1920×1080,
+    # 48kHz). The cut skill is supposed to always write the block for
+    # image-only cuts, so the last tier is a safety net, not a policy.
     def format_width
-      video_width(@clips.first[:path])
+      @timeline[:width] || source_format_width
     end
 
     def format_height
-      video_height(@clips.first[:path])
+      @timeline[:height] || source_format_height
     end
 
-    def format_frame_duration
-      frame_duration(@clips.first[:path])
+    def source_format_width
+      first_video_path ? video_width(first_video_path) : 1920
+    end
+
+    def source_format_height
+      first_video_path ? video_height(first_video_path) : 1080
     end
 
     def format_frame_rate
-      frame_rate(@clips.first[:path])
+      @timeline[:frame_rate] || (first_video_path ? frame_rate(first_video_path) : '24/1')
+    end
+
+    def format_frame_duration
+      numerator, denominator = format_frame_rate.split('/').map(&:to_i)
+      "#{denominator}/#{numerator}s"
     end
 
     def format_nominal_frame_rate
-      nominal_frame_rate(@clips.first[:path])
+      rate_num, rate_denom = format_frame_rate.split('/').map(&:to_i)
+      return 0 if rate_denom.zero?
+
+      (rate_num.to_f / rate_denom).round
     end
 
     def format_color_space
-      color_space(@clips.first[:path])
+      color_space(first_video_path)
     end
 
     def format_audio_rate
-      audio_sample_rate(@clips.first[:path])
+      (first_video_path && audio_sample_rate(first_video_path)) || '48000'
+    end
+
+    # Accept a frame rate as a fraction string ("30000/1001"), an integer, or
+    # the conventional NTSC decimals (23.976/29.97/59.94) and normalize to the
+    # exact fraction every internal computation expects.
+    def self.frame_rate_fraction(value)
+      str = value.to_s.strip
+      return str if str.include?('/')
+
+      rate = Float(str)
+      { 23.976 => '24000/1001', 29.97 => '30000/1001', 59.94 => '60000/1001' }.each do |decimal, fraction|
+        return fraction if (rate - decimal).abs < 0.005
+      end
+      raise ArgumentError, "frame_rate must be a whole number, an NTSC rate, or a fraction; got #{value.inspect}" unless (rate - rate.round).abs < 0.001
+
+      "#{rate.round}/1"
     end
 
     # Greatest Common Divisor (GCD): the largest whole number that divides two
@@ -343,9 +403,14 @@ class ButterCut
       File.expand_path(path)
     end
 
+    # RFC 2396/3986 file URL: every path segment percent-encoded (UTF-8 bytes,
+    # spaces, parens, #, &, …), slashes preserved. Editors resolve `src` /
+    # `pathurl` strictly — a single unescaped reserved character imports as
+    # offline ("missing") media.
     def path_to_file_url(path)
       abs_path = get_absolute_path(path)
-      "file://#{abs_path.gsub(' ', '%20')}"
+      encoded = abs_path.split('/', -1).map { |segment| ERB::Util.url_encode(segment) }.join('/')
+      "file://#{encoded}"
     end
 
     def escape_xml(str)
@@ -353,35 +418,42 @@ class ButterCut
       CGI.escapeHTML(str).gsub("&#39;", "&apos;")
     end
 
+    # One asset record per unique source file. Stills are timeless: only
+    # dimensions are probed — no duration, audio rate, timecode, frame rate,
+    # or rotation keys at all (generators branch on :type).
     def build_asset_map
       file_to_asset = {}
       @clips.each do |clip_def|
-        video_file_path = clip_def[:path]
-        abs_path = get_absolute_path(video_file_path)
+        media_file_path = clip_def[:path]
+        abs_path = get_absolute_path(media_file_path)
         next if file_to_asset.key?(abs_path)
 
-        asset_id = deterministic_asset_id(abs_path)
-        asset_uid = deterministic_asset_uid(abs_path)
-        filename = get_filename(video_file_path)
-        file_url = path_to_file_url(video_file_path)
-
-        file_to_asset[abs_path] = {
-          asset_id: asset_id,
-          asset_uid: asset_uid,
+        filename = get_filename(media_file_path)
+        asset = {
+          asset_id: deterministic_asset_id(abs_path),
+          asset_uid: deterministic_asset_uid(abs_path),
           abs_path: abs_path,
           filename: filename,
           basename: get_basename(filename),
-          file_url: file_url,
-          asset_duration: duration_to_fraction(video_file_path),
-          audio_rate: audio_sample_rate(video_file_path),
-          timecode: clip_timecode_fraction(video_file_path),
-          frame_duration: frame_duration(video_file_path),
-          frame_rate: frame_rate(video_file_path),
-          width: video_width(video_file_path),
-          height: video_height(video_file_path),
-          rotation: video_rotation(video_file_path),
-          color_space: color_space(video_file_path)
+          file_url: path_to_file_url(media_file_path),
+          type: clip_type(clip_def),
+          width: video_width(media_file_path),
+          height: video_height(media_file_path)
         }
+
+        if asset[:type] != 'image'
+          asset.merge!(
+            asset_duration: duration_to_fraction(media_file_path),
+            audio_rate: audio_sample_rate(media_file_path),
+            timecode: clip_timecode_fraction(media_file_path),
+            frame_duration: frame_duration(media_file_path),
+            frame_rate: frame_rate(media_file_path),
+            rotation: video_rotation(media_file_path),
+            color_space: color_space(media_file_path)
+          )
+        end
+
+        file_to_asset[abs_path] = asset
       end
       file_to_asset
     end
@@ -440,6 +512,19 @@ class ButterCut
     end
 
     protected
+
+    def normalize_timeline(timeline)
+      return {} if timeline.nil?
+
+      normalized = {}
+      frame_rate = timeline[:frame_rate] || timeline['frame_rate']
+      normalized[:frame_rate] = self.class.frame_rate_fraction(frame_rate) if frame_rate
+      width = timeline[:width] || timeline['width']
+      normalized[:width] = Integer(width) if width
+      height = timeline[:height] || timeline['height']
+      normalized[:height] = Integer(height) if height
+      normalized
+    end
 
     def extract_metadata_from_ffprobe(video_path)
       json_output = `#{Shellwords.escape(MediaTools.ffprobe)} -v quiet -print_format json -show_format -show_streams "#{video_path}" 2>&1`

--- a/lib/buttercut/export.rb
+++ b/lib/buttercut/export.rb
@@ -27,13 +27,15 @@ class Export
     @editor        = resolve_editor(editor.to_s)
   end
 
+  DEFAULT_STILL_DURATION = 5.0 # seconds; overridable per cut and via libraries/settings.yaml still_duration
+
   def perform
     roughcut    = load_yaml(@roughcut_path)
     library     = load_library(@roughcut_path)
-    video_paths = index_video_paths(library)
-    clips       = build_clips(roughcut, video_paths)
+    media_paths = index_media_paths(library)
+    clips       = build_clips(roughcut, media_paths)
 
-    write_xml(clips, @editor)
+    write_xml(clips, @editor, roughcut['timeline'])
     validate_fcpxml(@output_path) if @editor == :fcpx
     @output_path
   end
@@ -56,32 +58,61 @@ class Export
     load_yaml(library_yaml)
   end
 
-  def index_video_paths(library)
-    library['videos'].each_with_object({}) do |video, map|
-      map[File.basename(video['path'])] = video['path']
+  def index_media_paths(library)
+    library['media'].each_with_object({}) do |media, map|
+      map[File.basename(media['path'])] = media['path']
     end
   end
 
-  def build_clips(roughcut, video_paths)
+  def build_clips(roughcut, media_paths)
     roughcut['clips'].filter_map do |clip|
       source = clip['source_file']
-      path   = video_paths[source]
+      path   = media_paths[source]
 
       unless path
         warn "Warning: Source file not found in library data: #{source}"
         next
       end
 
-      start_at = timecode_to_seconds(clip['in_point'])
-      duration = timecode_to_seconds(clip['out_point']) - start_at
+      type = Library.media_type_of(path)
+      if type.nil?
+        warn "Warning: #{source} is outside the supported formats — the editor may import it as missing media. " \
+             'See "Supported media formats" in AGENTS.md.'
+        type = 'video'
+      end
 
-      { path: path, start_at: start_at.to_f, duration: duration.to_f }
+      if type == 'image'
+        duration = clip['duration'] ? timecode_to_seconds(clip['duration']) : still_duration_default
+        { path: path, type: :image, duration: duration.to_f }
+      else
+        start_at = timecode_to_seconds(clip['in_point'])
+        duration = timecode_to_seconds(clip['out_point']) - start_at
+
+        { path: path, type: :video, start_at: start_at.to_f, duration: duration.to_f }
+      end
     end
   end
 
-  # Accepts HH:MM:SS or HH:MM:SS.s
+  # Per-cut `duration:` wins (handled in build_clips); this is the fallback —
+  # `still_duration` from libraries/settings.yaml, else 5 seconds.
+  def still_duration_default
+    settings_path = 'libraries/settings.yaml'
+    if File.exist?(settings_path)
+      settings = YAML.safe_load_file(settings_path, permitted_classes: [Date, Time]) || {}
+      configured = settings['still_duration']
+      return configured.to_f if configured && configured.to_f.positive?
+    end
+    DEFAULT_STILL_DURATION
+  end
+
+  # Accepts HH:MM:SS or HH:MM:SS.s (also bare numeric seconds, e.g. an
+  # image clip's `duration: 5`).
   def timecode_to_seconds(timecode)
+    return timecode.to_f if timecode.is_a?(Numeric)
+
     hours, minutes, seconds = timecode.split(':')
+    return hours.to_f if minutes.nil?
+
     hours.to_i * 3600 + minutes.to_i * 60 + seconds.to_f
   end
 
@@ -92,9 +123,9 @@ class Export
     raise ArgumentError, "Unknown editor '#{input}'. Use 'fcpx', 'premiere', or 'resolve'"
   end
 
-  def write_xml(clips, editor)
+  def write_xml(clips, editor, timeline)
     puts "Converting #{clips.length} clips to #{EDITOR_LABELS.fetch(editor)}..."
-    ButterCut.new(clips, editor: editor).save(@output_path)
+    ButterCut.new(clips, editor: editor, timeline: timeline).save(@output_path)
     puts "\n✓ Rough cut exported to: #{@output_path}"
   end
 

--- a/lib/buttercut/export.rb
+++ b/lib/buttercut/export.rb
@@ -27,8 +27,6 @@ class Export
     @editor        = resolve_editor(editor.to_s)
   end
 
-  DEFAULT_STILL_DURATION = 5.0 # seconds; overridable per cut and via libraries/settings.yaml still_duration
-
   def perform
     roughcut    = load_yaml(@roughcut_path)
     library     = load_library(@roughcut_path)
@@ -82,7 +80,9 @@ class Export
       end
 
       if type == 'image'
-        duration = clip['duration'] ? timecode_to_seconds(clip['duration']) : still_duration_default
+        raise "Image clip '#{source}' is missing a required 'duration:' field." unless clip['duration']
+
+        duration = timecode_to_seconds(clip['duration'])
         { path: path, type: :image, duration: duration.to_f }
       else
         start_at = timecode_to_seconds(clip['in_point'])
@@ -91,18 +91,6 @@ class Export
         { path: path, type: :video, start_at: start_at.to_f, duration: duration.to_f }
       end
     end
-  end
-
-  # Per-cut `duration:` wins (handled in build_clips); this is the fallback —
-  # `still_duration` from libraries/settings.yaml, else 5 seconds.
-  def still_duration_default
-    settings_path = 'libraries/settings.yaml'
-    if File.exist?(settings_path)
-      settings = YAML.safe_load_file(settings_path, permitted_classes: [Date, Time]) || {}
-      configured = settings['still_duration']
-      return configured.to_f if configured && configured.to_f.positive?
-    end
-    DEFAULT_STILL_DURATION
   end
 
   # Accepts HH:MM:SS or HH:MM:SS.s (also bare numeric seconds, e.g. an

--- a/lib/buttercut/fcp7.rb
+++ b/lib/buttercut/fcp7.rb
@@ -25,7 +25,8 @@ class ButterCut
       first_path = clips.first[:path]
       sequence_name = "#{get_basename(get_filename(first_path))} #{timestamp_suffix}"
 
-      clip_payloads = build_clip_payloads(timeline_clips, timeline_frame_duration)
+      sequence_rate = { timebase: timebase, ntsc: ntsc_flag, display: display_format }
+      clip_payloads = build_clip_payloads(timeline_clips, timeline_frame_duration, sequence_rate)
       sequence_audio_rate = format_audio_rate || '48000'
 
       builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
@@ -80,7 +81,7 @@ class ButterCut
                 end
                 xml.track do
                   clip_payloads.each do |payload|
-                    build_audio_clipitem(xml, payload)
+                    build_audio_clipitem(xml, payload) unless payload[:still]
                   end
                 end
               end
@@ -98,49 +99,69 @@ class ButterCut
       rate_denom == 1 ? 'FALSE' : 'TRUE'
     end
 
-    def build_clip_payloads(timeline_clips, timeline_frame_duration)
+    def build_clip_payloads(timeline_clips, timeline_frame_duration, sequence_rate)
+      audio_index = 0
       timeline_clips.each_with_index.map do |clip, index|
         asset = clip[:asset]
-        asset_rate_num, asset_rate_denom = asset[:frame_rate].split('/').map(&:to_i)
-        asset_timebase = (asset_rate_num.to_f / asset_rate_denom).round
-        asset_ntsc = ntsc_flag_for(asset_rate_denom)
-        asset_display = ntsc_drop_frame_rate?(asset_rate_num, asset_rate_denom) ? 'DF' : 'NDF'
+        still = asset[:type] == 'image'
 
         timeline_duration_frames = frames_for_fraction(clip[:duration], timeline_frame_duration)
         timeline_start_frames = frames_for_fraction(clip[:timeline_offset], timeline_frame_duration)
         timeline_end_frames = timeline_start_frames + timeline_duration_frames
 
-        source_in_frames = frames_for_fraction(clip[:source_in], asset[:frame_duration])
-        source_duration_frames = frames_for_fraction(clip[:source_duration], asset[:frame_duration])
-        source_out_frames = source_in_frames + source_duration_frames
-
-        asset_duration_frames = frames_for_fraction(asset[:asset_duration], asset[:frame_duration])
-        asset_timecode_start = frames_for_fraction(asset[:timecode], asset[:frame_duration])
-
-        {
+        payload = {
           index: index + 1,
+          still: still,
           clip: clip,
           asset: asset,
           video_clip_id: "clipitem-video-#{index + 1}",
-          audio_clip_id: "clipitem-audio-#{index + 1}",
           file_id: "file-#{asset[:asset_id]}",
           timeline_start: timeline_start_frames,
           timeline_end: timeline_end_frames,
-          timeline_duration: timeline_duration_frames,
-          source_in: source_in_frames,
-          source_out: source_out_frames,
-          source_duration_frames: source_duration_frames,
-          asset_timebase: asset_timebase,
-          asset_ntsc: asset_ntsc,
-          asset_display: asset_display,
-          asset_duration_frames: asset_duration_frames,
-          asset_timecode_start: asset_timecode_start
+          timeline_duration: timeline_duration_frames
         }
+
+        if still
+          # Stills have no native rate or timecode: the file adopts the
+          # sequence rate, in/out span the timeline duration, and the file
+          # duration matches the cut (settled empirically in the editors).
+          payload.merge!(
+            asset_timebase: sequence_rate[:timebase],
+            asset_ntsc: sequence_rate[:ntsc],
+            asset_display: sequence_rate[:display],
+            source_in: 0,
+            source_out: timeline_duration_frames,
+            source_duration_frames: timeline_duration_frames,
+            asset_duration_frames: timeline_duration_frames,
+            asset_timecode_start: 0
+          )
+        else
+          asset_rate_num, asset_rate_denom = asset[:frame_rate].split('/').map(&:to_i)
+          source_in_frames = frames_for_fraction(clip[:source_in], asset[:frame_duration])
+          source_duration_frames = frames_for_fraction(clip[:source_duration], asset[:frame_duration])
+          audio_index += 1
+
+          payload.merge!(
+            audio_clip_id: "clipitem-audio-#{index + 1}",
+            audio_index: audio_index,
+            asset_timebase: (asset_rate_num.to_f / asset_rate_denom).round,
+            asset_ntsc: ntsc_flag_for(asset_rate_denom),
+            asset_display: ntsc_drop_frame_rate?(asset_rate_num, asset_rate_denom) ? 'DF' : 'NDF',
+            source_in: source_in_frames,
+            source_out: source_in_frames + source_duration_frames,
+            source_duration_frames: source_duration_frames,
+            asset_duration_frames: frames_for_fraction(asset[:asset_duration], asset[:frame_duration]),
+            asset_timecode_start: frames_for_fraction(asset[:timecode], asset[:frame_duration])
+          )
+        end
+
+        payload
       end
     end
 
     def build_video_clipitem(xml, payload)
       asset = payload[:asset]
+      still = payload[:still]
 
       xml.clipitem(id: payload[:video_clip_id]) do
         xml.name asset[:basename]
@@ -150,6 +171,10 @@ class ButterCut
         xml.end_ payload[:timeline_end]
         xml.in_ payload[:source_in]
         xml.out payload[:source_out]
+        # Documented still marker: "Photoshop PSD files, jpeg files, tiff
+        # files, or other still images imported into Final Cut have
+        # stillframe set to TRUE."
+        xml.stillframe 'TRUE' if still
         xml.file(id: payload[:file_id]) do
           xml.name asset[:filename]
           xml.pathurl asset[:file_url]
@@ -158,13 +183,15 @@ class ButterCut
             xml.ntsc payload[:asset_ntsc]
           end
           xml.duration payload[:asset_duration_frames]
-          xml.timecode do
-            xml.rate do
-              xml.timebase payload[:asset_timebase]
-              xml.ntsc payload[:asset_ntsc]
+          unless still
+            xml.timecode do
+              xml.rate do
+                xml.timebase payload[:asset_timebase]
+                xml.ntsc payload[:asset_ntsc]
+              end
+              xml.frame payload[:asset_timecode_start]
+              xml.displayformat payload[:asset_display]
             end
-            xml.frame payload[:asset_timecode_start]
-            xml.displayformat payload[:asset_display]
           end
           xml.media do
             xml.video do
@@ -180,10 +207,12 @@ class ButterCut
                 xml.fielddominance 'none'
               end
             end
-            xml.audio do
-              xml.samplecharacteristics do
-                xml.samplerate asset_audio_rate(asset)
-                xml.sampledepth 16
+            unless still
+              xml.audio do
+                xml.samplecharacteristics do
+                  xml.samplerate asset_audio_rate(asset)
+                  xml.sampledepth 16
+                end
               end
             end
           end
@@ -195,7 +224,8 @@ class ButterCut
           xml.mediatype 'video'
           xml.trackindex 1
         end
-        build_link_entries(xml, payload)
+        # Stills have no audio counterpart to link to.
+        build_link_entries(xml, payload) unless still
       end
     end
 
@@ -241,6 +271,9 @@ class ButterCut
       end
     end
 
+    # clipindex is the clip's position within its own track: the video track
+    # holds every clip (stills included), the audio track only the clips with
+    # sound — hence the separate audio_index counter.
     def build_link_entries(xml, payload)
       xml.link do
         xml.linkclipref payload[:video_clip_id]
@@ -252,7 +285,7 @@ class ButterCut
         xml.linkclipref payload[:audio_clip_id]
         xml.mediatype 'audio'
         xml.trackindex 1
-        xml.clipindex payload[:index]
+        xml.clipindex payload[:audio_index]
         xml.groupindex 1
       end
     end

--- a/lib/buttercut/fcpx.rb
+++ b/lib/buttercut/fcpx.rb
@@ -21,6 +21,8 @@ class ButterCut
       project_basename = get_basename(first_filename)
       timestamped_project_name = "#{project_basename} #{timestamp_suffix}"
 
+      still_format_ids = build_still_format_ids(asset_map)
+
       builder = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
         xml.fcpxml(version: '1.8') do
           xml.resources do
@@ -32,19 +34,45 @@ class ButterCut
               colorSpace: format_color_space
             )
 
-            asset_map.each_value do |asset|
-              xml.asset(
-                id: asset[:asset_id],
-                name: asset[:filename],
-                uid: asset[:asset_uid],
-                src: asset[:file_url],
-                start: asset[:timecode],
-                audioRate: asset[:audio_rate],
-                hasAudio: '1',
-                hasVideo: '1',
-                format: FORMAT_ID,
-                duration: asset[:asset_duration]
+            # Stills use a rate-undefined format (one per unique dimensions):
+            # no frameDuration — that's what marks the asset as timeless.
+            still_format_ids.each do |(width, height), format_id|
+              xml.format(
+                id: format_id,
+                name: 'FFVideoFormatRateUndefined',
+                width: width,
+                height: height
               )
+            end
+
+            asset_map.each_value do |asset|
+              if asset[:type] == 'image'
+                # Timeless still: duration/start pinned to 0s, video only —
+                # no audio attributes at all.
+                xml.asset(
+                  id: asset[:asset_id],
+                  name: asset[:filename],
+                  uid: asset[:asset_uid],
+                  src: asset[:file_url],
+                  start: '0s',
+                  duration: '0s',
+                  hasVideo: '1',
+                  format: still_format_ids.fetch([asset[:width], asset[:height]])
+                )
+              else
+                xml.asset(
+                  id: asset[:asset_id],
+                  name: asset[:filename],
+                  uid: asset[:asset_uid],
+                  src: asset[:file_url],
+                  start: asset[:timecode],
+                  audioRate: asset[:audio_rate],
+                  hasAudio: '1',
+                  hasVideo: '1',
+                  format: FORMAT_ID,
+                  duration: asset[:asset_duration]
+                )
+              end
             end
           end
 
@@ -54,15 +82,29 @@ class ButterCut
                 xml.sequence(duration: sequence_duration, format: FORMAT_ID, tcStart: '0s', audioRate: '48k') do
                   xml.spine do
                     timeline_clips.each do |clip|
-                      xml.send('asset-clip',
-                        name: clip[:filename],
-                        ref: clip[:asset_id],
-                        start: clip[:start],
-                        offset: clip[:timeline_offset],
-                        duration: clip[:duration],
-                        audioRole: 'dialogue'
-                      ) do
-                        xml.send('adjust-volume', amount: volume_adjustment)
+                      if clip[:asset][:type] == 'image'
+                        # Stills go on the spine as <video>, not <asset-clip>:
+                        # an asset-clip's duration defaults to the asset's,
+                        # which is 0s for a timeless still. No audio → no
+                        # adjust-volume child.
+                        xml.video(
+                          name: clip[:filename],
+                          ref: clip[:asset_id],
+                          start: '0s',
+                          offset: clip[:timeline_offset],
+                          duration: clip[:duration]
+                        )
+                      else
+                        xml.send('asset-clip',
+                          name: clip[:filename],
+                          ref: clip[:asset_id],
+                          start: clip[:start],
+                          offset: clip[:timeline_offset],
+                          duration: clip[:duration],
+                          audioRole: 'dialogue'
+                        ) do
+                          xml.send('adjust-volume', amount: volume_adjustment)
+                        end
                       end
                     end
                   end
@@ -74,6 +116,19 @@ class ButterCut
       end
 
       builder.to_xml
+    end
+
+    private
+
+    # One rate-undefined format resource per unique still dimensions, keyed
+    # [width, height] → format id.
+    def build_still_format_ids(asset_map)
+      asset_map.each_value.with_object({}) do |asset, ids|
+        next unless asset[:type] == 'image'
+
+        key = [asset[:width], asset[:height]]
+        ids[key] ||= "r_still_#{asset[:width]}x#{asset[:height]}"
+      end
     end
   end
 end

--- a/lib/buttercut/footage_processor.rb
+++ b/lib/buttercut/footage_processor.rb
@@ -97,7 +97,7 @@ class FootageProcessor
   def validate_clips!
     return unless @clips
 
-    known = @library.videos.map { |v| File.basename(v['path'].to_s) }
+    known = @library.media.map { |m| File.basename(m['path'].to_s) }
     unknown = @clips - known
     raise "clip(s) not in library: #{unknown.join(', ')}" unless unknown.empty?
   end

--- a/lib/buttercut/full_transcript.rb
+++ b/lib/buttercut/full_transcript.rb
@@ -22,7 +22,9 @@ class FullTranscript
 
   def export
     library = load_library
-    videos = library['videos'] || []
+    # Images have no transcript key, so they fall into the skipped count
+    # naturally — only spoken footage lands in the export.
+    videos = library['media'] || []
 
     lines = []
     skipped = 0

--- a/lib/buttercut/library.md
+++ b/lib/buttercut/library.md
@@ -15,11 +15,30 @@ ruby lib/buttercut/library.rb <library_name> <action> [args...]
   Only write to library when handling edge cases or failed migrations. 99
   percent of the time the library class should provide what you need.
 
+## Media types
+
+A library's `media:` array holds two kinds of entry, keyed by file extension
+(the type is inferred, never stored). The `MEDIA_TYPES` registry at the top of
+`library.rb` is the single owner of what's accepted and which fields apply:
+
+| Type    | Extensions                         | Per-clip fields                      | Duration probed? |
+|---------|------------------------------------|--------------------------------------|------------------|
+| `video` | `mov mp4 mts m2ts mxf avi`         | `transcript`, `contact_sheet`, `summary` | yes          |
+| `image` | `jpg jpeg png`                     | `summary` only                       | no               |
+
+The extension sets are a closed allowlist — the intersection of what Final Cut,
+Premiere, and Resolve all import natively (see "Supported media formats" in
+`AGENTS.md`). `add_media`/`create` reject anything outside it; **reads stay
+lenient** (an odd extension already in the yaml reads as video). Everything
+type-aware — `ready?`, `pending`, `incomplete_media`, `complete!`, `reset!` —
+is driven off this registry, so adding a media type is one registry entry, not a
+code audit. (ButterCut Pro extends the registry in its fork, e.g. an `audio`
+entry.)
+
 ## Fields and on-disk layout
 
-Completeness tracks three per-video fields. Each field's subdir, filename
-pattern, and orphan-sweep filter live in the `FIELDS` table at the top of
-`library.rb`:
+Each field's subdir, filename pattern, and orphan-sweep filter live in the
+`FIELDS` table at the top of `library.rb`:
 
 | Field           | Subdir            | Filename pattern    |
 |-----------------|-------------------|---------------------|
@@ -27,8 +46,15 @@ pattern, and orphan-sweep filter live in the `FIELDS` table at the top of
 | `contact_sheet` | `contact_sheets/` | `<clip>_full.jpg`   |
 | `summary`       | `summaries/`      | `summary_<clip>.md` |
 
+Artifact filenames are built from a **clip key**: for videos the extension is
+stripped (`P1055017.mov` → `P1055017`, matching every existing artifact on
+disk); for images the extension is flattened in (`DJI_0123.jpg` →
+`DJI_0123_jpg`) so a photo and a video that share a basename — common with
+drones and mirrorless stills — can't collide on artifact names.
+
 `complete` validates each batch atomically: every clip must exist in
-`library.yaml` AND its file must exist on disk before any YAML is written.
+`library.yaml` AND its file must exist on disk before any YAML is written, and
+the field must apply to the clip's type (e.g. `transcript` on an image raises).
 If any check fails the call raises and the YAML is left untouched.
 
 The audio transcript JSON is the source of truth for dialogue, and agents that
@@ -43,9 +69,10 @@ ruby lib/buttercut/library.rb list                # every library, newest first 
 ruby lib/buttercut/library.rb recent [N]          # N most recent libraries by deepest file mtime (default 10)
 ruby lib/buttercut/library.rb migrate             # run all migrations across every library (idempotent)
 ruby lib/buttercut/library.rb <name> exists       # exit 0 if it exists, 1 if not
-ruby lib/buttercut/library.rb <name> summary      # JSON: metadata + clip-completion breakdown
-ruby lib/buttercut/library.rb <name> incomplete_videos
-ruby lib/buttercut/library.rb <name> ready        # exit 0 if every video is ready for roughcut, 1 if not
+ruby lib/buttercut/library.rb <name> summary      # JSON: metadata + per-type counts + clip-completion breakdown
+ruby lib/buttercut/library.rb <name> incomplete_media
+ruby lib/buttercut/library.rb <name> unsupported_media   # JSON: entries whose extension no editor imports natively
+ruby lib/buttercut/library.rb <name> ready        # exit 0 if every clip is ready for a cut, 1 if not
 ruby lib/buttercut/library.rb update_checked      # record that you just checked GitHub for a newer ButterCut
 ```
 
@@ -55,19 +82,27 @@ user.
 
 `recent` is the right tool for "which library was the user most recently working on?" — it sees activity across `transcripts/`, `contact_sheets/`, `summaries/`, and `cuts/`, not just `library.yaml`. `list` is fine when you want the full set.
 
-`summary` is the snapshot to call when picking up a library — full metadata plus a clip-completion breakdown. `ready` is the one-shot pre-flight before building a cut: it's legacy-aware (a clip with `summary` + either `transcript` or `visual_transcript` counts as ready, even without a `contact_sheet`), so it doesn't block roughcut work on libraries that predate the contact-sheet pipeline. The roughcut sub-agent generates contact sheets on demand when it needs to see a clip.
+`summary` is the snapshot to call when picking up a library — full metadata, a `media_count` with a per-type breakdown (`video_count`, `image_count`), and a clip-completion list. `ready` is the one-shot pre-flight before building a cut: it's type- and legacy-aware (a video with `summary` + either `transcript` or `visual_transcript` counts as ready even without a `contact_sheet`; an image just needs its `summary`), so it doesn't block cut work on libraries that predate the contact-sheet pipeline. The cut sub-agent generates contact sheets on demand when it needs to see a clip.
 
 Use `summary` when you want to look at *what's* missing; use `ready` when you only need a yes/no gate.
 
 ### Add and update
 ```bash
-ruby lib/buttercut/library.rb <name> add_videos /abs/a.mov /abs/b.mov
+ruby lib/buttercut/library.rb <name> add_media    /abs/a.mov /abs/photo.jpg   # type inferred from extension
+ruby lib/buttercut/library.rb <name> remove_media a.mov                       # drop entry + its artifacts; source file untouched
 ruby lib/buttercut/library.rb <name> update_metadata footage_summary       "subjects, locations, activities"
 ruby lib/buttercut/library.rb <name> update_metadata user_context          "creative intent, characters"
 ruby lib/buttercut/library.rb <name> update_metadata language              english
 ruby lib/buttercut/library.rb <name> update_metadata editor                fcpx        # fcpx | premiere | resolve
 ruby lib/buttercut/library.rb <name> update_metadata transcript_refinement false       # true | false
 ```
+
+`add_media` appends videos and images alike — the type (and therefore which
+per-clip fields the entry gets) is inferred from each path's extension; an
+unsupported extension is rejected with a message naming the supported sets.
+`remove_media` drops an entry and deletes its artifacts (transcripts, contact
+sheets, summaries, plus any legacy visual transcript) but **never** touches the
+source footage on disk.
 
 `update_metadata` edits one field per call. Beyond the two free-text fields
 (`footage_summary`, `user_context`) it can also set the setup choices
@@ -100,7 +135,7 @@ ruby lib/buttercut/library.rb <name> remove_visual_transcripts   # legacy cleanu
 ```
 
 `reset` deletes every file in each named field's subdir and clears the
-field on every video. The `transcripts/` sweep leaves `visual_*.json`
+field on every clip that has it. The `transcripts/` sweep leaves `visual_*.json`
 alone — that's what `remove_visual_transcripts` is for.
 
 `reset_all` is a **factory reset**: on top of wiping all three artifact
@@ -108,7 +143,7 @@ fields it also clears library-level metadata — the setup choices
 (`language`, `editor`, `transcript_refinement`) and the analysis-derived
 context (`footage_summary`, `user_context`). Strings go blank and
 `transcript_refinement` goes nil ("unset"), so a re-run starts setup and
-footage analysis from scratch. Video records and dates are kept.
+footage analysis from scratch. Media records and dates are kept.
 `reset_all_except_audio_transcripts` does **not** touch metadata — it stays
 a narrow artifact reset.
 
@@ -123,5 +158,9 @@ ruby -e "require_relative 'lib/buttercut/library'; \
     language: 'en', \
     editor: 'fcpx', \
     transcript_refinement: true, \
-    video_paths: ['/abs/a.mov', '/abs/b.mov'])"
+    media_paths: ['/abs/a.mov', '/abs/photo.jpg'])"
 ```
+
+`media_paths` takes videos and images alike — each entry is scaffolded with the
+fields its type needs (videos get `transcript`/`contact_sheet`/`summary` and a
+probed duration; images get just `summary`).

--- a/lib/buttercut/library.rb
+++ b/lib/buttercut/library.rb
@@ -16,13 +16,34 @@ require_relative 'media_tools'
 class Library
   LIBRARIES_ROOT = File.expand_path('../../libraries', __dir__)
 
-  # Per-field on-disk layout. `namer` builds the filename from a clipname;
-  # `keep` is an optional regex of filenames the orphan-sweep must not delete
-  # (transcripts/ is shared with legacy visual_*.json — those stay).
+  # Per-field on-disk layout. `namer` builds the filename from a clip key
+  # (see `clip_key`); `keep` is an optional regex of filenames the
+  # orphan-sweep must not delete (transcripts/ is shared with legacy
+  # visual_*.json — those stay).
   FIELDS = {
     'transcript'    => { subdir: 'transcripts',    namer: ->(c) { "#{c}.json" },        keep: /\Avisual_/ }.freeze,
     'contact_sheet' => { subdir: 'contact_sheets', namer: ->(c) { "#{c}_full.jpg" } }.freeze,
     'summary'       => { subdir: 'summaries',      namer: ->(c) { "summary_#{c}.md" } }.freeze
+  }.freeze
+
+  # What kinds of media a library holds, keyed by file extension. `fields`
+  # names the FIELDS entries that apply to the type (everything else —
+  # ready?, pending, incomplete, complete!, reset — is driven from here, so
+  # a new type is one registry entry, not a code audit). `extensions` is a
+  # closed allowlist enforced when ADDING media; the video set is the Venn
+  # intersection of containers Final Cut, Premiere, and Resolve all import
+  # natively (see "Supported media formats" in AGENTS.md). Reads stay
+  # lenient: an already-present entry with an unrecognized extension is
+  # treated as video (`unsupported_media` surfaces those for cleanup).
+  #
+  # ButterCut Pro extends this registry (e.g. an 'audio' entry) in its fork;
+  # entries are matched in order, so additions are checked before anything
+  # else rejects.
+  MEDIA_TYPES = {
+    'video' => { fields: %w[transcript contact_sheet summary], probe_duration: true,
+                 extensions: %w[mov mp4 mts m2ts mxf avi] }.freeze,
+    'image' => { fields: %w[summary], probe_duration: false,
+                 extensions: %w[jpg jpeg png] }.freeze
   }.freeze
 
   SUBDIRS = %w[transcripts contact_sheets summaries cuts plans].freeze
@@ -86,7 +107,7 @@ class Library
        .map(&:first)
   end
 
-  def self.create(library_name, language:, editor:, transcript_refinement:, video_paths:)
+  def self.create(library_name, language:, editor:, transcript_refinement:, media_paths:)
     raise ArgumentError, 'library_name is required' if library_name.to_s.strip.empty?
 
     dir = File.join(LIBRARIES_ROOT, library_name)
@@ -103,31 +124,65 @@ class Library
       'transcript_refinement' => transcript_refinement,
       'user_context' => '',
       'footage_summary' => 'No footage analyzed yet.',
-      'videos' => Array(video_paths).map { |path| video_record(path) }
+      'media' => Array(media_paths).map { |path| media_record(path) }
     }
     File.write(File.join(dir, 'library.yaml'), payload.to_yaml)
     find(library_name)
   end
 
-  def self.video_record(path)
-    raise ArgumentError, 'video path is required' if path.to_s.strip.empty?
+  # The media type a path holds, inferred from its extension (never stored in
+  # library.yaml — like `filename`, it's fully determined by `path`, so storing
+  # it would only create a drift-able duplicate). Returns nil for extensions
+  # outside every registry set; callers decide whether that's a rejection
+  # (adding) or a video fallback (reading what's already in the yaml).
+  def self.media_type_of(path)
+    ext = File.extname(path.to_s).delete_prefix('.').downcase
+    MEDIA_TYPES.each { |type, spec| return type if spec[:extensions].include?(ext) }
+    nil
+  end
+
+  def self.fields_for(type)
+    MEDIA_TYPES.fetch(type) { raise ArgumentError, "unknown media type: #{type.inspect}" }[:fields]
+  end
+
+  def self.media_record(path)
+    raise ArgumentError, 'media path is required' if path.to_s.strip.empty?
 
     expanded = File.expand_path(path)
-    raise ArgumentError, "video file not found: #{expanded}" unless File.exist?(expanded)
+    raise ArgumentError, "media file not found: #{expanded}" unless File.exist?(expanded)
 
-    {
-      'path' => expanded,
-      'duration' => probe_duration(expanded),
-      'transcript' => '',
-      'contact_sheet' => '',
-      'summary' => ''
-    }
+    type = media_type_of(expanded)
+    raise ArgumentError, unsupported_format_message(expanded) if type.nil?
+
+    spec = MEDIA_TYPES[type]
+    record = { 'path' => expanded }
+    record['duration'] = probe_duration(expanded) if spec[:probe_duration]
+    spec[:fields].each { |field| record[field] = '' }
+    record
+  end
+
+  def self.unsupported_format_message(path)
+    sets = MEDIA_TYPES.map { |type, spec| "#{type}: #{spec[:extensions].join(', ')}" }.join('; ')
+    "unsupported media format for #{File.basename(path)}. Supported extensions — #{sets}. " \
+      'ffmpeg can convert it to a supported format — see "Supported media formats" in AGENTS.md.'
   end
 
   # The basename used everywhere to refer to a clip. Derived from the full
   # `path` and never stored in library.yaml — one owner so reads, lookups, and
-  # the `videos` reader all agree on what a clip is called.
-  def self.filename_of(video) = File.basename(video['path'].to_s)
+  # the `media` reader all agree on what a clip is called.
+  def self.filename_of(media) = File.basename(media['path'].to_s)
+
+  # The key artifact filenames are built from. Videos keep the original
+  # convention (extension stripped, matching every existing artifact on disk).
+  # Images flatten the extension in (DJI_0123.jpg → DJI_0123_jpg) so a photo
+  # and a video sharing a basename — common with drones and mirrorless stills —
+  # can't collide on artifact names.
+  def self.clip_key(filename)
+    base = File.basename(filename.to_s, '.*')
+    return base unless media_type_of(filename) == 'image'
+
+    "#{base}_#{File.extname(filename.to_s).delete_prefix('.').downcase}"
+  end
 
   def self.probe_duration(path)
     output = `#{Shellwords.escape(MediaTools.ffprobe)} -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 #{Shellwords.escape(path)} 2>&1`
@@ -187,56 +242,97 @@ class Library
 
   # Canonical on-disk path for one clip's artifact in a given field — the single
   # owner of the per-field filename convention (e.g. summary → `summaries/
-  # summary_<clip>.md`). Accepts a clip name with or without extension; the
-  # extension is stripped before the namer runs, so `field_path('summary',
-  # 'P1055017.mov')` and `field_path('summary', 'P1055017')` both resolve to
-  # `.../summaries/summary_P1055017.md`.
+  # summary_<clip>.md`). For videos the extension is stripped before the namer
+  # runs, so `field_path('summary', 'P1055017.mov')` and `field_path('summary',
+  # 'P1055017')` both resolve to `.../summaries/summary_P1055017.md`. Image
+  # clipnames must include their extension — it's part of the clip key
+  # (`summary_DJI_0123_jpg.md`).
   def field_path(field, clipname)
     spec = field_spec(field)
-    File.join(@library_dir, spec[:subdir], spec[:namer].call(File.basename(clipname, '.*')))
+    File.join(@library_dir, spec[:subdir], spec[:namer].call(self.class.clip_key(clipname)))
   end
 
-  def add_videos(video_paths)
-    records = Array(video_paths).map { |path| self.class.video_record(path) }
+  def add_media(media_paths)
+    records = Array(media_paths).map { |path| self.class.media_record(path) }
     mutate do |library|
-      existing = library['videos'].map { |v| v['path'] }
+      existing = library['media'].map { |m| m['path'] }
       records.each do |record|
-        raise ArgumentError, "video already in library: #{record['path']}" if existing.include?(record['path'])
+        raise ArgumentError, "media already in library: #{record['path']}" if existing.include?(record['path'])
       end
-      library['videos'].concat(records)
+      library['media'].concat(records)
     end
     self
   end
 
-  # Mark `video_filenames` complete for one field. Validates each file exists
+  # Remove entries from library.yaml and delete their artifact files
+  # (transcripts, contact sheets, summaries — plus legacy visual transcripts).
+  # NEVER touches the source footage itself.
+  def remove_media!(media_filenames)
+    removed = []
+    mutate do |library|
+      Array(media_filenames).each do |filename|
+        media = find_media!(library, filename)
+        delete_artifacts(media)
+        library['media'].delete(media)
+        removed << filename
+      end
+    end
+    puts "#{@name}: removed #{removed.size} media #{removed.size == 1 ? 'entry' : 'entries'} " \
+         "(#{removed.join(', ')}) — source files untouched"
+    self
+  end
+
+  # Entries whose extension is outside every registry set — footage that snuck
+  # in before the allowlist existed. Reads stay lenient (these are treated as
+  # video), but they'd export into XML the editors can't import, so skills
+  # surface them for convert-and-swap or removal.
+  def unsupported_media
+    load_library['media'].filter_map do |media|
+      next if self.class.media_type_of(media['path'])
+
+      {
+        'filename' => self.class.filename_of(media),
+        'path' => media['path'],
+        'extension' => File.extname(media['path'].to_s).delete_prefix('.').downcase
+      }
+    end
+  end
+
+  # Mark `media_filenames` complete for one field. Validates each file exists
   # on disk before writing — atomicity is preserved by building the full plan
   # first and only mutating the YAML once every check passes.
   #
   # `announce:` prints a one-line summary (default). JobRunner passes
   # `announce: false` because it owns its own progress output and calls this
   # once per finished job.
-  def complete!(field, video_filenames, announce: true)
+  def complete!(field, media_filenames, announce: true)
     field_spec(field) # validate the field name up front
     count = 0
     mutate do |library|
-      pairs = Array(video_filenames).map do |filename|
-        video = find_video!(library, filename)
+      pairs = Array(media_filenames).map do |filename|
+        media = find_media!(library, filename)
+        type = self.class.media_type_of(media['path']) || 'video'
+        unless self.class.fields_for(type).include?(field.to_s)
+          raise ArgumentError, "#{field} does not apply to #{type} media: #{filename}"
+        end
+
         path = field_path(field, filename)
         raise ArgumentError, "#{field} file does not exist: #{path}" unless File.exist?(path)
 
-        [video, File.basename(path)]
+        [media, File.basename(path)]
       end
-      pairs.each { |video, stored_filename| video[field] = stored_filename }
+      pairs.each { |media, stored_filename| media[field] = stored_filename }
       count = pairs.size
     end
-    puts "#{@name}: #{field} set for #{count} #{pluralize(count, 'video')}" if announce
+    puts "#{@name}: #{field} set for #{count} #{pluralize(count, 'clip')}" if announce
     self
   end
 
   # Destructive: for each named field, delete every file in its subdir and
-  # clear the field on every video. Pass several names to wipe several phases
-  # in one call. The transcripts/ sweep leaves `visual_*.json` alone so
-  # `remove_visual_transcripts!` stays the explicit tool for legacy cleanup.
+  # clear the field on every media entry that has it. Pass several names to
+  # wipe several phases in one call. The transcripts/ sweep leaves
+  # `visual_*.json` alone so `remove_visual_transcripts!` stays the explicit
+  # tool for legacy cleanup.
   def reset!(*fields)
     fields.each { |f| reset_field!(f) }
     self
@@ -244,7 +340,7 @@ class Library
 
   # Destructive: clear library-level metadata back to an unconfigured state —
   # both the setup choices and the analysis-derived context (see
-  # CLEARED_METADATA). Video records and dates are kept. Part of `reset_all`'s
+  # CLEARED_METADATA). Media records and dates are kept. Part of `reset_all`'s
   # factory reset, so a re-run starts setup and footage analysis from scratch.
   def reset_metadata!
     mutate { |library| CLEARED_METADATA.each { |key, value| library[key] = value } }
@@ -253,7 +349,7 @@ class Library
   end
 
   # Delete every `transcripts/visual_*.json` file and clear the
-  # `visual_transcript` field on every video. Legacy cleanup for libraries
+  # `visual_transcript` field on every entry. Legacy cleanup for libraries
   # that predate the contact-sheet pipeline.
   def remove_visual_transcripts!
     dir = File.join(@library_dir, 'transcripts')
@@ -276,10 +372,10 @@ class Library
 
     cleared = 0
     mutate do |library|
-      library['videos'].each do |video|
-        next unless present?(video['visual_transcript'])
+      library['media'].each do |media|
+        next unless present?(media['visual_transcript'])
 
-        video['visual_transcript'] = ''
+        media['visual_transcript'] = ''
         cleared += 1
       end
     end
@@ -288,10 +384,12 @@ class Library
     self
   end
 
-  # Each record carries the stored fields plus a derived `filename` (basename of
-  # `path`). The merge returns copies, so the convenience key never reaches the
-  # write path — mutations load and persist via `load_library` directly.
-  def videos = load_library['videos'].map { |v| v.merge('filename' => self.class.filename_of(v)) }
+  # Each record carries the stored fields plus two derived keys: `filename`
+  # (basename of `path`) and `type` (inferred from the extension; unknown
+  # extensions already in the yaml read as video). The merge returns copies,
+  # so the convenience keys never reach the write path — mutations load and
+  # persist via `load_library` directly.
+  def media = merged_media(load_library)
   def language = load_library['language']
   def transcript_refinement = load_library['transcript_refinement']
   def user_context = load_library['user_context'].to_s
@@ -312,11 +410,12 @@ class Library
     self
   end
 
-  # True when every video is ready for roughcut work under either pipeline.
-  # Current: transcript + summary. Legacy: visual_transcript + summary.
-  # `contact_sheet` is intentionally not required — new libraries always have
-  # them, and the roughcut sub-agent can generate sheets on demand for legacy
-  # libraries when it needs to "see" a clip.
+  # True when every media entry is ready for roughcut work. Videos under
+  # either pipeline — current: transcript + summary; legacy: visual_transcript
+  # + summary. `contact_sheet` is intentionally not required — new libraries
+  # always have them, and the roughcut sub-agent can generate sheets on demand
+  # for legacy libraries when it needs to "see" a clip. Other types just need
+  # their registry fields (image: summary).
   #
   # Raises if a legacy `roughcuts/` directory is still present — the cut skill
   # writes to `cuts/`, so building anything before migration would scatter
@@ -329,38 +428,43 @@ class Library
             'or just rename roughcuts/ to cuts/ manually.'
     end
 
-    vids = videos
-    return false if vids.empty?
+    meds = media
+    return false if meds.empty?
 
-    vids.all? do |v|
-      present?(v['summary']) && (present?(v['transcript']) || present?(v['visual_transcript']))
-    end
+    meds.all? { |m| artifacts_ready?(m) }
   end
 
-  def incomplete_videos = incomplete_from(videos)
+  def incomplete_media = incomplete_from(media)
 
   # Clips still missing one specific artifact, as records the JobRunner can turn
-  # straight into jobs. Unlike `incomplete_videos` (missing ANY field), this is
-  # scoped to a single field so the runner can build one independent batch per
-  # phase — transcripts and contact sheets don't depend on each other.
+  # straight into jobs. Unlike `incomplete_media` (missing ANY applicable
+  # field), this is scoped to a single field so the runner can build one
+  # independent batch per phase — transcripts and contact sheets don't depend
+  # on each other. Only types the field applies to are returned, so the
+  # WhisperX/ffmpeg pipeline never sees images.
   def pending(field)
     field_spec(field) # validate the field name up front
-    videos.filter_map { |video| clip_record(video) unless present?(video[field]) }
+    media.filter_map do |m|
+      next unless self.class.fields_for(m['type']).include?(field.to_s)
+
+      clip_record(m) unless present?(m[field])
+    end
   end
 
   # Every clip as a job-ready record, in the same shape as `pending` but
   # unfiltered. FootageProcessor's --force path uses this to rebuild artifacts
   # that already exist; keeping it here means the record shape has one owner.
-  def clip_records = videos.map { |video| clip_record(video) }
+  def clip_records = media.map { |m| clip_record(m) }
 
-  # Per-clip artifact status for the live "follow along" view: every clip with a
-  # boolean per field (transcript, contact_sheet, summary). Read-only, so it's
-  # safe to poll from a separate process (the status server) while the JobRunner
-  # records progress — atomic writes keep each read whole.
+  # Per-clip artifact status for the live "follow along" view: every clip with
+  # a boolean per applicable field. Read-only, so it's safe to poll from a
+  # separate process (the status server) while the JobRunner records progress —
+  # atomic writes keep each read whole.
   def clip_statuses
-    videos.map do |video|
-      FIELDS.keys.each_with_object('filename' => self.class.filename_of(video)) do |field, row|
-        row[field] = present?(video[field])
+    media.map do |m|
+      base = { 'filename' => m['filename'], 'type' => m['type'] }
+      self.class.fields_for(m['type']).each_with_object(base) do |field, row|
+        row[field] = present?(m[field])
       end
     end
   end
@@ -369,10 +473,11 @@ class Library
   # clip-completion breakdown. `incomplete_count == 0` means ready for roughcut.
   def summary
     data = load_library
-    vids = data['videos']
-    incomplete = incomplete_from(vids)
+    meds = merged_media(data)
+    incomplete = incomplete_from(meds)
+    counts = meds.group_by { |m| m['type'] }.transform_values(&:size)
 
-    {
+    snapshot = {
       'name' => @name,
       'created_date' => data['created_date'],
       'last_updated' => data['last_updated'],
@@ -381,11 +486,14 @@ class Library
       'transcript_refinement' => data['transcript_refinement'],
       'user_context' => data['user_context'].to_s,
       'footage_summary' => data['footage_summary'].to_s,
-      'video_count' => vids.size,
-      'complete_count' => vids.size - incomplete.size,
+      'media_count' => meds.size
+    }
+    MEDIA_TYPES.each_key { |type| snapshot["#{type}_count"] = counts.fetch(type, 0) }
+    snapshot.merge(
+      'complete_count' => meds.size - incomplete.size,
       'incomplete_count' => incomplete.size,
       'incomplete' => incomplete
-    }
+    )
   end
 
   private
@@ -398,24 +506,44 @@ class Library
 
   def pluralize(count, word) = "#{word}#{'s' unless count == 1}"
 
-  def incomplete_from(vids)
-    vids.filter_map do |video|
-      missing = FIELDS.keys.reject { |f| present?(video[f]) }
+  def merged_media(data)
+    data['media'].map do |m|
+      m.merge('filename' => self.class.filename_of(m),
+              'type' => self.class.media_type_of(m['path']) || 'video')
+    end
+  end
+
+  # Legacy-aware per-entry readiness; see `ready?` for the video rule.
+  def artifacts_ready?(media)
+    if media['type'] == 'video'
+      return present?(media['summary']) && (present?(media['transcript']) || present?(media['visual_transcript']))
+    end
+
+    self.class.fields_for(media['type']).all? { |f| present?(media[f]) }
+  end
+
+  # Expects merged records (with derived `type`).
+  def incomplete_from(meds)
+    meds.filter_map do |m|
+      missing = self.class.fields_for(m['type']).reject { |f| present?(m[f]) }
       next if missing.empty?
 
-      clip_record(video).merge('missing' => missing)
+      clip_record(m).merge('missing' => missing)
     end
   end
 
   # The job-ready shape of one clip: just what a Job constructor (and the
   # JobRunner / status callers) need. Single owner of this hash so `pending`,
-  # `clip_records`, and `incomplete_from` stay in lockstep.
-  def clip_record(video)
-    {
-      'filename' => self.class.filename_of(video),
-      'path' => video['path'],
-      'duration' => video['duration']
+  # `clip_records`, and `incomplete_from` stay in lockstep. Expects merged
+  # records; `duration` is only present for types that probe it.
+  def clip_record(media)
+    record = {
+      'filename' => media['filename'],
+      'path' => media['path'],
+      'type' => media['type']
     }
+    record['duration'] = media['duration'] if media.key?('duration')
+    record
   end
 
   def reset_field!(field)
@@ -426,14 +554,14 @@ class Library
     errors = []
 
     mutate do |library|
-      library['videos'].each do |video|
-        filename = video[field]
+      library['media'].each do |media|
+        filename = media[field]
         next unless present?(filename)
 
         begin
           path = File.join(dir, filename)
           File.delete(path) if File.file?(path)
-          video[field] = ''
+          media[field] = ''
           cleared += 1
         rescue StandardError => e
           errors << "#{filename}: #{e.message}"
@@ -444,6 +572,25 @@ class Library
     end
 
     puts format_reset_summary("#{field} reset", cleared, orphans, errors)
+  end
+
+  # Delete one entry's artifact files on disk (used by remove_media!). Covers
+  # every FIELDS artifact the entry has recorded, plus a legacy visual
+  # transcript if present. Never touches the source footage.
+  def delete_artifacts(media)
+    FIELDS.each do |field, spec|
+      stored = media[field]
+      next unless present?(stored)
+
+      path = File.join(@library_dir, spec[:subdir], stored)
+      File.delete(path) if File.file?(path)
+    end
+
+    visual = media['visual_transcript']
+    return unless present?(visual)
+
+    path = File.join(@library_dir, 'transcripts', visual)
+    File.delete(path) if File.file?(path)
   end
 
   def sweep_orphans(dir, keep, errors)
@@ -466,16 +613,23 @@ class Library
   end
 
   def format_reset_summary(label, cleared, swept, errors)
-    msg = "#{@name}: #{label} (#{cleared} #{pluralize(cleared, 'video')} cleared, #{swept} #{pluralize(swept, 'file')} swept)"
+    msg = "#{@name}: #{label} (#{cleared} #{pluralize(cleared, 'clip')} cleared, #{swept} #{pluralize(swept, 'file')} swept)"
     msg += "; #{errors.size} #{pluralize(errors.size, 'error')}: #{errors.join('; ')}" unless errors.empty?
     msg
   end
 
-  # `videos` is guaranteed to be an array on the returned hash so callers can
-  # iterate without defensive `|| []` checks.
+  # `media` is guaranteed to be an array on the returned hash so callers can
+  # iterate without defensive `|| []` checks. A legacy `videos:` key means the
+  # library predates the media schema — refuse to operate until the (pure
+  # key-rename) migration has run, same pattern as the roughcuts/ check.
   def load_library
     data = YAML.safe_load_file(@library_yaml_path, permitted_classes: [Date, Time])
-    data['videos'] ||= []
+    if data.key?('videos') && !data.key?('media')
+      raise "Library '#{@name}' uses the legacy `videos:` key. " \
+            'Run `ruby lib/buttercut/library.rb migrate` to rename it to `media:` ' \
+            '(or rename the key manually — that is the whole migration).'
+    end
+    data['media'] ||= []
     data
   end
 
@@ -514,9 +668,9 @@ class Library
     File.rename(tmp, @library_yaml_path)
   end
 
-  def find_video!(library, video_filename)
-    library['videos'].find { |v| self.class.filename_of(v) == video_filename } ||
-      raise(ArgumentError, "video not found in library.yaml: #{video_filename}")
+  def find_media!(library, media_filename)
+    library['media'].find { |m| self.class.filename_of(m) == media_filename } ||
+      raise(ArgumentError, "media not found in library.yaml: #{media_filename}")
   end
 end
 
@@ -531,14 +685,16 @@ if __FILE__ == $PROGRAM_NAME
 
     Existence + status (no library load required for `exists`):
       <name> exists                                   — exits 0 if library exists, 1 otherwise
-      <name> summary                                  — JSON snapshot
-      <name> incomplete_videos                        — JSON array of incomplete clips
-      <name> pending <field>                          — JSON array of clips still missing one field
-      <name> ready                                    — exits 0 if every video is ready for roughcut, 1 otherwise
+      <name> summary                                  — JSON snapshot (media_count + per-type counts + incomplete breakdown)
+      <name> incomplete_media                         — JSON array of incomplete clips
+      <name> unsupported_media                        — JSON array of entries whose extension no editor imports natively
+      <name> pending <field>                          — JSON array of clips still missing one field (only types the field applies to)
+      <name> ready                                    — exits 0 if every clip is ready for roughcut, 1 otherwise
       <name> field_path <field> <clip>                — canonical path for a clip's artifact (e.g. summary → summaries/summary_<clip>.md)
 
     Writes:
-      <name> add_videos <video_path>...               — append video records
+      <name> add_media <path>...                      — append media records (type inferred from extension; video: #{Library::MEDIA_TYPES['video'][:extensions].join('/')}; image: #{Library::MEDIA_TYPES['image'][:extensions].join('/')})
+      <name> remove_media <files>                     — drop entries + delete their artifacts (source footage untouched)
       <name> update_metadata <key> <value...>         — set footage_summary, user_context, language, editor, or transcript_refinement
       <name> complete <field> <files>                 — mark files done for one field
       <name> reset <field> [<field>...]               — wipe one or more phases
@@ -554,7 +710,7 @@ if __FILE__ == $PROGRAM_NAME
     Library.create is not exposed via the CLI (kwarg-heavy). From bash:
       ruby -e "require_relative 'lib/buttercut/library'; \\
         Library.create('my-lib', language: 'en', editor: 'fcpx', \\
-                       transcript_refinement: true, video_paths: ['/abs/a.mov'])"
+                       transcript_refinement: true, media_paths: ['/abs/a.mov', '/abs/b.jpg'])"
   USAGE
 
   # Agent records that it just checked for updates (see check_for_update!). Kept
@@ -606,8 +762,10 @@ if __FILE__ == $PROGRAM_NAME
     case action
     when 'summary'
       puts JSON.pretty_generate(library.summary)
-    when 'incomplete_videos'
-      puts JSON.pretty_generate(library.incomplete_videos)
+    when 'incomplete_media'
+      puts JSON.pretty_generate(library.incomplete_media)
+    when 'unsupported_media'
+      puts JSON.pretty_generate(library.unsupported_media)
     when 'pending'
       field, = rest
       raise ArgumentError, 'pending requires <field>' if field.nil?
@@ -620,10 +778,14 @@ if __FILE__ == $PROGRAM_NAME
       raise ArgumentError, 'field_path requires <field> <clip>' if field.nil? || clip.nil?
 
       puts library.field_path(field, clip)
-    when 'add_videos'
-      raise ArgumentError, 'add_videos requires <video_path>...' if rest.empty?
+    when 'add_media'
+      raise ArgumentError, 'add_media requires <path>...' if rest.empty?
 
-      library.add_videos(rest)
+      library.add_media(rest)
+    when 'remove_media'
+      raise ArgumentError, 'remove_media requires <files>' if rest.empty?
+
+      library.remove_media!(split_files.call(rest))
     when 'update_metadata'
       key, *value_parts = rest
       raise ArgumentError, 'update_metadata requires <key> <value>' if key.nil? || value_parts.empty?

--- a/lib/buttercut/premiere.rb
+++ b/lib/buttercut/premiere.rb
@@ -11,15 +11,17 @@ class ButterCut
   # rotation written explicitly into the timeline.
   #
   class Premiere < FCP7
-    # The sequence frame follows the first clip's *display* orientation, so a quarter-turn
-    # source gives a portrait timeline (the stored landscape dimensions swapped) rather than
-    # a landscape one the rotated footage can't fill.
-    def format_width
-      quarter_turn?(@clips.first[:path]) ? video_height(@clips.first[:path]) : super
+    # The sequence frame follows the first video clip's *display* orientation, so a
+    # quarter-turn source gives a portrait timeline (the stored landscape dimensions
+    # swapped) rather than a landscape one the rotated footage can't fill. Stills
+    # carry no rotation flag, so the check keys off the first video clip; an explicit
+    # `timeline:` block still wins (format_width/height in the base check it first).
+    def source_format_width
+      first_video_path && quarter_turn?(first_video_path) ? video_height(first_video_path) : super
     end
 
-    def format_height
-      quarter_turn?(@clips.first[:path]) ? video_width(@clips.first[:path]) : super
+    def source_format_height
+      first_video_path && quarter_turn?(first_video_path) ? video_width(first_video_path) : super
     end
 
     private

--- a/scripts/003_migrate_add_summary.rb
+++ b/scripts/003_migrate_add_summary.rb
@@ -51,7 +51,9 @@ def migrate_library(library_path)
 
   # Sanity check: parse the result to make sure we didn't produce invalid YAML.
   parsed = YAML.load(new_content, permitted_classes: [Date, Time, Symbol])
-  unless parsed.is_a?(Hash) && parsed['videos'].is_a?(Array)
+  # Accept either key: 005 renames videos: → media:, and this script must stay
+  # re-runnable on already-renamed files.
+  unless parsed.is_a?(Hash) && (parsed['videos'] || parsed['media']).is_a?(Array)
     puts "  ✗ Insert produced unexpected YAML; refusing to write"
     return false
   end

--- a/scripts/005_migrate_videos_to_media.rb
+++ b/scripts/005_migrate_videos_to_media.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Migration script: rename the top-level `videos:` key to `media:`.
+#
+# Libraries now hold mixed media (videos + images), so the array is called
+# `media`. That key rename is the whole migration — no per-entry changes,
+# because the media type is inferred from each entry's file extension, and
+# every pre-migration entry is a video by definition.
+#
+# This migration edits the file textually — it does not round-trip through
+# YAML, so quote styles and indentation elsewhere in the file are preserved
+# exactly.
+#
+# Usage: ruby scripts/005_migrate_videos_to_media.rb [library_name]
+#        ruby scripts/005_migrate_videos_to_media.rb --all
+
+require 'date'
+require 'yaml'
+
+def migrate_library(library_path)
+  unless File.exist?(library_path)
+    puts "  ✗ Not found: #{library_path}"
+    return false
+  end
+
+  content = File.read(library_path, encoding: 'UTF-8')
+
+  if content.match?(/^media:/)
+    puts '  - Already uses `media:`; no change'
+    return false
+  end
+
+  unless content.match?(/^videos:/)
+    puts '  - No top-level `videos:` key found; no change'
+    return false
+  end
+
+  new_content = content.sub(/^videos:/, 'media:')
+
+  # Sanity check: parse the result to make sure we didn't produce invalid YAML.
+  parsed = YAML.load(new_content, permitted_classes: [Date, Time, Symbol])
+  unless parsed.is_a?(Hash) && parsed['media'].is_a?(Array)
+    puts '  ✗ Rename produced unexpected YAML; refusing to write'
+    return false
+  end
+
+  File.write(library_path, new_content)
+  puts '  ✓ Renamed `videos:` to `media:`'
+  true
+end
+
+def find_libraries
+  Dir.glob('libraries/*/library.yaml')
+end
+
+if __FILE__ == $PROGRAM_NAME
+  if ARGV.empty?
+    puts 'Usage: ruby scripts/005_migrate_videos_to_media.rb [library_name]'
+    puts '       ruby scripts/005_migrate_videos_to_media.rb --all'
+    exit 1
+  end
+
+  if ARGV[0] == '--all'
+    libraries = find_libraries
+    puts "Migrating #{libraries.length} libraries...\n\n"
+    libraries.each do |lib_path|
+      lib_name = lib_path.split('/')[1]
+      puts "#{lib_name}:"
+      migrate_library(lib_path)
+    end
+  else
+    library_name = ARGV[0]
+    library_path = "libraries/#{library_name}/library.yaml"
+    puts "#{library_name}:"
+    migrate_library(library_path)
+  end
+
+  puts "\nMigration complete."
+end

--- a/skills/analyze-video/SKILL.md
+++ b/skills/analyze-video/SKILL.md
@@ -123,6 +123,8 @@ The `contact_sheet` field was already populated in step 2, so the sub-agent retu
 
 Don't move forward until summaries are complete. Advance the "Analyze footage" count as clips are summarized; mark it done when finished.
 
+**Images.** Still images skip Steps 2–3 entirely (no audio to transcribe, no contact sheet to build) — a `summary` is the only artifact they need, and they show up in `ruby lib/buttercut/library.rb <name> pending summary` right alongside videos. The image *is* the thing to look at, so summarize it directly: read the image file (it's small) from the main thread or a Sonnet sub-agent and write a 3–4 sentence description — subjects, setting, composition, any on-image text — to the canonical path from `ruby lib/buttercut/library.rb <name> field_path summary <image-filename>`. Note image clip keys include the extension (`title-card.png` → `summaries/summary_title-card_png.md`), which `field_path` handles for you. Then record it the same way: `ruby lib/buttercut/library.rb <name> complete summary <image-filename>`.
+
 ## Step 5 — Confirm footage understanding with the user
 
 (This is the "Review the footage together" todo.) Once every summary is written, talk through what the footage actually shows — confirm character names, locations, the narrative through-line, any stray or off-thesis clips, and the user's creative intent for this library. Use plain conversation; only reach for `AskUserQuestion` when offering a discrete choice. As you learn things, update:

--- a/skills/create-library/SKILL.md
+++ b/skills/create-library/SKILL.md
@@ -45,10 +45,11 @@ Ask the user these questions one at a time — never all at once.
    - Examples: "bike-locking-video-series", "raiders-2025-highlights", "yo-yo-techniques"
    - Normalize the name: replace spaces with dashes, lowercase, drop special characters (keep alphanumeric and dashes).
 
-2. **Where are the video files located?**
-   - Ask: "Where are your video files? You can drag folders or individual files directly into the chat."
+2. **Where are the footage files located?**
+   - Ask: "Where are your videos and photos? You can drag folders or individual files directly into the chat."
+   - A library can hold videos *and* still images (photos, screenshots, title cards). Supported: video — `mov`, `mp4`, `mts`, `m2ts`, `mxf`, `avi`; image — `jpg`, `jpeg`, `png`. Anything else is rejected with a message naming the supported sets (it can be converted with ffmpeg first).
    - Verify all files exist before proceeding.
-   - Inform the user of what was found: "Found 5 video files totaling 2.3GB."
+   - Inform the user of what was found: "Found 5 videos and 3 photos totaling 2.3GB."
 
 3. **What language is spoken in these videos?**
    - `AskUserQuestion` with options: "English", "Spanish", and a free-text fallback for other languages.
@@ -64,7 +65,7 @@ Read the `editor` from `libraries/settings.yaml` — you'll pass it into the cre
 
 ## Step 3 — Create the library
 
-`Library.create` is the one operation that doesn't have a plain CLI form (kwarg-heavy). Run it via `ruby -e`. It creates the directory tree (transcripts/, contact_sheets/, summaries/, cuts/, plans/), ffprobes each video for duration, and writes library.yaml in one call:
+`Library.create` is the one operation that doesn't have a plain CLI form (kwarg-heavy). Run it via `ruby -e`. It creates the directory tree (transcripts/, contact_sheets/, summaries/, cuts/, plans/), ffprobes each video for duration, and writes library.yaml in one call. `media_paths` takes videos and images together — the type is inferred from each file's extension:
 
 ```bash
 ruby -e "require_relative 'lib/buttercut/library'; \
@@ -72,10 +73,10 @@ ruby -e "require_relative 'lib/buttercut/library'; \
     language: 'en', \
     editor: 'fcpx', \
     transcript_refinement: true, \
-    video_paths: ['/abs/foo.mov', '/abs/bar.mov'])"
+    media_paths: ['/abs/foo.mov', '/abs/title-card.png'])"
 ```
 
-Each video entry starts with empty `transcript`, `contact_sheet`, and `summary` — empty means "todo", filename presence means "done."
+Each video entry starts with empty `transcript`, `contact_sheet`, and `summary` — empty means "todo", filename presence means "done." Image entries get only an empty `summary` (no transcript, contact sheet, or duration — stills are timeless).
 
 ## Step 4 — Hand off to process-library
 

--- a/skills/cut/cut_yaml_schema.md
+++ b/skills/cut/cut_yaml_schema.md
@@ -25,21 +25,54 @@ Generate the timestamp with `date +%Y%m%d_%H%M%S`.
 | Field            | Format                | Notes |
 | ---------------- | --------------------- | ----- |
 | `description`    | one-line string       | What the cut is. For selects, use the selection criteria (e.g. "All mentions of Claude Code across interview footage"). |
+| `timeline`       | block (optional)      | Explicit output format — see "Timeline format" below. Omit for the usual case (format follows the first video clip). |
 | `clips`          | list of clip objects, in timeline order | The timeline. See per-clip fields below. |
 | `metadata.created_date`   | `YYYY-MM-DD HH:MM:SS` | When the YAML was finalized. |
 | `metadata.total_duration` | `HH:MM:SS.ss`         | Sum of all clip durations. |
 
 ## Per-clip fields
 
-Each entry in `clips:`
+Each entry in `clips:`. A clip is either a **video** (trimmed with in/out points) or an **image** (a still held for a duration) — the type is inferred from `source_file`'s extension, so you never declare it.
 
-| Field                | Format          | Notes |
-| -------------------- | --------------- | ----- |
-| `source_file`        | filename only   | Bare filename from the video's entry in `library.yaml` — no path. |
-| `in_point`           | `HH:MM:SS.ss`   | Start of the cut. Preserve sub-second precision (2.849s → `00:00:02.85`). |
-| `out_point`          | `HH:MM:SS.ss`   | End of the cut. Same precision rule. |
-| `dialogue`           | string          | Spoken words for the span; concatenate across transcript segments if the cut crosses them. Empty string when the clip is silent / B-roll. |
-| `visual_description` | string          | Shot description based on what the contact sheet shows for this range. Wrap in brackets to match template style. |
+| Field                | Format          | Applies to | Notes |
+| -------------------- | --------------- | ---------- | ----- |
+| `source_file`        | filename only   | both       | Bare filename from the clip's entry in `library.yaml` — no path. |
+| `in_point`           | `HH:MM:SS.ss`   | video      | Start of the cut. Preserve sub-second precision (2.849s → `00:00:02.85`). |
+| `out_point`          | `HH:MM:SS.ss`   | video      | End of the cut. Same precision rule. |
+| `duration`           | `HH:MM:SS.ss` or seconds | image | How long the still is held on the timeline. Images have no in/out — they're timeless. Omit to use the default (5s, or `still_duration` in `libraries/settings.yaml`). |
+| `dialogue`           | string          | both       | Spoken words for the span; concatenate across transcript segments if the cut crosses them. Empty string when the clip is silent / B-roll / an image. |
+| `visual_description` | string          | both       | Shot description (video: what the contact sheet shows for the range; image: what the still depicts, from its summary). Wrap in brackets to match template style. |
+
+### Image (still) clips
+
+A still is one line — a `source_file` and a `duration`:
+
+```yaml
+clips:
+  - source_file: "DJI_20250423171212_0210_D.mov"
+    in_point: "00:00:02.00"
+    out_point: "00:00:06.00"
+  - source_file: "title-card.png"      # an image — held, not trimmed
+    duration: "00:00:03"
+```
+
+Remember ButterCut is single-track: a still has no audio of its own, so when the timeline reaches it you cut to silence (and back to sound on the next clip). Don't plan a still as a cutaway "over" continuing dialogue — that's a second track ButterCut doesn't have.
+
+## Timeline format
+
+By default the output format (frame rate, resolution, audio rate) follows the **first video clip** — no `timeline:` block needed. Add one only when:
+
+- **The cut is image-only** (no video clips to inherit from). The block is required here — without it the export falls back to 24fps / 1920×1080. Set it to the format the user is editing in.
+- **You want to override** the inherited format (e.g. force 1080p, or a specific frame rate).
+
+```yaml
+timeline:
+  frame_rate: 24        # whole number, an NTSC rate (23.976 / 29.97 / 59.94), or a fraction string ("30000/1001")
+  width: 1920
+  height: 1080
+```
+
+Any subset is allowed — given keys win, the rest fall back to the first video clip (then to the 24fps/1920×1080 default). Match the user's editing timeline when you set it: a 1080p/24 cut of 4K/23.976 footage should say so explicitly.
 
 ## Timestamp format
 

--- a/skills/cut/roughcut_agent_prompt.md
+++ b/skills/cut/roughcut_agent_prompt.md
@@ -42,10 +42,12 @@ Derive a slug from the plan's working title — the `# ` heading at the top of t
   - For word-level in/out points at a cut boundary: grep the JSON directly for the words you need. Don't read the whole file.
 - **Visual transcript** (`transcripts/visual_*.json`, legacy / optional) — older libraries from the previous pipeline carry these. If present, treat them as extra planning context alongside the contact sheet. Newly-processed libraries won't have them, and you should never generate new ones.
 
+**Images (stills).** A library can hold still images (photos, screenshots, title cards) alongside video — they're the entries whose `source_file` ends in `.jpg`/`.jpeg`/`.png`. An image has only a **summary** (no contact sheet, transcript, or duration); read the summary and, if you need to see it, the image file itself. Place a still as a one-line clip with a `duration:` instead of in/out points (see `cut_yaml_schema.md`). Stills are timeless and silent: pick a hold length that fits the pacing (a title card might sit 2–3s; a hero photo longer), and remember the single-track rule — a still cuts to silence, so don't use one as a cutaway over continuing narration.
+
 For each beat in the plan:
 - Skim summaries to shortlist candidate clips.
-- For shortlisted clips, read the contact sheet and extract the dialogue (`script_extractor.rb`).
-- Set in/out points by grepping the audio transcript for the words at your cut boundaries.
+- For shortlisted **video** clips, read the contact sheet and extract the dialogue (`script_extractor.rb`); set in/out points by grepping the audio transcript for the words at your cut boundaries.
+- For **image** clips, read the summary (and the still itself if useful) and choose a hold `duration`.
 
 **Zoom in when timing matters.** Generate a tighter contact sheet for any clip and any range whenever the existing one leaves you guessing at a cut point:
 

--- a/skills/process-library/SKILL.md
+++ b/skills/process-library/SKILL.md
@@ -44,13 +44,13 @@ ruby lib/buttercut/library.rb recent [N]   # N most-recently-touched libraries (
 
 ## Step 2 — Add new footage
 
-If the user is adding footage new footage to an existing library, append the clips first:
+If the user is adding new footage to an existing library, append the clips first. `add_media` takes videos and images together — the type is inferred from each file's extension:
 
 ```bash
-ruby lib/buttercut/library.rb <name> add_videos /abs/new1.mov /abs/new2.mov
+ruby lib/buttercut/library.rb <name> add_media /abs/new1.mov /abs/photo.jpg
 ```
 
-Each new entry starts with empty `transcript`, `contact_sheet`, and `summary` — empty means "todo." The analysis steps below are idempotent and only touch clips missing an artifact, so they'll process just the new clips.
+Each new video entry starts with empty `transcript`, `contact_sheet`, and `summary`; each image entry starts with an empty `summary` only. Empty means "todo." The analysis steps below are idempotent and only touch clips missing an artifact, so they'll process just the new clips — and because the transcript/contact-sheet phases are video-only, images flow straight to the summary step.
 
 If you're simply resuming or processing a freshly created library, skip this step.
 

--- a/spec/buttercut/generator_stills_spec.rb
+++ b/spec/buttercut/generator_stills_spec.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tempfile'
+
+# Image (still) handling across all three generators. Stills are timeless: they
+# carry only dimensions, take their duration from the cut, and produce no audio.
+# The behaviors asserted here were verified by importing the exported XML into
+# Final Cut Pro, Premiere, and DaVinci Resolve — these specs lock the structure
+# the editors accepted so it can't silently regress.
+RSpec.describe 'Generator still handling' do
+  let(:video_path)  { '/tmp/stills_spec_video.mov' }
+  let(:image_path)  { '/tmp/stills_spec_red.png' }
+  let(:square_path) { '/tmp/stills_spec_square.png' }
+  # A space + non-ASCII filename — the URL-encoding regression case.
+  let(:unicode_image_path) { '/tmp/blue café (test).jpg' }
+
+  def video_metadata(width: 1920, height: 1080, frame_rate: '24/1', duration: 4.0, sample_rate: '48000', timecode: nil)
+    video_stream = {
+      'codec_type' => 'video', 'codec_name' => 'h264',
+      'width' => width, 'height' => height, 'r_frame_rate' => frame_rate,
+      'color_space' => 'bt709', 'color_primaries' => 'bt709', 'color_transfer' => 'bt709'
+    }
+    video_stream['tags'] = { 'timecode' => timecode } if timecode
+    {
+      'streams' => [video_stream, { 'codec_type' => 'audio', 'sample_rate' => sample_rate }],
+      'format' => { 'duration' => duration.to_s, 'tags' => timecode ? { 'timecode' => timecode } : {} }
+    }
+  end
+
+  # An image probes as a single video stream with dimensions and NO audio stream
+  # — exactly what ffprobe returns for a JPEG/PNG.
+  def image_metadata(width:, height:)
+    {
+      'streams' => [{ 'codec_type' => 'video', 'codec_name' => 'png', 'width' => width, 'height' => height }],
+      'format' => { 'duration' => 'N/A', 'tags' => {} }
+    }
+  end
+
+  let(:metadata_by_path) do
+    {
+      video_path => video_metadata(timecode: '01:00:00:00'),
+      image_path => image_metadata(width: 1920, height: 1080),
+      square_path => image_metadata(width: 1080, height: 1080),
+      unicode_image_path => image_metadata(width: 3840, height: 2160)
+    }
+  end
+
+  before do
+    allow_any_instance_of(ButterCut::EditorBase).to receive(:extract_metadata_from_ffprobe) do |_instance, path|
+      metadata_by_path.fetch(path)
+    end
+  end
+
+  # An image-only cut on an explicit 24fps/1920x1080 timeline (what the cut skill
+  # writes for image-only cuts) plus a video+stills mix.
+  let(:image_only_clips) do
+    [
+      { path: image_path,  type: :image, duration: 3.0 },
+      { path: square_path, type: :image, duration: 2.0 }
+    ]
+  end
+  let(:timeline_block) { { frame_rate: 24, width: 1920, height: 1080 } }
+
+  let(:mixed_clips) do
+    [
+      { path: video_path, type: :video, start_at: 0.0, duration: 2.0 },
+      { path: image_path, type: :image, duration: 3.0 }
+    ]
+  end
+
+  describe 'image clip validation (EditorBase)' do
+    it 'rejects an image clip with no duration — stills are timeless' do
+      clips = [{ path: image_path, type: :image }]
+      expect { ButterCut::FCPX.new(clips, timeline: timeline_block) }
+        .to raise_error(ArgumentError, /Image clip.*must have a 'duration'/)
+    end
+
+    it 'accepts an image clip once a duration is given' do
+      clips = [{ path: image_path, type: :image, duration: 3.0 }]
+      expect { ButterCut::FCPX.new(clips, timeline: timeline_block) }.not_to raise_error
+    end
+  end
+
+  describe ButterCut::FCPX do
+    it 'emits one rate-undefined format per unique still dimension, with no frameDuration' do
+      xml = described_class.new(image_only_clips, timeline: timeline_block).to_xml
+      # 1920x1080 and 1080x1080 → two distinct still formats.
+      expect(xml).to include('<format id="r_still_1920x1080" name="FFVideoFormatRateUndefined" width="1920" height="1080"/>')
+      expect(xml).to include('<format id="r_still_1080x1080" name="FFVideoFormatRateUndefined" width="1080" height="1080"/>')
+      # The timeless marker is the ABSENCE of frameDuration on the still format.
+      expect(xml).not_to match(/name="FFVideoFormatRateUndefined"[^>]*frameDuration/)
+    end
+
+    it 'makes still assets timeless (duration 0s, video-only, no audio attributes)' do
+      xml = described_class.new(image_only_clips, timeline: timeline_block).to_xml
+      asset = xml[/<asset [^>]*name="stills_spec_red\.png"[^>]*\/>/]
+      expect(asset).to include('start="0s"', 'duration="0s"', 'hasVideo="1"')
+      expect(asset).not_to include('hasAudio')
+      expect(asset).not_to include('audioRate')
+    end
+
+    it 'places stills on the spine as <video> elements (never asset-clip) with the cut duration' do
+      xml = described_class.new(image_only_clips, timeline: timeline_block).to_xml
+      expect(xml).to match(/<video name="stills_spec_red\.png"[^>]*offset="0s"[^>]*duration="3\/1s"/)
+      expect(xml).to match(/<video name="stills_spec_square\.png"[^>]*offset="3\/1s"[^>]*duration="2\/1s"/)
+      # A still must not be emitted as an asset-clip.
+      expect(xml).not_to match(/<asset-clip[^>]*stills_spec_red/)
+    end
+
+    it 'mixes a video asset-clip and a still <video> in one spine' do
+      xml = described_class.new(mixed_clips).to_xml
+      expect(xml).to match(/<asset-clip name="stills_spec_video\.mov"/)
+      expect(xml).to match(/<video name="stills_spec_red\.png"/)
+    end
+
+    it 'percent-encodes spaces and non-ASCII in the still asset src' do
+      clips = [{ path: unicode_image_path, type: :image, duration: 3.0 }]
+      xml = described_class.new(clips, timeline: timeline_block).to_xml
+      expect(xml).to include('src="file:///tmp/blue%20caf%C3%A9%20%28test%29.jpg"')
+    end
+
+    it 'validates against the FCPXML 1.8 DTD' do
+      skip 'xmllint not available' unless system('command -v xmllint > /dev/null 2>&1')
+      dtd = File.expand_path('../../dtd/FCPXMLv1_8.dtd', __dir__)
+      skip 'DTD not present' unless File.exist?(dtd)
+
+      xml = described_class.new(mixed_clips).to_xml
+      Tempfile.create(['stills', '.fcpxml']) do |f|
+        f.write(xml)
+        f.flush
+        expect(system('xmllint', '--noout', '--dtdvalid', dtd, f.path, out: File::NULL, err: File::NULL))
+          .to be(true)
+      end
+    end
+  end
+
+  shared_examples 'an xmeml still generator' do
+    it 'marks the still clipitem with <stillframe>TRUE</stillframe>' do
+      xml = described_class.new(image_only_clips, timeline: timeline_block).to_xml
+      expect(xml.scan('<stillframe>TRUE</stillframe>').size).to eq(2)
+    end
+
+    it 'gives the still a file duration equal to the timeline duration, at the sequence rate' do
+      xml = described_class.new(image_only_clips, timeline: timeline_block).to_xml
+      clipitem = xml[/<clipitem id="clipitem-video-1">.*?<\/clipitem>/m]
+      # 3.0s at 24fps → 72 frames, in/out/duration all span the timeline.
+      expect(clipitem).to include('<duration>72</duration>', '<in>0</in>', '<out>72</out>')
+      # Still adopts the sequence timebase (24), not a native still rate.
+      expect(clipitem).to include('<timebase>24</timebase>')
+    end
+
+    it 'gives the still no source timecode block and no audio (no audio clipitem, no links)' do
+      xml = described_class.new(image_only_clips, timeline: timeline_block).to_xml
+      clipitem = xml[/<clipitem id="clipitem-video-1">.*?<\/clipitem>/m]
+      expect(clipitem).not_to include('<timecode>')
+      expect(clipitem).not_to include('mediatype>audio')
+      # Pure-still timeline: no audio clipitems, no link entries at all.
+      expect(xml).not_to include('clipitem-audio')
+      expect(xml).not_to include('<link>')
+    end
+
+    it 'keeps audio + links for video clips while the still has neither' do
+      xml = described_class.new(mixed_clips).to_xml
+      # The video clip gets its audio clipitem and link pair...
+      expect(xml).to include('clipitem-audio')
+      expect(xml).to include('<link>')
+      # ...but only ONE stillframe marker and no audio clipitem for the still.
+      expect(xml.scan('<stillframe>TRUE</stillframe>').size).to eq(1)
+      # Exactly one audio clipitem (the video's), not two.
+      expect(xml.scan(/<clipitem id="clipitem-audio-\d+">/).size).to eq(1)
+    end
+
+    it 'percent-encodes spaces and non-ASCII in the still pathurl' do
+      clips = [{ path: unicode_image_path, type: :image, duration: 3.0 }]
+      xml = described_class.new(clips, timeline: timeline_block).to_xml
+      expect(xml).to include('<pathurl>file:///tmp/blue%20caf%C3%A9%20%28test%29.jpg</pathurl>')
+    end
+  end
+
+  describe ButterCut::FCP7 do
+    it_behaves_like 'an xmeml still generator'
+  end
+
+  describe ButterCut::Resolve do
+    it_behaves_like 'an xmeml still generator'
+  end
+
+  describe ButterCut::Premiere do
+    it_behaves_like 'an xmeml still generator'
+
+    it 'adds no rotation filter for a still (images carry no rotation flag)' do
+      clips = [{ path: image_path, type: :image, duration: 3.0 }]
+      xml = described_class.new(clips, timeline: timeline_block).to_xml
+      expect(xml).not_to include('<filter>')
+      expect(xml).not_to include('Basic Motion')
+    end
+  end
+end

--- a/spec/buttercut/library_spec.rb
+++ b/spec/buttercut/library_spec.rb
@@ -21,22 +21,31 @@ RSpec.describe Library do
     allow($stdout).to receive(:puts)
   end
 
-  def write_library(videos:, name: library_name, **metadata)
+  def write_library(media:, name: library_name, **metadata)
     dir = File.join(libraries_root, name)
     FileUtils.mkdir_p(File.join(dir, 'transcripts'))
     FileUtils.mkdir_p(File.join(dir, 'contact_sheets'))
     FileUtils.mkdir_p(File.join(dir, 'summaries'))
-    payload = metadata.transform_keys(&:to_s).merge('videos' => videos)
+    payload = metadata.transform_keys(&:to_s).merge('media' => media)
     File.write(File.join(dir, 'library.yaml'), payload.to_yaml)
     dir
   end
 
+  # A video record: probed duration + the three video fields.
   def video_entry(filename, **overrides)
     {
       'path' => "/tmp/#{filename}",
       'duration' => '00:00:05',
       'transcript' => '',
       'contact_sheet' => '',
+      'summary' => ''
+    }.merge(overrides.transform_keys(&:to_s))
+  end
+
+  # An image record: no duration, no transcript/contact_sheet — just a summary.
+  def image_entry(filename, **overrides)
+    {
+      'path' => "/tmp/#{filename}",
       'summary' => ''
     }.merge(overrides.transform_keys(&:to_s))
   end
@@ -51,7 +60,7 @@ RSpec.describe Library do
 
   describe '.exists?' do
     it 'returns true when both directory and library.yaml exist' do
-      write_library(videos: [])
+      write_library(media: [])
       expect(Library.exists?(library_name)).to be(true)
     end
 
@@ -72,15 +81,15 @@ RSpec.describe Library do
 
   describe '.list' do
     it 'returns library names sorted by library.yaml mtime (newest first)' do
-      write_library(videos: [], name: 'older')
-      write_library(videos: [], name: 'newer')
+      write_library(media: [], name: 'older')
+      write_library(media: [], name: 'newer')
       File.utime(Time.now - 100, Time.now - 100, File.join(libraries_root, 'older', 'library.yaml'))
       File.utime(Time.now, Time.now, File.join(libraries_root, 'newer', 'library.yaml'))
       expect(Library.list).to eq(%w[newer older])
     end
 
     it 'ignores directories without a library.yaml' do
-      write_library(videos: [], name: 'real')
+      write_library(media: [], name: 'real')
       FileUtils.mkdir_p(File.join(libraries_root, 'half-built'))
       expect(Library.list).to eq(['real'])
     end
@@ -92,8 +101,8 @@ RSpec.describe Library do
 
   describe '.recent' do
     it 'orders by the newest file mtime inside the library dir, not just library.yaml' do
-      write_library(videos: [], name: 'a')
-      write_library(videos: [], name: 'b')
+      write_library(media: [], name: 'a')
+      write_library(media: [], name: 'b')
 
       old = Time.now - 1000
       [%w[a library.yaml], %w[b library.yaml]].each { |parts| File.utime(old, old, File.join(libraries_root, *parts)) }
@@ -105,13 +114,13 @@ RSpec.describe Library do
     end
 
     it 'caps the result at limit (default 10)' do
-      11.times { |i| write_library(videos: [], name: "lib#{i}") }
+      11.times { |i| write_library(media: [], name: "lib#{i}") }
       expect(Library.recent.size).to eq(10)
       expect(Library.recent(limit: 3).size).to eq(3)
     end
 
     it 'ignores directories without a library.yaml' do
-      write_library(videos: [], name: 'real')
+      write_library(media: [], name: 'real')
       FileUtils.mkdir_p(File.join(libraries_root, 'half-built'))
       expect(Library.recent).to eq(['real'])
     end
@@ -121,19 +130,58 @@ RSpec.describe Library do
     end
   end
 
+  describe '.media_type_of' do
+    it 'infers video and image from the extension, case-insensitively' do
+      expect(Library.media_type_of('/a/b/CLIP.MOV')).to eq('video')
+      expect(Library.media_type_of('clip.mp4')).to eq('video')
+      expect(Library.media_type_of('photo.JPEG')).to eq('image')
+      expect(Library.media_type_of('x.png')).to eq('image')
+    end
+
+    it 'returns nil for an extension outside every set' do
+      expect(Library.media_type_of('archive.mkv')).to be_nil
+      expect(Library.media_type_of('clip.webm')).to be_nil
+      expect(Library.media_type_of('noext')).to be_nil
+    end
+  end
+
+  describe '.clip_key' do
+    it 'strips the extension for videos so it matches artifacts already on disk' do
+      expect(Library.clip_key('P1055017.mov')).to eq('P1055017')
+    end
+
+    it 'flattens the extension into the key for images so photo/video basenames cannot collide' do
+      expect(Library.clip_key('DJI_0123.jpg')).to eq('DJI_0123_jpg')
+      expect(Library.clip_key('DJI_0123.PNG')).to eq('DJI_0123_png')
+    end
+  end
+
+  describe '.fields_for' do
+    it 'returns the registry fields for each type' do
+      expect(Library.fields_for('video')).to eq(%w[transcript contact_sheet summary])
+      expect(Library.fields_for('image')).to eq(%w[summary])
+    end
+
+    it 'raises for an unknown type' do
+      expect { Library.fields_for('audio') }.to raise_error(ArgumentError, /unknown media type/)
+    end
+  end
+
   describe '.create' do
     let(:video_path) { File.join(@libraries_root, 'src', 'a.mov') }
+    let(:image_path) { File.join(@libraries_root, 'src', 'pic.png') }
 
     before do
       FileUtils.mkdir_p(File.dirname(video_path))
       FileUtils.touch(video_path)
+      FileUtils.touch(image_path)
       allow(Library).to receive(:probe_duration).and_return('00:00:42')
     end
 
     it 'creates the directory tree, library.yaml, and returns a handle' do
       lib = Library.create(
         'fresh', language: 'en', editor: 'Final Cut Pro X',
-        transcript_refinement: true, video_paths: [video_path]
+        transcript_refinement: true, media_paths: [video_path]
       )
       expect(lib).to be_a(Library)
       expect(File.directory?(File.join(libraries_root, 'fresh', 'transcripts'))).to be(true)
@@ -144,79 +192,118 @@ RSpec.describe Library do
         'library_name' => 'fresh', 'language' => 'en', 'editor' => 'Final Cut Pro X',
         'transcript_refinement' => true, 'user_context' => ''
       )
-      expect(yaml['videos'].first).to include(
+      expect(yaml['media'].first).to include(
         'path' => video_path, 'duration' => '00:00:42',
         'transcript' => '', 'contact_sheet' => '', 'summary' => ''
       )
     end
 
+    it 'creates an image entry with only a summary field — no duration probe, no video fields' do
+      Library.create(
+        'fresh', language: 'en', editor: 'fcpx',
+        transcript_refinement: false, media_paths: [image_path]
+      )
+      record = YAML.safe_load_file(File.join(libraries_root, 'fresh', 'library.yaml'), permitted_classes: [Date, Time])['media'].first
+      expect(record).to include('path' => image_path, 'summary' => '')
+      expect(record).not_to have_key('duration')
+      expect(record).not_to have_key('transcript')
+      expect(record).not_to have_key('contact_sheet')
+    end
+
     it 'refuses to overwrite an existing library' do
-      write_library(videos: [], name: 'fresh')
+      write_library(media: [], name: 'fresh')
       expect do
         Library.create('fresh', language: 'en', editor: 'fcpx',
-                       transcript_refinement: true, video_paths: [video_path])
+                       transcript_refinement: true, media_paths: [video_path])
       end.to raise_error(ArgumentError, /already exists/)
     end
 
-    it 'raises when a video file is missing' do
+    it 'raises when a media file is missing' do
       expect do
         Library.create('fresh', language: 'en', editor: 'fcpx',
-                       transcript_refinement: true, video_paths: ['/nope.mov'])
-      end.to raise_error(ArgumentError, /video file not found/)
+                       transcript_refinement: true, media_paths: ['/nope.mov'])
+      end.to raise_error(ArgumentError, /media file not found/)
+    end
+
+    it 'rejects a media file whose extension no editor imports' do
+      bad = File.join(@libraries_root, 'src', 'clip.mkv')
+      FileUtils.touch(bad)
+      expect do
+        Library.create('fresh', language: 'en', editor: 'fcpx',
+                       transcript_refinement: true, media_paths: [bad])
+      end.to raise_error(ArgumentError, /unsupported media format/)
     end
 
     it 'rejects a blank library name' do
       expect do
         Library.create('', language: 'en', editor: 'fcpx',
-                       transcript_refinement: true, video_paths: [])
+                       transcript_refinement: true, media_paths: [])
       end.to raise_error(ArgumentError, /library_name is required/)
     end
   end
 
-  describe '#add_videos' do
+  describe '#add_media' do
     let(:video_a) { File.join(@libraries_root, 'src', 'a.mov') }
     let(:video_b) { File.join(@libraries_root, 'src', 'b.mov') }
+    let(:image_c) { File.join(@libraries_root, 'src', 'c.jpg') }
 
     before do
       FileUtils.mkdir_p(File.dirname(video_a))
       FileUtils.touch(video_a)
       FileUtils.touch(video_b)
+      FileUtils.touch(image_c)
       allow(Library).to receive(:probe_duration).and_return('00:00:10')
-      write_library(videos: [video_entry('existing.mov', path: '/tmp/existing.mov')])
+      write_library(media: [video_entry('existing.mov', path: '/tmp/existing.mov')])
     end
 
-    it 'appends new entries with ffprobe duration and empty per-clip fields' do
-      Library.find(library_name).add_videos([video_a, video_b])
-      videos = load_yaml['videos']
-      expect(videos.map { |v| v['path'] }).to eq(['/tmp/existing.mov', video_a, video_b])
-      expect(videos.last).to include('duration' => '00:00:10', 'transcript' => '', 'summary' => '')
+    it 'appends new video entries with ffprobe duration and empty per-clip fields' do
+      Library.find(library_name).add_media([video_a, video_b])
+      media = load_yaml['media']
+      expect(media.map { |v| v['path'] }).to eq(['/tmp/existing.mov', video_a, video_b])
+      expect(media.last).to include('duration' => '00:00:10', 'transcript' => '', 'summary' => '')
+    end
+
+    it 'appends an image with only a summary field and no duration probe' do
+      Library.find(library_name).add_media([image_c])
+      record = load_yaml['media'].last
+      expect(record['path']).to eq(image_c)
+      expect(record).to include('summary' => '')
+      expect(record).not_to have_key('duration')
+      expect(record).not_to have_key('transcript')
     end
 
     it 'refuses to add a path already in the library' do
-      Library.find(library_name).add_videos([video_a])
-      expect { Library.find(library_name).add_videos([video_a]) }
-        .to raise_error(ArgumentError, /already in library/)
+      Library.find(library_name).add_media([video_a])
+      expect { Library.find(library_name).add_media([video_a]) }
+        .to raise_error(ArgumentError, /media already in library/)
     end
 
-    it 'raises if the video file does not exist on disk' do
-      expect { Library.find(library_name).add_videos(['/nope.mov']) }
-        .to raise_error(ArgumentError, /video file not found/)
+    it 'raises if the media file does not exist on disk' do
+      expect { Library.find(library_name).add_media(['/nope.mov']) }
+        .to raise_error(ArgumentError, /media file not found/)
+    end
+
+    it 'rejects an extension outside every supported set' do
+      bad = File.join(@libraries_root, 'src', 'clip.mkv')
+      FileUtils.touch(bad)
+      expect { Library.find(library_name).add_media([bad]) }
+        .to raise_error(ArgumentError, /unsupported media format/)
     end
 
     it 'coerces a single path into a one-element array' do
-      Library.find(library_name).add_videos(video_a)
-      expect(load_yaml['videos'].last['path']).to eq(video_a)
+      Library.find(library_name).add_media(video_a)
+      expect(load_yaml['media'].last['path']).to eq(video_a)
     end
 
     it 'returns self for chaining' do
       lib = Library.find(library_name)
-      expect(lib.add_videos([video_a])).to be(lib)
+      expect(lib.add_media([video_a])).to be(lib)
     end
 
     it 'expands relative paths to absolute before storing' do
       stored = Dir.chdir(File.dirname(video_a)) do
-        Library.find(library_name).add_videos(['./a.mov'])
-        load_yaml['videos'].last['path']
+        Library.find(library_name).add_media(['./a.mov'])
+        load_yaml['media'].last['path']
       end
       expect(stored).to start_with('/')
       expect(stored).to end_with('/src/a.mov')
@@ -224,9 +311,74 @@ RSpec.describe Library do
     end
   end
 
+  describe '#remove_media!' do
+    before do
+      write_library(media: [
+                      video_entry('a.mov', transcript: 'a.json', contact_sheet: 'a_full.jpg', summary: 'summary_a.md'),
+                      image_entry('b.jpg', summary: 'summary_b_jpg.md')
+                    ])
+      touch(
+        File.join(library_dir, 'transcripts', 'a.json'),
+        File.join(library_dir, 'contact_sheets', 'a_full.jpg'),
+        File.join(library_dir, 'summaries', 'summary_a.md'),
+        File.join(library_dir, 'summaries', 'summary_b_jpg.md')
+      )
+    end
+
+    it 'drops a video entry and deletes its artifacts' do
+      Library.find(library_name).remove_media!(['a.mov'])
+      expect(load_yaml['media'].map { |m| File.basename(m['path']) }).to eq(['b.jpg'])
+      expect(File.exist?(File.join(library_dir, 'transcripts', 'a.json'))).to be(false)
+      expect(File.exist?(File.join(library_dir, 'contact_sheets', 'a_full.jpg'))).to be(false)
+      expect(File.exist?(File.join(library_dir, 'summaries', 'summary_a.md'))).to be(false)
+    end
+
+    it 'drops an image entry and deletes its summary' do
+      Library.find(library_name).remove_media!(['b.jpg'])
+      expect(load_yaml['media'].map { |m| File.basename(m['path']) }).to eq(['a.mov'])
+      expect(File.exist?(File.join(library_dir, 'summaries', 'summary_b_jpg.md'))).to be(false)
+    end
+
+    it 'never deletes the source footage' do
+      src = File.join(libraries_root, 'real-source.mov')
+      FileUtils.touch(src)
+      write_library(media: [video_entry('real-source.mov', path: src)])
+      Library.find(library_name).remove_media!(['real-source.mov'])
+      expect(File.exist?(src)).to be(true)
+      expect(load_yaml['media']).to eq([])
+    end
+
+    it 'raises when the entry is not present in library.yaml' do
+      expect { Library.find(library_name).remove_media!(['nope.mov']) }
+        .to raise_error(ArgumentError, /media not found in library\.yaml/)
+    end
+
+    it 'returns self for chaining' do
+      lib = Library.find(library_name)
+      expect(lib.remove_media!(['b.jpg'])).to be(lib)
+    end
+  end
+
+  describe '#unsupported_media' do
+    it 'surfaces entries whose extension no editor imports natively' do
+      write_library(media: [
+                      video_entry('good.mov'),
+                      video_entry('legacy.mkv', path: '/tmp/legacy.mkv')
+                    ])
+      result = Library.find(library_name).unsupported_media
+      expect(result.map { |m| m['filename'] }).to eq(['legacy.mkv'])
+      expect(result.first).to include('path' => '/tmp/legacy.mkv', 'extension' => 'mkv')
+    end
+
+    it 'returns an empty array when every entry is a supported type' do
+      write_library(media: [video_entry('a.mov'), image_entry('b.jpg')])
+      expect(Library.find(library_name).unsupported_media).to eq([])
+    end
+  end
+
   describe '.find' do
     it 'returns a Library instance for an existing library' do
-      write_library(videos: [])
+      write_library(media: [])
       expect(Library.find(library_name)).to be_a(Library)
     end
 
@@ -247,10 +399,19 @@ RSpec.describe Library do
     end
   end
 
+  describe 'legacy videos: schema' do
+    it 'refuses to load a library still on the videos: key, pointing at migrate' do
+      FileUtils.mkdir_p(library_dir)
+      File.write(library_yaml_path, { 'videos' => [] }.to_yaml)
+      expect { Library.find(library_name).media }
+        .to raise_error(/legacy `videos:` key.*migrate/m)
+    end
+  end
+
   describe '#summary' do
     it 'returns top-level metadata plus a clip-completion breakdown' do
       write_library(
-        videos: [
+        media: [
           video_entry('a.mov', transcript: 'a.json', contact_sheet: 'a_full.jpg',
                       summary: 'summary_a.md'),
           video_entry('b.mov', transcript: 'b.json', summary: 'summary_b.md'),
@@ -275,7 +436,7 @@ RSpec.describe Library do
         'transcript_refinement' => true,
         'user_context' => 'user is Andrew',
         'footage_summary' => 'cycling in Lisbon',
-        'video_count' => 3,
+        'media_count' => 3,
         'complete_count' => 1,
         'incomplete_count' => 2
       )
@@ -283,14 +444,25 @@ RSpec.describe Library do
       expect(result['incomplete'].first['missing']).to eq(%w[contact_sheet])
     end
 
-    it 'returns zero counts and an empty incomplete list for a brand-new empty library' do
-      write_library(videos: [], footage_summary: 'No footage analyzed yet.')
+    it 'breaks media_count down by registry type' do
+      write_library(media: [
+                      video_entry('a.mov', transcript: 'a.json', contact_sheet: 'a_full.jpg', summary: 'summary_a.md'),
+                      image_entry('b.jpg', summary: 'summary_b_jpg.md'),
+                      image_entry('c.png')
+                    ])
       result = Library.find(library_name).summary
-      expect(result).to include('video_count' => 0, 'complete_count' => 0, 'incomplete_count' => 0, 'incomplete' => [])
+      expect(result).to include('media_count' => 3, 'video_count' => 1, 'image_count' => 2)
+    end
+
+    it 'returns zero counts and an empty incomplete list for a brand-new empty library' do
+      write_library(media: [], footage_summary: 'No footage analyzed yet.')
+      result = Library.find(library_name).summary
+      expect(result).to include('media_count' => 0, 'complete_count' => 0, 'incomplete_count' => 0, 'incomplete' => [])
+      expect(result).to include('video_count' => 0, 'image_count' => 0)
     end
 
     it 'defaults free-text fields to empty strings when absent' do
-      write_library(videos: [])
+      write_library(media: [])
       result = Library.find(library_name).summary
       expect(result['user_context']).to eq('')
       expect(result['footage_summary']).to eq('')
@@ -299,13 +471,13 @@ RSpec.describe Library do
 
   describe '#dir' do
     it 'returns the absolute path to the library directory' do
-      write_library(videos: [])
+      write_library(media: [])
       expect(Library.find(library_name).dir).to eq(library_dir)
     end
   end
 
   describe '#field_path' do
-    before { write_library(videos: []) }
+    before { write_library(media: []) }
 
     it 'returns the canonical on-disk path for each field' do
       lib = Library.find(library_name)
@@ -314,11 +486,17 @@ RSpec.describe Library do
       expect(lib.field_path('summary', 'DJI_0123')).to eq(File.join(library_dir, 'summaries', 'summary_DJI_0123.md'))
     end
 
-    it 'strips the clip extension so a basename with or without it resolves identically' do
+    it 'strips the clip extension so a video basename with or without it resolves identically' do
       lib = Library.find(library_name)
       expect(lib.field_path('summary', 'P1055017.mov'))
         .to eq(lib.field_path('summary', 'P1055017'))
         .and eq(File.join(library_dir, 'summaries', 'summary_P1055017.md'))
+    end
+
+    it 'flattens the extension into image artifact names so photo and video basenames cannot collide' do
+      lib = Library.find(library_name)
+      expect(lib.field_path('summary', 'DJI_0123.jpg')).to eq(File.join(library_dir, 'summaries', 'summary_DJI_0123_jpg.md'))
+      expect(lib.field_path('summary', 'DJI_0123.mov')).to eq(File.join(library_dir, 'summaries', 'summary_DJI_0123.md'))
     end
 
     it 'raises for unknown fields' do
@@ -327,31 +505,39 @@ RSpec.describe Library do
     end
   end
 
-  describe '#videos' do
-    it 'returns the video entries from library.yaml' do
-      write_library(videos: [video_entry('a.mov'), video_entry('b.mov')])
-      videos = Library.find(library_name).videos
-      expect(videos.map { |v| v['path'] }).to eq(['/tmp/a.mov', '/tmp/b.mov'])
+  describe '#media' do
+    it 'returns the media entries from library.yaml' do
+      write_library(media: [video_entry('a.mov'), video_entry('b.mov')])
+      media = Library.find(library_name).media
+      expect(media.map { |v| v['path'] }).to eq(['/tmp/a.mov', '/tmp/b.mov'])
     end
 
-    it 'exposes a derived filename without persisting it to library.yaml' do
-      write_library(videos: [video_entry('a.mov')])
+    it 'exposes derived filename and type without persisting them to library.yaml' do
+      write_library(media: [video_entry('a.mov'), image_entry('b.jpg')])
       library = Library.find(library_name)
 
-      expect(library.videos.first['filename']).to eq('a.mov')
-      expect(YAML.safe_load_file(library_yaml_path)['videos'].first).not_to have_key('filename')
+      expect(library.media.map { |m| m['filename'] }).to eq(%w[a.mov b.jpg])
+      expect(library.media.map { |m| m['type'] }).to eq(%w[video image])
+
+      persisted = YAML.safe_load_file(library_yaml_path)['media']
+      expect(persisted).to all(satisfy { |m| !m.key?('filename') && !m.key?('type') })
     end
 
-    it 'returns an empty array when there are no videos' do
-      write_library(videos: [])
-      expect(Library.find(library_name).videos).to eq([])
+    it 'reads an entry with an unrecognized extension as video (lenient read)' do
+      write_library(media: [video_entry('legacy.mkv', path: '/tmp/legacy.mkv')])
+      expect(Library.find(library_name).media.first['type']).to eq('video')
+    end
+
+    it 'returns an empty array when there is no media' do
+      write_library(media: [])
+      expect(Library.find(library_name).media).to eq([])
     end
   end
 
   describe 'metadata readers' do
     it 'returns top-level fields from library.yaml' do
       write_library(
-        videos: [],
+        media: [],
         language: 'en',
         transcript_refinement: true,
         user_context: 'user is Andrew',
@@ -367,7 +553,7 @@ RSpec.describe Library do
     end
 
     it 'returns sensible defaults when fields are absent' do
-      write_library(videos: [])
+      write_library(media: [])
       lib = Library.find(library_name)
       expect(lib.language).to be_nil
       expect(lib.transcript_refinement).to be_nil
@@ -379,7 +565,7 @@ RSpec.describe Library do
 
   describe '#update_metadata!' do
     it 'updates footage_summary and user_context independently' do
-      write_library(videos: [], footage_summary: 'old summary', user_context: 'old context')
+      write_library(media: [], footage_summary: 'old summary', user_context: 'old context')
       Library.find(library_name).update_metadata!(footage_summary: 'new summary')
       reloaded = load_yaml
       expect(reloaded['footage_summary']).to eq('new summary')
@@ -387,7 +573,7 @@ RSpec.describe Library do
     end
 
     it 'leaves untouched fields alone' do
-      write_library(videos: [], footage_summary: 'keep me', user_context: 'and me')
+      write_library(media: [], footage_summary: 'keep me', user_context: 'and me')
       Library.find(library_name).update_metadata!
       reloaded = load_yaml
       expect(reloaded['footage_summary']).to eq('keep me')
@@ -395,19 +581,19 @@ RSpec.describe Library do
     end
 
     it 'accepts empty strings to clear a field' do
-      write_library(videos: [], footage_summary: 'old')
+      write_library(media: [], footage_summary: 'old')
       Library.find(library_name).update_metadata!(footage_summary: '')
       expect(load_yaml['footage_summary']).to eq('')
     end
 
     it 'returns self for chaining' do
-      write_library(videos: [])
+      write_library(media: [])
       lib = Library.find(library_name)
       expect(lib.update_metadata!(footage_summary: 'x')).to be(lib)
     end
 
     it 'updates the config fields (language, editor, transcript_refinement)' do
-      write_library(videos: [], language: '', editor: '', transcript_refinement: nil)
+      write_library(media: [], language: '', editor: '', transcript_refinement: nil)
       Library.find(library_name).update_metadata!(language: 'english', editor: 'fcpx', transcript_refinement: false)
       reloaded = load_yaml
       expect(reloaded['language']).to eq('english')
@@ -416,50 +602,60 @@ RSpec.describe Library do
     end
 
     it 'writes transcript_refinement: false without treating it as "omitted"' do
-      write_library(videos: [], transcript_refinement: true)
+      write_library(media: [], transcript_refinement: true)
       Library.find(library_name).update_metadata!(transcript_refinement: false)
       expect(load_yaml['transcript_refinement']).to be(false)
     end
   end
 
-  describe '#incomplete_videos' do
+  describe '#incomplete_media' do
     it 'returns an empty array when every video has all three fields set' do
-      write_library(videos: [
+      write_library(media: [
                       video_entry('a.mov', transcript: 'a.json', contact_sheet: 'a_full.jpg',
                                   summary: 'summary_a.md')
                     ])
-      expect(Library.find(library_name).incomplete_videos).to eq([])
+      expect(Library.find(library_name).incomplete_media).to eq([])
     end
 
-    it 'reports each missing field' do
-      write_library(videos: [
+    it 'reports each missing field for a video' do
+      write_library(media: [
                       video_entry('a.mov', transcript: 'a.json'),
                       video_entry('b.mov', transcript: 'b.json', summary: 'summary_b.md')
                     ])
-      result = Library.find(library_name).incomplete_videos
+      result = Library.find(library_name).incomplete_media
       expect(result.size).to eq(2)
       expect(result[0]).to include('filename' => 'a.mov', 'missing' => %w[contact_sheet summary])
       expect(result[1]).to include('filename' => 'b.mov', 'missing' => %w[contact_sheet])
     end
 
     it 'treats nil and whitespace-only values as missing' do
-      write_library(videos: [video_entry('a.mov', transcript: nil, contact_sheet: '   ')])
-      expect(Library.find(library_name).incomplete_videos.first['missing'])
+      write_library(media: [video_entry('a.mov', transcript: nil, contact_sheet: '   ')])
+      expect(Library.find(library_name).incomplete_media.first['missing'])
         .to include('transcript', 'contact_sheet')
     end
 
+    it 'reports only the summary field for an image (and omits it when present)' do
+      write_library(media: [
+                      image_entry('a.jpg'),
+                      image_entry('b.png', summary: 'summary_b_png.md')
+                    ])
+      result = Library.find(library_name).incomplete_media
+      expect(result.map { |m| m['filename'] }).to eq(['a.jpg'])
+      expect(result.first['missing']).to eq(%w[summary])
+    end
+
     it 'ignores legacy visual_transcript when reporting missing fields' do
-      write_library(videos: [
+      write_library(media: [
                       video_entry('a.mov', summary: 'summary_a.md').merge('visual_transcript' => 'visual_a.json')
                     ])
-      expect(Library.find(library_name).incomplete_videos.first['missing'])
+      expect(Library.find(library_name).incomplete_media.first['missing'])
         .to eq(%w[transcript contact_sheet])
     end
   end
 
   describe '#pending' do
     it 'returns records only for clips missing the named field' do
-      write_library(videos: [
+      write_library(media: [
                       video_entry('a.mov', transcript: 'a.json'),
                       video_entry('b.mov', transcript: ''),
                       video_entry('c.mov', transcript: 'c.json')
@@ -470,7 +666,7 @@ RSpec.describe Library do
     end
 
     it 'is independent per field' do
-      write_library(videos: [
+      write_library(media: [
                       video_entry('a.mov', transcript: 'a.json', contact_sheet: ''),
                       video_entry('b.mov', transcript: '', contact_sheet: 'b_full.jpg')
                     ])
@@ -479,15 +675,35 @@ RSpec.describe Library do
       expect(library.pending('contact_sheet').map { |r| r['filename'] }).to eq(['a.mov'])
     end
 
+    it 'never returns images for a video-only field (the WhisperX/ffmpeg pipeline never sees images)' do
+      write_library(media: [
+                      video_entry('a.mov', transcript: ''),
+                      image_entry('b.jpg')
+                    ])
+      result = Library.find(library_name).pending('transcript')
+      expect(result.map { |r| r['filename'] }).to eq(['a.mov'])
+    end
+
+    it 'returns images for summary, which applies to both types — and omits no-duration key for images' do
+      write_library(media: [
+                      video_entry('a.mov', summary: 'summary_a.md'),
+                      image_entry('b.jpg')
+                    ])
+      result = Library.find(library_name).pending('summary')
+      expect(result.map { |r| r['filename'] }).to eq(['b.jpg'])
+      expect(result.first).to include('type' => 'image')
+      expect(result.first).not_to have_key('duration')
+    end
+
     it 'raises on an unknown field' do
-      write_library(videos: [])
+      write_library(media: [])
       expect { Library.find(library_name).pending('nonsense') }.to raise_error(ArgumentError, /unknown field/)
     end
   end
 
   describe '#ready?' do
     it 'returns true when every video has transcript + summary (current pipeline)' do
-      write_library(videos: [
+      write_library(media: [
                       video_entry('a.mov', transcript: 'a.json', summary: 'summary_a.md'),
                       video_entry('b.mov', transcript: 'b.json', summary: 'summary_b.md')
                     ])
@@ -495,35 +711,53 @@ RSpec.describe Library do
     end
 
     it 'returns true when every video has visual_transcript + summary (legacy)' do
-      write_library(videos: [
+      write_library(media: [
                       video_entry('a.mov', summary: 'summary_a.md').merge('visual_transcript' => 'visual_a.json')
                     ])
       expect(Library.find(library_name).ready?).to be(true)
     end
 
     it 'accepts a mix of legacy and current videos' do
-      write_library(videos: [
+      write_library(media: [
                       video_entry('a.mov', transcript: 'a.json', summary: 'summary_a.md'),
                       video_entry('b.mov', summary: 'summary_b.md').merge('visual_transcript' => 'visual_b.json')
                     ])
       expect(Library.find(library_name).ready?).to be(true)
     end
 
+    it 'returns true for an image once it has a summary (its only required field)' do
+      write_library(media: [image_entry('a.jpg', summary: 'summary_a_jpg.md')])
+      expect(Library.find(library_name).ready?).to be(true)
+    end
+
+    it 'is ready when a mix of video and image are each complete' do
+      write_library(media: [
+                      video_entry('a.mov', transcript: 'a.json', summary: 'summary_a.md'),
+                      image_entry('b.jpg', summary: 'summary_b_jpg.md')
+                    ])
+      expect(Library.find(library_name).ready?).to be(true)
+    end
+
     it 'returns false when any video is missing a summary' do
-      write_library(videos: [
+      write_library(media: [
                       video_entry('a.mov', transcript: 'a.json', summary: 'summary_a.md'),
                       video_entry('b.mov', transcript: 'b.json')
                     ])
       expect(Library.find(library_name).ready?).to be(false)
     end
 
+    it 'returns false when an image is missing its summary' do
+      write_library(media: [image_entry('a.jpg')])
+      expect(Library.find(library_name).ready?).to be(false)
+    end
+
     it 'returns false for an empty library' do
-      write_library(videos: [])
+      write_library(media: [])
       expect(Library.find(library_name).ready?).to be(false)
     end
 
     it 'raises a migration-required error when a legacy roughcuts/ directory is present' do
-      write_library(videos: [video_entry('a.mov', transcript: 'a.json', summary: 'summary_a.md')])
+      write_library(media: [video_entry('a.mov', transcript: 'a.json', summary: 'summary_a.md')])
       FileUtils.mkdir_p(File.join(library_dir, 'roughcuts'))
 
       expect { Library.find(library_name).ready? }
@@ -533,7 +767,7 @@ RSpec.describe Library do
 
   describe '#complete!' do
     before do
-      write_library(videos: [video_entry('a.mov'), video_entry('b.mov'), video_entry('c.mov')])
+      write_library(media: [video_entry('a.mov'), video_entry('b.mov'), video_entry('c.mov')])
       touch(
         File.join(library_dir, 'summaries', 'summary_a.md'),
         File.join(library_dir, 'summaries', 'summary_b.md'),
@@ -543,10 +777,23 @@ RSpec.describe Library do
 
     it 'sets the field on each named video' do
       Library.find(library_name).complete!('summary', ['a.mov', 'b.mov'])
-      videos = load_yaml['videos']
-      expect(videos[0]['summary']).to eq('summary_a.md')
-      expect(videos[1]['summary']).to eq('summary_b.md')
-      expect(videos[2]['summary']).to eq('')
+      media = load_yaml['media']
+      expect(media[0]['summary']).to eq('summary_a.md')
+      expect(media[1]['summary']).to eq('summary_b.md')
+      expect(media[2]['summary']).to eq('')
+    end
+
+    it 'sets summary on an image clip using the extension-flattened clip key' do
+      write_library(media: [image_entry('photo.jpg')])
+      touch(File.join(library_dir, 'summaries', 'summary_photo_jpg.md'))
+      Library.find(library_name).complete!('summary', ['photo.jpg'])
+      expect(load_yaml['media'][0]['summary']).to eq('summary_photo_jpg.md')
+    end
+
+    it 'raises when the field does not apply to the media type' do
+      write_library(media: [image_entry('photo.jpg')])
+      expect { Library.find(library_name).complete!('transcript', ['photo.jpg']) }
+        .to raise_error(ArgumentError, /transcript does not apply to image media/)
     end
 
     it 'returns self for chaining' do
@@ -558,13 +805,13 @@ RSpec.describe Library do
       File.delete(File.join(library_dir, 'summaries', 'summary_b.md'))
       expect { Library.find(library_name).complete!('summary', ['a.mov', 'b.mov']) }
         .to raise_error(ArgumentError, /summary file does not exist/)
-      expect(load_yaml['videos'][0]['summary']).to eq('')
+      expect(load_yaml['media'][0]['summary']).to eq('')
     end
 
-    it 'raises if a video is not present in library.yaml' do
+    it 'raises if a clip is not present in library.yaml' do
       touch(File.join(library_dir, 'summaries', 'summary_missing.md'))
       expect { Library.find(library_name).complete!('summary', ['missing.mov']) }
-        .to raise_error(ArgumentError, /video not found in library\.yaml/)
+        .to raise_error(ArgumentError, /media not found in library\.yaml/)
     end
 
     it 'raises for an unknown field name' do
@@ -574,13 +821,13 @@ RSpec.describe Library do
 
     it 'coerces a single filename into a one-element batch' do
       Library.find(library_name).complete!('summary', 'a.mov')
-      expect(load_yaml['videos'][0]['summary']).to eq('summary_a.md')
+      expect(load_yaml['media'][0]['summary']).to eq('summary_a.md')
     end
   end
 
   describe '#reset!' do
     before do
-      write_library(videos: [
+      write_library(media: [
                       video_entry('a.mov', summary: 'summary_a.md'),
                       video_entry('b.mov', summary: 'summary_b.md')
                     ])
@@ -593,7 +840,7 @@ RSpec.describe Library do
     it 'deletes referenced files and clears YAML fields' do
       Library.find(library_name).reset!('summary')
       expect(Dir.children(File.join(library_dir, 'summaries'))).to eq([])
-      expect(load_yaml['videos'].map { |v| v['summary'] }).to eq(['', ''])
+      expect(load_yaml['media'].map { |v| v['summary'] }).to eq(['', ''])
     end
 
     it 'sweeps orphan files in the directory' do
@@ -603,7 +850,7 @@ RSpec.describe Library do
     end
 
     it 'is variadic — wipes every named field in one call' do
-      write_library(videos: [
+      write_library(media: [
                       video_entry('a.mov', transcript: 'a.json', summary: 'summary_a.md',
                                   contact_sheet: 'a_full.jpg')
                     ])
@@ -613,7 +860,7 @@ RSpec.describe Library do
         File.join(library_dir, 'contact_sheets', 'a_full.jpg')
       )
       Library.find(library_name).reset!('transcript', 'summary', 'contact_sheet')
-      video = load_yaml['videos'].first
+      video = load_yaml['media'].first
       expect(video.values_at('transcript', 'summary', 'contact_sheet')).to eq(['', '', ''])
       expect(Dir.children(File.join(library_dir, 'transcripts'))).to eq([])
       expect(Dir.children(File.join(library_dir, 'summaries'))).to eq([])
@@ -621,14 +868,14 @@ RSpec.describe Library do
     end
 
     it 'leaves legacy visual_*.json files alone when resetting transcripts' do
-      write_library(videos: [video_entry('a.mov', transcript: 'a.json').merge('visual_transcript' => 'visual_a.json')])
+      write_library(media: [video_entry('a.mov', transcript: 'a.json').merge('visual_transcript' => 'visual_a.json')])
       touch(
         File.join(library_dir, 'transcripts', 'a.json'),
         File.join(library_dir, 'transcripts', 'visual_a.json')
       )
       Library.find(library_name).reset!('transcript')
       expect(Dir.children(File.join(library_dir, 'transcripts'))).to eq(['visual_a.json'])
-      expect(load_yaml['videos'].first['visual_transcript']).to eq('visual_a.json')
+      expect(load_yaml['media'].first['visual_transcript']).to eq('visual_a.json')
     end
 
     it 'raises for an unknown field name' do
@@ -648,7 +895,7 @@ RSpec.describe Library do
 
       lib = Library.find(library_name)
       expect { lib.reset!('summary') }.not_to raise_error
-      yaml = load_yaml['videos']
+      yaml = load_yaml['media']
       expect(yaml[0]['summary']).to eq('summary_a.md') # not cleared — delete failed
       expect(yaml[1]['summary']).to eq('')             # cleared — delete succeeded
     end
@@ -657,7 +904,7 @@ RSpec.describe Library do
   describe '#reset_metadata!' do
     before do
       write_library(
-        videos: [video_entry('a.mov')],
+        media: [video_entry('a.mov')],
         created_date: '2026-05-30', last_updated: '2026-05-30',
         language: 'english', editor: 'fcpx', transcript_refinement: true,
         footage_summary: 'A vlog about Ruby meetups.', user_context: 'Subject is named Andrew.'
@@ -672,10 +919,10 @@ RSpec.describe Library do
       expect(yaml.key?('transcript_refinement')).to be(true) # key kept so 002 migration treats it as set
     end
 
-    it 'keeps video records and dates' do
+    it 'keeps media records and dates' do
       Library.find(library_name).reset_metadata!
       yaml = load_yaml
-      expect(yaml['videos'].map { |v| v['path'] }).to eq(['/tmp/a.mov'])
+      expect(yaml['media'].map { |v| v['path'] }).to eq(['/tmp/a.mov'])
       expect(yaml.values_at('created_date', 'last_updated')).to eq(['2026-05-30', '2026-05-30'])
     end
 
@@ -687,7 +934,7 @@ RSpec.describe Library do
 
   describe '#remove_visual_transcripts!' do
     before do
-      write_library(videos: [
+      write_library(media: [
                       video_entry('a.mov', transcript: 'a.json').merge('visual_transcript' => 'visual_a.json'),
                       video_entry('b.mov', transcript: 'b.json').merge('visual_transcript' => 'visual_b.json')
                     ])
@@ -703,19 +950,19 @@ RSpec.describe Library do
       Library.find(library_name).remove_visual_transcripts!
       remaining = Dir.children(File.join(library_dir, 'transcripts')).sort
       expect(remaining).to eq(%w[a.json b.json])
-      expect(load_yaml['videos'].map { |v| v['visual_transcript'] }).to eq(['', ''])
+      expect(load_yaml['media'].map { |v| v['visual_transcript'] }).to eq(['', ''])
     end
 
     it 'leaves non-visual transcript files and other YAML fields intact' do
       Library.find(library_name).remove_visual_transcripts!
-      yaml = load_yaml['videos']
+      yaml = load_yaml['media']
       expect(yaml.map { |v| v['transcript'] }).to eq(%w[a.json b.json])
     end
 
     it 'is a no-op when no visual transcripts are present' do
       FileUtils.rm_rf(File.join(library_dir, 'transcripts'))
       FileUtils.mkdir_p(File.join(library_dir, 'transcripts'))
-      write_library(videos: [video_entry('a.mov', transcript: 'a.json')])
+      write_library(media: [video_entry('a.mov', transcript: 'a.json')])
       touch(File.join(library_dir, 'transcripts', 'a.json'))
       expect { Library.find(library_name).remove_visual_transcripts! }.not_to raise_error
       expect(Dir.children(File.join(library_dir, 'transcripts'))).to eq(['a.json'])
@@ -738,7 +985,7 @@ RSpec.describe Library do
 
       n = 30
       clips = Array.new(n) { |i| "clip#{i}.mov" }
-      write_library(videos: clips.map { |c| video_entry(c) }, footage_summary: '')
+      write_library(media: clips.map { |c| video_entry(c) }, footage_summary: '')
       clips.each { |c| touch(File.join(library_dir, 'transcripts', "#{File.basename(c, '.*')}.json")) }
 
       # Child: record each clip's transcript as its own complete! call.
@@ -764,7 +1011,7 @@ RSpec.describe Library do
 
       yaml = load_yaml
       # Every transcript landed (child's writes weren't clobbered by the parent)...
-      expect(yaml['videos'].map { |v| v['transcript'] }).to all(satisfy { |t| !t.to_s.empty? })
+      expect(yaml['media'].map { |v| v['transcript'] }).to all(satisfy { |t| !t.to_s.empty? })
       # ...and the parent's final metadata write survived (not reverted by a
       # concurrent complete!).
       expect(yaml['footage_summary']).to eq('FINAL')

--- a/spec/migrations_spec.rb
+++ b/spec/migrations_spec.rb
@@ -718,6 +718,70 @@ RSpec.describe 'Migration scripts' do
     end
   end
 
+  # ─── 005: rename top-level videos: → media: ───
+
+  describe '005_migrate_videos_to_media' do
+    before(:context) { load File.expand_path('../scripts/005_migrate_videos_to_media.rb', __dir__) }
+
+    def migrate(name = 'test-lib')
+      migrate_library(library_yaml_path(name))
+    end
+
+    it 'renames the top-level videos: key to media:' do
+      write_yaml(<<~YAML)
+        library_name: test-lib
+        videos:
+          - path: /tmp/DJI_0001.mov
+            duration: "00:05:00"
+            transcript: ""
+            contact_sheet: ""
+            summary: ""
+      YAML
+
+      expect(migrate).to be true
+      data = read_yaml
+      expect(data).to have_key('media')
+      expect(data).not_to have_key('videos')
+      expect(data['media'].first['path']).to eq('/tmp/DJI_0001.mov')
+    end
+
+    it 'preserves quote styles and indentation elsewhere — only the key line changes' do
+      original = <<~YAML
+        library_name: test-lib
+        footage_summary: "Wedding footage from São Paulo"
+        videos:
+          - path: /tmp/a.mov
+            duration: "00:05:00"
+      YAML
+      write_yaml(original)
+      migrate
+      expect(read_raw).to eq(original.sub(/^videos:/, 'media:'))
+    end
+
+    it 'is a no-op when already on media: (idempotent)' do
+      write_yaml(<<~YAML)
+        library_name: test-lib
+        media:
+          - path: /tmp/a.mov
+            summary: ""
+      YAML
+      expect(migrate).to be false
+      expect(read_yaml).to have_key('media')
+    end
+
+    it 'is a no-op when there is no videos: key at all' do
+      write_yaml(<<~YAML)
+        library_name: test-lib
+        media: []
+      YAML
+      expect(migrate).to be false
+    end
+
+    it 'returns false for a nonexistent library file' do
+      expect(migrate_library('/nonexistent/library.yaml')).to be false
+    end
+  end
+
   # ─── migrate_all.rb orchestrator ───
 
   describe 'migrate_all' do
@@ -732,13 +796,14 @@ RSpec.describe 'Migration scripts' do
         expect(output).to include('002_migrate_add_transcript_refinement.rb')
         expect(output).to include('003_migrate_add_summary.rb')
         expect(output).to include('004_migrate_roughcuts_to_cuts.rb')
+        expect(output).to include('005_migrate_videos_to_media.rb')
       end
     end
 
     it 'runs scripts in numeric order' do
       Dir.chdir(repo_root) do
         output = `ruby #{script_path} 2>&1`
-        positions = %w[001 002 003 004].map { |n| output.index(n) }
+        positions = %w[001 002 003 004 005].map { |n| output.index(n) }
         expect(positions).to eq(positions.sort)
       end
     end
@@ -823,16 +888,21 @@ RSpec.describe 'Migration scripts' do
       expect(File.directory?(File.join(library_dir, 'roughcuts'))).to be false
       expect(File.read(File.join(library_dir, 'cuts', 'first_draft.xml'))).to eq('<timeline/>')
 
-      # Verify final state
+      # Run 005: videos: → media:
+      load File.expand_path('../scripts/005_migrate_videos_to_media.rb', __dir__)
+      expect(migrate_library(library_yaml_path)).to be true
+
+      # Verify final state — now on the current media: schema
       final = read_yaml
       expect(final['library_name']).to eq('legacy-project')
       expect(final['language']).to eq('english')
       expect(final['transcript_refinement']).to be false
       expect(final['user_context']).to eq('The woman in red is Maria')
+      expect(final).not_to have_key('videos')
 
-      # All three videos still present with correct data
-      expect(final['videos'].size).to eq(3)
-      expect(final['videos'].map { |v| v['path'] }).to eq([
+      # All three clips still present with correct data, under media:
+      expect(final['media'].size).to eq(3)
+      expect(final['media'].map { |v| v['path'] }).to eq([
         '/Volumes/SSD/wedding/DJI_0001.mov',
         '/Volumes/SSD/wedding/DJI_0002.mov',
         '/Volumes/SSD/wedding/DJI_0003.mov'
@@ -848,6 +918,8 @@ RSpec.describe 'Migration scripts' do
       migrate_library(library_yaml_path)
       load File.expand_path('../scripts/004_migrate_roughcuts_to_cuts.rb', __dir__)
       migrate_library(library_dir)
+      load File.expand_path('../scripts/005_migrate_videos_to_media.rb', __dir__)
+      migrate_library(library_yaml_path)
       expect(read_raw).to eq(snapshot)
     end
 

--- a/templates/library_template.yaml
+++ b/templates/library_template.yaml
@@ -9,14 +9,18 @@ user_context: ""
 # Whenever you ask the user questions about the library, save a summarized version here.
 # ie; The man wearing the dark blue long sleeve shirt is "Andrew". The small brown dog is "Sammy". This footage was shot over one evening.
 
-# Full footage summary - progressively updated after each video is transcribed. This can be up to 10-20 lines summarizing all of the footage we have.
+# Full footage summary - progressively updated after each clip is analyzed. This can be up to 10-20 lines summarizing all of the footage we have.
 footage_summary: "No footage analyzed yet."
 # "This footage appears to be wedding footage. It includes the bride and groom getting dressed, preparing for the wedding ceremomy, the ceremony, and the post ceremony dinner and party."
 # "This footage appears to be a vlog. The footage starts in The Richmond District in San Francisco, includes a bus ride on the 38R, and concludes at a Ruby Meetup in downtown San Francisco."
 
-# Video files and analysis status
+# Media files and analysis status
 #
-# Per clip, analysis fills three fields:
+# Each entry's type (video or image) is inferred from its file extension —
+# never stored here. Videos: mov/mp4/mts/m2ts/mxf/avi. Images: jpg/jpeg/png.
+# (See "Supported media formats" in AGENTS.md.)
+#
+# Per video, analysis fills three fields:
 #   transcript     — audio transcript JSON (word-level timing, in transcripts/);
 #                    also the source for on-demand dialogue extraction via
 #                    lib/buttercut/script_extractor.rb
@@ -24,11 +28,17 @@ footage_summary: "No footage analyzed yet."
 #                    sheets for clips >10 min live alongside on disk
 #   summary        — markdown overview (in summaries/)
 #
+# Per image, analysis fills only `summary` — a short 3-4 sentence greppable
+# description (in summaries/, named summary_<basename>_<ext>.md). Images carry
+# no duration, transcript, or contact_sheet keys at all.
+#
 # Note: visual_transcript is deprecated. Older libraries may still carry the
 # field; new libraries use the contact_sheet field instead.
-videos:
+media:
   - path: /full/path/to/video_file.mp4
     duration: "00:05:32"
     transcript: # filename only (stored in libraries/[library-name]/transcripts/)
     contact_sheet: # filename only (_full.jpg in libraries/[library-name]/contact_sheets/)
     summary: # filename only (summary_*.md in libraries/[library-name]/summaries/)
+  - path: /full/path/to/photo.jpg
+    summary: # filename only (summary_<basename>_<ext>.md in libraries/[library-name]/summaries/)

--- a/templates/settings_template.yaml
+++ b/templates/settings_template.yaml
@@ -14,10 +14,6 @@ whisper_model: small
 # higher values can exhaust RAM on smaller machines. Leave blank to use 2.
 parallel_jobs: 2
 
-# Default hold length (seconds) for a still image in a cut when the clip
-# doesn't specify its own `duration:`. Leave blank to use 5 seconds.
-# still_duration: 5
-
 # After exporting a roughcut, also drop a copy of the XML on the Desktop for easy import
 save_to_desktop_after_export: true
 

--- a/templates/settings_template.yaml
+++ b/templates/settings_template.yaml
@@ -14,6 +14,10 @@ whisper_model: small
 # higher values can exhaust RAM on smaller machines. Leave blank to use 2.
 parallel_jobs: 2
 
+# Default hold length (seconds) for a still image in a cut when the clip
+# doesn't specify its own `duration:`. Leave blank to use 5 seconds.
+# still_duration: 5
+
 # After exporting a roughcut, also drop a copy of the XML on the Desktop for easy import
 save_to_desktop_after_export: true
 


### PR DESCRIPTION
## Summary

Libraries can now hold **still images** (JPEG/PNG) alongside video. The `library.yaml` `videos:` array becomes `media:`, with the media type inferred from each file's extension (never stored). Images are deliberately lightweight — only a short `summary`, no transcript / contact sheet / duration — and flow through cuts and exported XML for all three editors as held, single-track stills.

## What's included

- **Library core** — a `MEDIA_TYPES` registry drives everything type-aware (`ready?`, `pending`, `incomplete_media`, `complete!`, `reset!`), so adding a type is one registry entry. Type inference (`media_type_of`), extension-flattened image clip keys (so a photo and a video sharing a basename can't collide on artifact names), `add_media` / `remove_media!` / `unsupported_media`, and a hard load guard on the legacy `videos:` key.
- **Migration 005** (`videos:` → `media:`) — a pure textual key rename, idempotent, wired into `migrate_all`.
- **Export + generators** — image clips carry a `duration:` (default 5s, or `still_duration` in settings). Stills emit correctly for each editor: FCPXML rate-undefined formats + timeless assets + `<video>` spine elements; xmeml `<stillframe>TRUE</stillframe>` with file-duration = timeline-duration and no audio clipitems/links. Optional cut-level `timeline:` block (frame rate / resolution) for image-only cuts or format overrides. Also hardens `src`/`pathurl` to percent-encode every path segment (fixes a latent missing-media bug on spaces / non-ASCII filenames).

## Verification

Exported a stress library (real 4K footage + ffmpeg-generated images across formats and dimensions — JPEG/PNG/JPEG, HD/4K/square/portrait/odd) through mixed, image-only, and bookend cuts, then **imported the XML into Final Cut Pro, Premiere, and DaVinci Resolve**. All three: correct still durations (e.g. an all-stills cut lands at exactly 21s = 7×3s), off-format stills letterboxed/pillarboxed correctly, every clip online (no missing media), no audio under stills, and the `timeline:` frame-rate override honored (sequence created at exactly 24.00 fps). The XML opening in the editor — not the unit tests — is the source of truth here.

## Tests

302 examples, 0 failures. Rewrote `library_spec` for the media API (+ image/type coverage), added `generator_stills_spec` exercising still handling across FCPX/FCP7/Resolve/Premiere (rate-undefined formats, timeless assets, `<video>` spine, stillframe, no audio/links, no rotation filter on images, encoded URLs, the stills-need-duration guard, FCPXML DTD validation), and migration 005 specs.

## Docs

AGENTS.md (migration trigger + "Supported media formats" explainer + images principle), `lib/buttercut/library.md`, and the create-library / process-library / analyze-video / cut skills (image clips + the `timeline:` block). Customer-facing changelog entry under `[Unreleased]`.

Targets **0.8.0**. The release ceremony (version bump, tag, GitHub release) is intentionally left out of this PR.