### PR TITLE
core: Add bc, buttercut home-menu skills

### DIFF
--- a/skills/.gitignore
+++ b/skills/.gitignore
@@ -34,3 +34,7 @@
 !reprocess-with-contact-sheets/**
 !misc-task/
 !misc-task/**
+!buttercut/
+!buttercut/**
+!bc/
+!bc/**

--- a/skills/bc/SKILL.md
+++ b/skills/bc/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: bc
+description: The ButterCut home menu — welcome the user back, then ask what they'd like to do (start a new cut, add footage to a library, a one-off task, or something else) and hand off to the right skill. Use as the front door when the user opens ButterCut, types "buttercut" or "bc", or asks "where do I start", "what can you do", or "help me get started".
+---
+
+# Skill: bc (alias for `buttercut`)
+
+`bc` is the short name for the `buttercut` skill. The instructions live in one place — **read and follow `skills/buttercut/SKILL.md`.**

--- a/skills/buttercut/SKILL.md
+++ b/skills/buttercut/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: buttercut
+description: The ButterCut home menu — welcome the user back, then ask what they'd like to do (start a new cut, add footage to a library, a one-off task, or something else) and hand off to the right skill. Use as the front door when the user opens ButterCut, types "buttercut" or "bc", or asks "where do I start", "what can you do", or "help me get started".
+---
+
+# Skill: ButterCut home
+
+This is the front door to ButterCut. Welcome the user, find out what they want, and hand off to the right skill. Don't do the work here — route to it.
+
+## What to do
+
+1. Welcome the user back to ButterCut in a sentence — warm and brief, in an editor's voice (no developer talk).
+2. Ask what they'd like to do with the **AskUserQuestion** tool. Offer these three options (the tool adds its own "Other" choice for anything else):
+   - **New cut** — build a roughcut, scene, selects reel, or an edit from a script.
+   - **Add footage** — add new clips to an existing library and analyze them.
+   - **Misc task** — a one-off, like pulling a clip's audio, extracting a frame, converting a file, or drafting notes.
+3. Route to the matching skill based on their answer:
+
+| they picked… | run |
+| --- | --- |
+| New cut | the `cut` skill |
+| Add footage | the `process-library` skill |
+| Misc task | the `misc-task` skill |
+| Other / something else | read what they wrote and run the closest skill — `create-library` for a brand-new project, or `backup-library`, `full-transcript`, etc. If it's still unclear, ask a follow-up. |
+
+Keep it short. The point is to get the user moving, not to explain ButterCut.


### PR DESCRIPTION
Adds a home-menu "front door" skill, back-ported from ButterCut Pro (`94875b2`).

## What this adds
- **`skills/buttercut/SKILL.md`** — welcomes the user, asks what they want via `AskUserQuestion`, and routes to the right skill (`cut` for a new cut, `process-library` to add footage, `misc-task` for one-offs, falling back to `create-library`/`backup-library`/`full-transcript` for anything else).
- **`skills/bc/SKILL.md`** — short `bc` alias that defers to the `buttercut` skill.
- **`skills/.gitignore`** — whitelists `buttercut/` and `bc/` so they ship on `git pull`.

## Edition parity
Both `SKILL.md` files are byte-identical to their ButterCut Pro counterparts, so they'll merge clean on future upstream pulls. The Pro commit's `.gitignore` hunk replaced Pro-only `!preview/` lines (which don't exist here), so the whitelist entries were hand-applied in this repo's existing position rather than cherry-picking that hunk verbatim.

No Ruby touched; no behavior changes to existing skills.
