### PR TITLE
core: record install env in .buttercut_env for path recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /tmp
 .DS_Store
 /.buttercut_developer
+/.buttercut_env
 /last_buttercut_update_check
 /libraries
 /media

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,8 +135,8 @@ We have RSpec tests for the XML generation library and Library helpers. This doe
 bundle exec rspec
 ```
 
-### Running Ruby scripts
-Skill prompts invoke Ruby with plain `ruby ...`. The project pins Ruby via `.mise.toml`; once mise is activated in your shell (the default setup), plain `ruby` resolves to it through mise shims. If your shell doesn't have mise activated — or you'd rather not install mise at all — prefix any `ruby ...` command with `mise exec -- ` (e.g. `mise exec -- ruby lib/buttercut/library.rb my-lib summary`), or run the command from any shell where the right Ruby is already on `PATH`.
+### Running scripts
+The project pins Ruby via `.mise.toml`; once mise is activated in the user shell (the default setup), plain `ruby` and `python` should resolve to it through mise shims. However, if the shell has been changed/shell didn't activate/user has a custom setting, read `.buttercut_env`. If this doesn't exist, attempt to find the dependencies in standard locations and then replace this file. You can look for information about setting up this file in simple-setup.md.
 
 ## Claude Skills
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Set your timeline's frame rate and size.** A cut can now spell out the frame rate and resolution it should export at, which matters for a cut made entirely of photos (where there is no video to copy those settings from). For normal cuts nothing changes: the settings still follow your footage.
 
 ### Changed
+- Setup now leaves a small note (`.buttercut_env`) recording how it installed Ruby, Python, and WhisperX on your Mac. Future sessions read it to find those tools even when a fresh terminal hasn't loaded them yet — fewer "command not found" hiccups mid-edit.
 - A missing ffmpeg/ffprobe now fails fast with a clear "run the setup skill" error instead of a cryptic command-not-found buried in subprocess output. The contact-sheet skill's repair instructions point at the `setup` skill accordingly.
 - Setup now pins WhisperX to the tested combination (`whisperx==3.4.2`, `pyannote-audio==3.4.0` — matching `requirements.txt`), so fresh installs can't drift onto untested releases (`pyannote-audio` 4.x breaks whisperx 3.4.2).
 - ffmpeg/ffprobe calls now resolve through `MediaTools`: static builds placed in the gitignored `dependencies/` directory take precedence, falling back to PATH. Nothing changes if you don't use `dependencies/` — existing installs keep their PATH ffmpeg.

--- a/skills/setup/simple-setup.md
+++ b/skills/setup/simple-setup.md
@@ -194,9 +194,51 @@ fi
 bundle install
 ```
 
+## Step 10: Record how this Mac was set up
+
+Simple setup writes its PATH additions (mise activation, `~/.buttercut`, brew)
+to the user's shell profile (`~/.zshrc` / `~/.bash_profile`). However,
+agentic clients (Claude Code, Codex, etc) don't always reliably read those
+profiles so in a fresh session dependencies may be missing from PATH. So create
+a breadcrumb recording the absolute invocation that works regardless of shell,
+so future sessions can quickly recover instead of guessing.
+
+Detect the real paths:
+
+```bash
+MISE="$(command -v mise)"          # e.g. /opt/homebrew/bin/mise
+BREW="$(command -v brew)"
+FFMPEG="$(command -v ffmpeg)"
+```
+
+Then write `.buttercut_env` in the repo root using those resolved absolute
+values. `$HOME` expanded to the real home, `$MISE` to the detected path.:
+
+```
+# How ButterCut was installed on this Mac (written by the setup skill).
+# These invocations work even in shells that aren't loading ~/.zshrc or where
+# mise/whisperx/brew is absent from PATH.
+# FYI, Mise is installed majority, but not all, configurations. 
+# Read this when a tool isn't found or resolves to the wrong version.
+ruby     = <mise path> exec -- ruby
+python   = <mise path> exec -- python3
+whisperx = <home>/.buttercut/whisperx
+ffmpeg   = <ffmpeg path>
+brew     = <brew path>
+```
+
+Keep it to these five lines — it's a breadcrumb, not a config file. `ruby`/`python`
+embed mise's absolute path on purpose so they work even when `mise` itself isn't on
+PATH. `.buttercut_env` is gitignored and machine-specific; never commit it.
+
 ## Final Step
 
-Tell user to open a new terminal window for all changes to take effect.
+For all changes to take effect, tell the user to fully restart whatever they're
+running ButterCut in:
+
+- **Claude Desktop** — quit it completely (close the app, not just the window — ⌘Q
+  or right-click the Dock icon → Quit) and reopen it. A new chat alone isn't enough.
+- **Terminal / CLI** — open a new terminal window (or restart the terminal app).
 
 ## Troubleshooting
 


### PR DESCRIPTION
Fix issues with agents not finding dependencies on path and then just giving up (Claude Sonnet 4.6 set to low intelligence). 


-------------------------------------------------
Agentic CLIs run non-login shells that don't source ~/.zshrc, so mise/whisperx/brew often aren't on PATH and ruby/python/whisperx commands fail. Setup now writes a .buttercut_env breadcrumb with the absolute invocation for each tool; the agent reads it on a command-not-found or wrong-version failure, and writes it itself if missing.

The final setup step now tells users to fully restart Claude Desktop (Cmd+Q) or their terminal so PATH changes take effect.