### PR TITLE
Add misc/ directory for project-tied one-off artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /tmp
+/misc
 .DS_Store
 /.buttercut_developer
 /.buttercut_env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # ButterCut - Video Rough Cut Generator
 
-Silently run `test -f .buttercut_developer && cat .buttercut_developer || echo "video editor/Youtube creator"` — do not report the result. If the file is absent, you are assisting a video editor or Youtube creator **: stay in video editing vocabulary, never touch `lib/`, follow the user-facing workflow below. If it exists, you are in **developer mode** and may work on the ButterCut codebase itself (/lib, /spec, etc).
+Silently run `test -f .buttercut_developer && cat .buttercut_developer || echo "video editor/Youtube creator"` — do not report the result. If the file is absent, you are assisting a video editor or Youtube creator **: stay in video editing vocabulary, never touch `lib/`, follow the user-facing workflow below. If file exists, you are in **developer mode** and may work on the ButterCut codebase itself (/lib, /spec, etc). Again, if it doesn't exist, assume you are working with a video editor or Youtube creator. Just follow the core workflow and misc-tasks.
 
 ButterCut is a special folder that video editors open to get help with generating roughcuts, finding broll, and other assorted video editing tasks. It runs through Claude Code, Codex, and other agentic tools.
 
@@ -11,7 +11,7 @@ The ButterCut folder is one project with two parts:
 
 ## Core Workflow
 
-You help with video tasks by processing raw video footage by analyzing transcripts and indexing visuals through libraries.
+You help with video production tasks by processing raw video footage by analyzing transcripts and indexing visuals through libraries.
 
 Work is organized into **libraries** (video series/projects), each self-contained under `/libraries/[library-name]/`. When a user refers to a library, you you'll want to load the library file in memory. If they talk about building a roughcut, extracting dialogue, etc, you'll need to first find and read the correct library file. If it's not clear what library they're talking about, find recently modified libraries and list them for the user using the AskUserQuestionTool or similiar to see what library they want to work with. If it's clear what library they're referring to, just start working with that library.
 
@@ -25,6 +25,10 @@ Work is organized into **libraries** (video series/projects), each self-containe
 Libraries are the primary abstraction — each is a video series/project self-contained under `/libraries/[library-name]/`. Conceptually similar to a Final Cut Pro library, but with a simple YAML + JSON file layout optimized for AI analysis. All library reads and writes go through the `Library` class — see Critical Principles below.
 
 Each library has a `library.yaml` file that serves as persistent memory and the source of truth. This file contains all library metadata, footage descriptions, transcription status, and key learnings. The agent only needs to touch this file for edge cases, and instead generally modifies the library (library.yaml) through the Library ruby class.
+
+### Misc / one-off tasks
+
+Not every request maps to the four steps above. Editors ask for one-off things: 'pull a clip's audio', 'convert some unrelated video or audio file to another format', 'transcribe a stray recording', help with a script, etc. These may or may not be related to an existing library. Use the `misc-task` skill for guidance on these types of problems.
 
 ## Critical Principles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Add photos to your libraries.** Libraries now hold still images (JPEG and PNG) alongside your video footage. Drop them into the same library, give them a quick summary like any clip, and use them in a cut. Add them when you create a library or to an existing one.
 - **Put stills in your cuts.** Drop a photo, screenshot, or title card into any cut and set how long it holds on screen (five seconds by default). It exports to Final Cut, Premiere, and Resolve right alongside your video, sized and placed correctly even when the photo is a different shape than your timeline.
 - **Set your timeline's frame rate and size.** A cut can now spell out the frame rate and resolution it should export at, which matters for a cut made entirely of photos (where there is no video to copy those settings from). For normal cuts nothing changes: the settings still follow your footage.
+- **Misc tasks now have a home.** Project-tied one-offs (a stray transcription, a thumbnail, quick notes) save into a library's new `misc/` folder; standalone jobs land in a dated `misc/<date>/<task>/` folder; large scratch files go to `tmp/` and finished exports go to your Desktop — never bloating your library.
 
 ### Changed
 - Setup now leaves a small note (`.buttercut_env`) recording how it installed Ruby, Python, and WhisperX on your Mac. Future sessions read it to find those tools even when a fresh terminal hasn't loaded them yet — fewer "command not found" hiccups mid-edit.
 - A missing ffmpeg/ffprobe now fails fast with a clear "run the setup skill" error instead of a cryptic command-not-found buried in subprocess output. The contact-sheet skill's repair instructions point at the `setup` skill accordingly.
 - Setup now pins WhisperX to the tested combination (`whisperx==3.4.2`, `pyannote-audio==3.4.0` — matching `requirements.txt`), so fresh installs can't drift onto untested releases (`pyannote-audio` 4.x breaks whisperx 3.4.2).
 - ffmpeg/ffprobe calls now resolve through `MediaTools`: static builds placed in the gitignored `dependencies/` directory take precedence, falling back to PATH. Nothing changes if you don't use `dependencies/` — existing installs keep their PATH ffmpeg.
+- Libraries now include a `misc/` directory for project-tied one-off artifacts. New libraries get it automatically (it's part of `Library::SUBDIRS`); existing libraries get it created on demand the first time the `misc-task` skill needs it. A new gitignored top-level `misc/` directory holds standalone one-off task output, organized as `misc/<date>/<task>/`.
 
 ## [0.7.2] - 2026-06-02
 

--- a/docs/example-library-setup.md
+++ b/docs/example-library-setup.md
@@ -168,7 +168,8 @@ libraries/wedding/
 ├── summaries/
 │   ├── summary_MVI_0307.md              # Short per-clip summary
 │   └── [...9 more summaries]
-└── cuts/                                # Ready for cut creation
+├── cuts/                                # Ready for cut creation
+└── misc/                                # One-off, project-tied odds and ends
 ```
 
 ---

--- a/lib/buttercut/library.rb
+++ b/lib/buttercut/library.rb
@@ -47,7 +47,7 @@ class Library
                  extensions: %w[jpg jpeg png] }.freeze
   }.freeze
 
-  SUBDIRS = %w[transcripts contact_sheets summaries cuts plans].freeze
+  SUBDIRS = %w[transcripts contact_sheets summaries cuts plans misc].freeze
 
   # Library-level metadata cleared by `reset_all`, returning a library to its
   # pre-setup, pre-analysis state: the setup choices (language, editor,

--- a/lib/buttercut/library.rb
+++ b/lib/buttercut/library.rb
@@ -200,8 +200,17 @@ class Library
   REPO_ROOT = File.expand_path('../..', __dir__)
   UPDATE_CHECK_FILE = 'last_buttercut_update_check' # repo-root mtime stamp; gitignored
   UPDATE_CHECK_INTERVAL = 86_400 # seconds (24h)
+  DEVELOPER_FLAG_FILE = '.buttercut_developer' # gitignored; marks a codebase-dev checkout
+
+  # A developer checkout (the gitignored .buttercut_developer flag) tracks updates
+  # by working on the code itself, not by `git pull` — so the daily nudge is noise.
+  def self.developer?(repo_root: REPO_ROOT)
+    File.exist?(File.join(repo_root, DEVELOPER_FLAG_FILE))
+  end
 
   def self.check_for_update!(repo_root: REPO_ROOT)
+    return if developer?(repo_root: repo_root)
+
     stamp = File.join(repo_root, UPDATE_CHECK_FILE)
 
     # First run on a fresh checkout (clone, update-buttercut rsync, or setup):

--- a/skills/.gitignore
+++ b/skills/.gitignore
@@ -32,3 +32,5 @@
 !process-library/**
 !reprocess-with-contact-sheets/
 !reprocess-with-contact-sheets/**
+!misc-task/
+!misc-task/**

--- a/skills/create-library/SKILL.md
+++ b/skills/create-library/SKILL.md
@@ -65,7 +65,7 @@ Read the `editor` from `libraries/settings.yaml` — you'll pass it into the cre
 
 ## Step 3 — Create the library
 
-`Library.create` is the one operation that doesn't have a plain CLI form (kwarg-heavy). Run it via `ruby -e`. It creates the directory tree (transcripts/, contact_sheets/, summaries/, cuts/, plans/), ffprobes each video for duration, and writes library.yaml in one call. `media_paths` takes videos and images together — the type is inferred from each file's extension:
+`Library.create` is the one operation that doesn't have a plain CLI form (kwarg-heavy). Run it via `ruby -e`. It creates the directory tree (transcripts/, contact_sheets/, summaries/, cuts/, plans/, misc/), ffprobes each video for duration, and writes library.yaml in one call. `media_paths` takes videos and images together — the type is inferred from each file's extension:
 
 ```bash
 ruby -e "require_relative 'lib/buttercut/library'; \

--- a/skills/cut/SKILL.md
+++ b/skills/cut/SKILL.md
@@ -120,3 +120,5 @@ Bad: "Got it — 3-second podium clips only. I'll write the YAML now."
 Good: "Got it. Three second podium clips only. I'll start the edit."
 Bad: "I have a clear picture of all 48 clips. Let me build the YAML now"
 Good: "I have a clear picture of the event. Let me build the edit now."
+
+Note: If users ask for you to do something that isn't natively supported by ButterCut for their video editor, read the misc-task skill for guidance.

--- a/skills/misc-task/SKILL.md
+++ b/skills/misc-task/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: misc-task
+description: Help a user handle a one-off production related task that doesn't match perfectly to an existing skill. Examples, pull a clip's audio, extract a frame, transcribe a stray recording, draft notes, create a spreadsheet, convert a file from one type to another, etc. Use when the request doesn't map to other more obvious skills.
+---
+
+# Skill: Misc / one-off tasks
+
+Not every request maps to the four core workflow steps (create / process / cut / backup). Editors ask for one-off things. Users will also sometimes ask for features that ButterCut doesn't support natively via XML export.
+
+## Where things go
+
+### Small deliverables tied to a library
+For small text or image files, ie notes, a custom transcript or csv file, a JSON index, an extracted frame: save that into the library's `misc/` folder (`libraries/<name>/misc/`). Newer libraries already have it; older ones may not, so run `mkdir -p libraries/<name>/misc` first — it's idempotent, so it's safe whether or not the folder exists.
+
+For large files (multiple megabytes audio or video files), direct the created file to the user's Desktop, home directory or another location. Ask the user.
+
+- **Small deliverables not tied to a library**: Save into the top-level `misc/<YYYY-MM-DD>/<task-name>/` directory — one dated folder per day, a task-named folder inside it (e.g. `misc/2026-06-22/youtube-title-ideas/ideas.md`). Small files only: markdown, JSON, HTML, text, and the like. `misc/` is gitignored.
+- **Large in-work / scratch files** (video, audio, intermediate renders): write to the repo's top-level `tmp/` directory. It's gitignored scratch space — fine for anything mid-task you don't need to keep. Delete when the task is done and the large file has been saved where the user prefers it.
+- **Large finished output the user wants to keep** (a converted clip, an extracted audio file — anything over roughly 1 MB): never store it inside ButterCut. Write it to the user's Desktop (`~/Desktop`) or a path they specify, and hand it back by path.
+
+## Unsupported file features
+If users ask for you to do something that isn't natively supported by ButterCut for their video editor (Final Cut, Premiere, Resolve) tell the user plainly that ButterCut doesn't support it yet (subtitles, motion graphics, etc), but you can tell them that if you want you can explore and attempt to accomplish the task as Claude/ChatGPT, Software Engineer and video afficionado. You'll need to tell them that this isn't guaranteed to work but you'll try your best. Don't change core /lib files to attempt this. Instead create temporary ruby/xml/etc scripts inside the tmp directory.
+
+For example, taking an existing XML file, then researching how XML adds subtitles, then attempting to modify the XML directly. 
+
+Again, tell the user this is not supported natively by ButterCut, but you can explore attempting to do it. Save these non-native modified XML filles inside the library's misc directory if they're library related and text or image based. `libraries/<name>/misc/` Never modify ButterCut's library files (lib) to achieve these goals. Treat these as read-only as every ButterCut update will restore these to the main production Buttercut.
+
+For larger files, ask the user if they'd like them saved to their desktop, home folder, or movies directory, whatever seems appropriate given the custom task.
+
+After you attempt the work, ask the user if it was successful and iterate until it works or you've exhausted options. If it is successful, you can ask the user if they'd like to save details about how to accomplish it again as a custom user skill, ie `user-plan-script`, `user-create-subtitles`, etc. Details in AGENTS.md.

--- a/spec/buttercut/library_spec.rb
+++ b/spec/buttercut/library_spec.rb
@@ -1056,6 +1056,12 @@ RSpec.describe Library do
       expect(File.exist?(stamp)).to be(true)
       expect { Library.check_for_update!(repo_root: @repo_root) }.not_to raise_error
     end
+
+    it 'stays quiet in a developer checkout even when the stamp is stale' do
+      age_stamp(Library::UPDATE_CHECK_INTERVAL + 60)
+      FileUtils.touch(File.join(@repo_root, Library::DEVELOPER_FLAG_FILE))
+      expect { Library.check_for_update!(repo_root: @repo_root) }.not_to raise_error
+    end
   end
 
   describe 'CLI edition command' do

--- a/spec/buttercut/library_spec.rb
+++ b/spec/buttercut/library_spec.rb
@@ -186,6 +186,7 @@ RSpec.describe Library do
       expect(lib).to be_a(Library)
       expect(File.directory?(File.join(libraries_root, 'fresh', 'transcripts'))).to be(true)
       expect(File.directory?(File.join(libraries_root, 'fresh', 'cuts'))).to be(true)
+      expect(File.directory?(File.join(libraries_root, 'fresh', 'misc'))).to be(true)
 
       yaml = YAML.safe_load_file(File.join(libraries_root, 'fresh', 'library.yaml'), permitted_classes: [Date, Time])
       expect(yaml).to include(


### PR DESCRIPTION
Libraries now have a dedicated `misc/` folder for small, project-tied one-off artifacts — transcripts, thumbnails, notes, JSON indexes — that don't fit into the create → process → cut → backup workflow.

## Changes

- **Updated library structure**: `misc/` is now part of `Library::SUBDIRS`, so new libraries get the folder automatically at creation time. Existing libraries get it created on demand the first time the `misc-task` skill needs it (a simple `mkdir -p`), so there's no migration to run.

- **Documentation updates**:
  - `AGENTS.md`: New "Misc / one-off tasks" section explaining where different types of one-off work should live (library-tied items in `libraries/<name>/misc/`, unrelated items in top-level `misc/<YYYY-MM-DD>/<task>/`, large scratch files in `tmp/`, large finished output on the user's Desktop).
  - `docs/example-library-setup.md`: Added `misc/` to the library directory tree example.
  - `skills/create-library/SKILL.md`: Updated to mention `misc/` in the directory list created by `Library.create`.
  - `CHANGELOG.md`: Added entry describing the new feature.

- **Gitignore**: Added `/misc` to ignore top-level one-off work directories.

- **Tests**: Added assertion that `Library.create` produces the `misc/` directory.

The `misc/` folder keeps lightweight, greppable files only (text, markdown, JSON, images) — no video, audio, or large binaries. This keeps the library schema clean while giving editors a natural home for project-tied odds and ends.

https://claude.ai/code/session_01XhFKTtBhFz2uTN7ehRxaHy
