### PR TITLE
core: scale Premiere clips to fit the sequence frame

### DIFF
--- a/lib/buttercut/premiere.rb
+++ b/lib/buttercut/premiere.rb
@@ -10,6 +10,12 @@ class ButterCut
   # source rotation flag, so the same XML imports sideways. Premiere therefore needs the
   # rotation written explicitly into the timeline.
   #
+  # The same gap applies to frame size. Final Cut (spatial conform) and Resolve ("scale
+  # entire image to fit") auto-fit a clip whose native resolution differs from the
+  # sequence; Premiere maps an FCP7 clip 1:1, so a 4K clip in a 1080 timeline imports
+  # cropped to its center (i.e. "zoomed in"). Premiere therefore also needs a scale-to-fit
+  # written explicitly — folded into the same Basic Motion filter as the rotation.
+  #
   class Premiere < FCP7
     # The sequence frame follows the first video clip's *display* orientation, so a
     # quarter-turn source gives a portrait timeline (the stored landscape dimensions
@@ -30,14 +36,13 @@ class ButterCut
       [90, 270].include?(video_rotation(video_path))
     end
 
-    # Premiere ignores the source rotation flag, so bake the rotation into the timeline
-    # as a Basic Motion effect. Rotation is clockwise-positive; 270 is written as -90 so
-    # the applied turn is the short way around.
+    # Premiere ignores both the source rotation flag and any frame-size mismatch, so bake
+    # the rotation AND a scale-to-fit into the timeline as one Basic Motion effect. A clip
+    # already upright and at sequence size needs neither, so it gets no filter at all.
     def add_video_filters(xml, payload)
-      rotation = payload[:asset][:rotation].to_i
-      return if rotation.zero?
-
-      degrees = rotation > 180 ? rotation - 360 : rotation
+      degrees = rotation_degrees(payload[:asset])
+      scale = scale_to_fit(payload[:asset])
+      return if degrees.zero? && scale.nil?
 
       xml.filter do
         xml.effect do
@@ -46,15 +51,52 @@ class ButterCut
           xml.effectcategory 'motion'
           xml.effecttype 'motion'
           xml.mediatype 'video'
-          xml.parameter do
-            xml.parameterid 'rotation'
-            xml.name 'Rotation'
-            xml.valuemin(-100000)
-            xml.valuemax 100000
-            xml.value degrees
+          if scale
+            xml.parameter do
+              xml.parameterid 'scale'
+              xml.name 'Scale'
+              xml.valuemin 0
+              xml.valuemax 1000
+              xml.value scale
+            end
+          end
+          unless degrees.zero?
+            xml.parameter do
+              xml.parameterid 'rotation'
+              xml.name 'Rotation'
+              xml.valuemin(-100000)
+              xml.valuemax 100000
+              xml.value degrees
+            end
           end
         end
       end
+    end
+
+    # Rotation clockwise-positive; 270 is written as -90 so the applied turn is the short
+    # way around. 0 (upright) means no rotation parameter.
+    def rotation_degrees(asset)
+      rotation = asset[:rotation].to_i
+      rotation > 180 ? rotation - 360 : rotation
+    end
+
+    # Percent scale that fits the clip's *display* frame (post-rotation) inside the
+    # sequence, contained (letterboxed) so nothing is cropped — the min of the width and
+    # height ratios. Returns nil when the clip already fills the frame (≈100%), so a
+    # same-size clip gets no scale parameter. Stills are scaled too: a 4K screenshot in a
+    # 1080 timeline would otherwise zoom the same way a 4K video does.
+    def scale_to_fit(asset)
+      return nil unless asset[:width] && asset[:height]
+
+      quarter = [90, 270].include?(asset[:rotation].to_i)
+      display_width = quarter ? asset[:height] : asset[:width]
+      display_height = quarter ? asset[:width] : asset[:height]
+
+      factor = [format_width.to_f / display_width, format_height.to_f / display_height].min
+      percent = (factor * 100).round(4)
+      return nil if (percent - 100).abs < 0.01
+
+      percent
     end
   end
 end

--- a/spec/buttercut/premiere_spec.rb
+++ b/spec/buttercut/premiere_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe ButterCut::Premiere do
   end
 
   let(:cw_rotated_clip_path) { '/tmp/premiere_cw_rotated.mov' }
+  let(:oversized_clip_path)  { '/tmp/premiere_oversized.mov' }
 
   let(:metadata_by_path) do
     {
@@ -47,7 +48,9 @@ RSpec.describe ButterCut::Premiere do
       upright_clip_path => build_metadata(duration_seconds: 3.0, width: 1920, height: 1080),
       # Vertical footage rotated the other quarter-turn: a +90 display-matrix flag
       # normalizes to 270 clockwise, which the timeline writes the short way as -90.
-      cw_rotated_clip_path => build_metadata(duration_seconds: 4.0, width: 3840, height: 2160, rotation: 90)
+      cw_rotated_clip_path => build_metadata(duration_seconds: 4.0, width: 3840, height: 2160, rotation: 90),
+      # 4K landscape, upright — a second-camera angle larger than a 1080 sequence.
+      oversized_clip_path => build_metadata(duration_seconds: 4.0, width: 3840, height: 2160)
     }
   end
 
@@ -76,6 +79,30 @@ RSpec.describe ButterCut::Premiere do
       xml = described_class.new([{ path: cw_rotated_clip_path }]).to_xml
 
       expect(xml).to match(%r{<parameterid>rotation</parameterid>.*?<value>-90</value>}m)
+    end
+
+    # Premiere maps an FCP7 clip 1:1, so a 4K clip in a 1080 sequence imports cropped to
+    # its center ("zoomed in"). A scale-to-fit must be baked in. The first clip (1080)
+    # sets the sequence; the 4K second clip scales to 50% (1920/3840) to fit.
+    it 'writes a Basic Motion scale-to-fit for a clip larger than the sequence' do
+      doc = Nokogiri::XML(
+        described_class.new([{ path: upright_clip_path }, { path: oversized_clip_path }]).to_xml
+      )
+      clipitems = doc.xpath('/xmeml/sequence/media/video/track/clipitem')
+      by_name = clipitems.each_with_object({}) { |ci, h| h[ci.at_xpath('name').text] = ci }
+
+      def_scale = ->(ci) { ci.at_xpath(".//filter/effect[name='Basic Motion']/parameter[parameterid='scale']/value")&.text }
+
+      # The sequence-sized first clip needs no scaling; the 4K clip fits at 50%.
+      expect(def_scale.call(by_name['premiere_upright'])).to be_nil
+      expect(def_scale.call(by_name['premiere_oversized'])).to eq('50.0')
+    end
+
+    it 'does not scale a clip that already matches the sequence frame' do
+      xml = described_class.new([{ path: upright_clip_path }]).to_xml
+
+      expect(xml).not_to include('<parameterid>scale</parameterid>')
+      expect(xml).not_to include('<name>Basic Motion</name>')
     end
 
     # The sequence frame follows the first clip's *display* orientation, so a
@@ -121,6 +148,10 @@ RSpec.describe ButterCut::Premiere do
       clipitem.at_xpath(".//filter/effect[name='Basic Motion']/parameter[parameterid='rotation']/value")&.text
     end
 
+    def baked_scale(clipitem)
+      clipitem.at_xpath(".//filter/effect[name='Basic Motion']/parameter[parameterid='scale']/value")&.text
+    end
+
     it 'judges each clip on its own source flag' do
       expect(video_clipitems.length).to eq(3)
       expect(baked_rotation(clipitem_by_name['premiere_rotated'])).to eq('90')
@@ -128,8 +159,18 @@ RSpec.describe ButterCut::Premiere do
       expect(baked_rotation(clipitem_by_name['premiere_cw_rotated'])).to eq('-90')
     end
 
-    it 'writes exactly one Basic Motion filter per rotated clip' do
-      expect(xml.scan('<name>Basic Motion</name>').length).to eq(2)
+    # The first (quarter-turn) clip makes the sequence portrait 2160x3840. The two
+    # quarter-turn clips display at that exact size, so they only rotate; the 1920x1080
+    # landscape clip must scale to fit the portrait frame's width (2160/1920 = 112.5%).
+    it 'scales the upright landscape clip to fit the portrait sequence' do
+      expect(baked_scale(clipitem_by_name['premiere_rotated'])).to be_nil
+      expect(baked_scale(clipitem_by_name['premiere_upright'])).to eq('112.5')
+      expect(baked_scale(clipitem_by_name['premiere_cw_rotated'])).to be_nil
+    end
+
+    it 'writes one Basic Motion filter per clip needing rotation or scale' do
+      # Two rotated clips + one scaled upright clip = three filters.
+      expect(xml.scan('<name>Basic Motion</name>').length).to eq(3)
     end
 
     it 'orients the sequence to the first clip regardless of later clips' do


### PR DESCRIPTION
## Summary

Scale Premiere clips to fit the sequence frame so larger-than-timeline footage no longer imports cropped.

Premiere maps an FCP7 clip 1:1, so a clip bigger than the sequence — a 4K angle dropped into a 1080 timeline — imports cropped to its center and reads as "zoomed in." Final Cut and Resolve auto-fit mismatched media on import; Premiere honors only what the XML declares. That's the same gap that already forces ButterCut to write rotation explicitly for Premiere.

## Changes

- Bake a contain scale-to-fit into the same Basic Motion filter as the rotation, computed against the clip's display dimensions (post-rotation), so rotation and scale compose.
- Return no filter when the clip already fills the frame (~100%), so a same-size clip stays untouched.
- Cover stills too — a 4K screenshot in a 1080 timeline would zoom the same way a 4K video does.

The Resolve (shared FCP7) path is unchanged; a regression guard confirms it emits no rotation or scale filter.

## Testing

`bundle exec rspec spec/buttercut/premiere_spec.rb` — 12 examples, 0 failures.