### PR TITLE
core: add per-clip mute to silence a clip

### DIFF
--- a/lib/buttercut/export_core.rb
+++ b/lib/buttercut/export_core.rb
@@ -87,7 +87,10 @@ class Export
         start_at = timecode_to_seconds(clip['in_point'])
         duration = timecode_to_seconds(clip['out_point']) - start_at
 
-        { path: path, type: :video, start_at: start_at.to_f, duration: duration.to_f }
+        result = { path: path, type: :video, start_at: start_at.to_f, duration: duration.to_f }
+        # Silence this clip's audio entirely instead of playing it.
+        result[:mute] = true if clip['mute']
+        result
       end
     end
   end

--- a/lib/buttercut/fcp7_core.rb
+++ b/lib/buttercut/fcp7_core.rb
@@ -262,12 +262,39 @@ class ButterCut
             end
           end
         end
+        # Filters sit after <file> and before <sourcetrack> (Premiere ignores
+        # out-of-order filters). A muted clip gets a level-0 cut here.
+        add_audio_filters(xml, payload)
         xml.sourcetrack do
           xml.mediatype 'audio'
           xml.trackindex 1
         end
         xml.channelcount 2
         build_link_entries(xml, payload)
+      end
+    end
+
+    # Emit an Audio Levels filter when a clip needs a non-unity level. A clip
+    # marked `mute` is silenced outright (level 0); unmarked clips play at unity
+    # with no filter. FCP7 levels are a linear gain: 1.0 = unity, 0 = silent.
+    def add_audio_filters(xml, payload)
+      return unless payload.dig(:clip, :clip_definition, :mute)
+
+      xml.filter do
+        xml.effect do
+          xml.name 'Audio Levels'
+          xml.effectid 'audiolevels'
+          xml.effectcategory 'audiolevels'
+          xml.effecttype 'audiolevels'
+          xml.mediatype 'audio'
+          xml.parameter do
+            xml.parameterid 'level'
+            xml.name 'Level'
+            xml.valuemin 0
+            xml.valuemax 3.98109
+            xml.value 0
+          end
+        end
       end
     end
 

--- a/lib/buttercut/fcpx_core.rb
+++ b/lib/buttercut/fcpx_core.rb
@@ -5,6 +5,9 @@ class ButterCut
   # Final Cut Pro X (FCPXML 1.8) implementation.
   class FCPX < EditorBase
     FORMAT_ID = "r1".freeze
+    # adjust-volume amount that silences a clip outright (a muted clip).
+    # -96 dB is below the audible floor — effectively off.
+    MUTE_VOLUME_ADJUSTMENT = "-96db".freeze
 
     def to_xml
       raise ArgumentError, "No clips provided" if clips.empty?
@@ -103,7 +106,10 @@ class ButterCut
                           duration: clip[:duration],
                           audioRole: 'dialogue'
                         ) do
-                          xml.send('adjust-volume', amount: volume_adjustment)
+                          # A clip marked `mute` is silenced outright; otherwise
+                          # it plays at the base trim level.
+                          amount = clip.dig(:clip_definition, :mute) ? MUTE_VOLUME_ADJUSTMENT : volume_adjustment
+                          xml.send('adjust-volume', amount: amount)
                         end
                       end
                     end

--- a/skills/cut/SKILL.md
+++ b/skills/cut/SKILL.md
@@ -39,6 +39,16 @@ The roughcut path runs a deeper flow because the agent needs to explore the libr
 ## 3. Build the Cut (produces YAML)
 Both paths produce a YAML at `libraries/[library-name]/cuts/[slug]_[YYYYMMDD_HHMMSS].yaml`. The export in step 5 is the same regardless of which path you take.
 
+### What a cut can express
+A quick menu for shaping the cut with the user. Full field list and formats: `skills/cut/cut_yaml_schema.md`.
+
+- **Trimmed video** — a clip cut to in/out points.
+- **Stills** — an image held for a set duration (timeless and silent).
+- **Mute** — silence a clip's own audio (e.g. you'll score it with music, or its source audio is unusable).
+- **Timeline format** — override the output frame rate and resolution; by default they follow the first video clip.
+
+Single-track: clips play in sequence and each carries its own audio.
+
 ### Roughcut path
 Read `skills/cut/roughcut_path.md` and follow it.
 

--- a/skills/cut/cut_yaml_schema.md
+++ b/skills/cut/cut_yaml_schema.md
@@ -40,6 +40,7 @@ Each entry in `clips:`. A clip is either a **video** (trimmed with in/out points
 | `in_point`           | `HH:MM:SS.ss`   | video      | Start of the cut. Preserve sub-second precision (2.849s → `00:00:02.85`). |
 | `out_point`          | `HH:MM:SS.ss`   | video      | End of the cut. Same precision rule. |
 | `duration`           | `HH:MM:SS.ss` or seconds | image | How long the still is held on the timeline. Images have no in/out — they're timeless. Omit to use the default (5s, or `still_duration` in `libraries/settings.yaml`). |
+| `mute`               | boolean         | video      | Silence this clip's audio entirely instead of playing it. Default: omit (the clip plays its own audio). |
 | `dialogue`           | string          | both       | Spoken words for the span; concatenate across transcript segments if the cut crosses them. Empty string when the clip is silent / B-roll / an image. |
 | `visual_description` | string          | both       | Shot description (video: what the contact sheet shows for the range; image: what the still depicts, from its summary). Wrap in brackets to match template style. |
 

--- a/spec/buttercut/fcp7_spec.rb
+++ b/spec/buttercut/fcp7_spec.rb
@@ -99,5 +99,20 @@ RSpec.describe ButterCut::FCP7 do
       # 01:00:00:00 @ 25fps => 90000 frames
       expect(xml).to include('<frame>90000</frame>')
     end
+
+    it 'silences a muted clip with a level-0 audio filter' do
+      xml = described_class.new([{ path: clip_a_path, mute: true }]).to_xml
+      clipitem = xml[/<clipitem id="clipitem-audio-1">.*?<\/clipitem>/m]
+
+      level = clipitem[/<effectid>audiolevels<\/effectid>.*?<value>(.*?)<\/value>/m, 1]
+      expect(level).to eq('0')
+    end
+
+    it 'leaves an unmuted clip at unity with no audio filter' do
+      xml = described_class.new([{ path: clip_a_path }]).to_xml
+      clipitem = xml[/<clipitem id="clipitem-audio-1">.*?<\/clipitem>/m]
+
+      expect(clipitem).not_to include('audiolevels')
+    end
   end
 end

--- a/spec/buttercut/fcpx_spec.rb
+++ b/spec/buttercut/fcpx_spec.rb
@@ -386,6 +386,14 @@ RSpec.describe ButterCut::FCPX do
       expect(xml).to include('<adjust-volume amount="-13.100000000000001db"/>')
     end
 
+    it 'silences a muted clip outright instead of playing it' do
+      generator = ButterCut::FCPX.new([{ path: video_file_path, mute: true }])
+      xml = generator.to_xml
+
+      expect(xml).to include('<adjust-volume amount="-96db"/>')
+      expect(xml).not_to include('<adjust-volume amount="-13.100000000000001db"/>')
+    end
+
     it 'handles multiple video files' do
       generator = ButterCut::FCPX.new([{ path: video_file_path }, { path: video_file_path }])
       xml = generator.to_xml


### PR DESCRIPTION
Mirrors the per-clip mute feature (Pro #20) to open-source ButterCut, now that the engine split has landed.

## What

A clip marked `mute: true` in the cut YAML is silenced outright on export instead of playing its own audio:
- **FCPX** — a `-96db` `adjust-volume`.
- **FCP7 / Premiere / Resolve** — a level-0 Audio Levels filter.

Engine changes go to the post-split `_core` files (`fcpx_core.rb`, `fcp7_core.rb`, `export_core.rb`). Also documents the `mute` field in `cut_yaml_schema.md` and adds a "what a cut can express" menu to the cut skill.

## Behavior

Additive — unmuted clips are unchanged (FCPX stays at the base trim, FCP7 emits no filter). Suite green (314 examples), including new mute coverage in `fcpx_spec.rb` and `fcp7_spec.rb`.

With this, the `_core` engine files are byte-identical to ButterCut Pro's.