### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### New & Improved
-- **Add photos to your libraries.** Libraries now hold still images (JPEG and PNG) alongside your video footage. Drop them into the same library, give them a quick summary like any clip, and use them in a cut. Add them when you create a library or to an existing one.
-- **Put stills in your cuts.** Drop a photo, screenshot, or title card into any cut and set how long it holds on screen (five seconds by default). It exports to Final Cut, Premiere, and Resolve right alongside your video, sized and placed correctly even when the photo is a different shape than your timeline.
-- **Set your timeline's frame rate and size.** A cut can now spell out the frame rate and resolution it should export at, which matters for a cut made entirely of photos (where there is no video to copy those settings from). For normal cuts nothing changes: the settings still follow your footage.
-- **Misc tasks now have a home.** Project-tied one-offs (a stray transcription, a thumbnail, quick notes) save into a library's new `misc/` folder; standalone jobs land in a dated `misc/<date>/<task>/` folder; large scratch files go to `tmp/` and finished exports go to your Desktop — never bloating your library.
+## [0.8.0] - 2026-06-26
 
-### Changed
-- Setup now leaves a small note (`.buttercut_env`) recording how it installed Ruby, Python, and WhisperX on your Mac. Future sessions read it to find those tools even when a fresh terminal hasn't loaded them yet — fewer "command not found" hiccups mid-edit.
+**ButterCut gets Multi-track editing, a new Preview app, and better support for misc production tasks**
+
+ButterCut Pro gets a new Preview app for viewing libraries, clips, settings and more. We'll add more features based on your requests. (I want to add a characters feature so Claude doesn't ask for the thousandth time if I'm the one in the video.)
+
+We've also added the initial ability to edit multi-track videos. It works well for adding b-roll clips after creating an initial spine (a-roll story) as well as for working between a/b cameras. Beyond that we might need more work to help the agent understand what's happening at each second.
+
+Preview and multi-track are in ButterCut Pro. $49 a year. 20 percent off with coupon `QYOTC4OA`. Learn more at [buttercut.io](https://buttercut.io).
+
+Pro and Core both add the ability to add photos to libraries and mute clips (nice for B-roll), plus a new 'buttercut' home menu skill that makes your first ButterCut chat more welcoming.
+
+### ButterCut Pro
+
+- **Multi-track timelines.** Lay B-roll and cutaways over a continuing voiceover instead of hard-cutting to them. Pro cuts can place a clip on a second video track; the free edition stays single-track.
+- **Preview libraries and clips inside Claude.** A Claude Desktop panel for browsing a library's clips and cuts and handing work back to ButterCut — add footage, start a cut, pull a full transcript, change settings, or run a one-off task — without leaving the conversation.
+- **Installation improvements.** Smoother, terminal-free setup. Claude brings over existing libraries too.
+
+### ButterCut Pro & Core
+
+#### New & Improved
+- **Misc tasks now have a home.** Project-tied one-offs (a stray transcription, a thumbnail, quick notes) save into a library's new `misc/` folder; standalone jobs land in a dated `misc/<date>/<task>/` folder; large scratch files go to `tmp/` and finished exports go to your Desktop — never bloating your library.
+- **Add photos to your libraries.** Libraries now hold still images (JPEG and PNG) alongside your video footage.
+- **Start from a home menu.** Type "/buttercut" (or "/bc") and ButterCut welcomes you, asks what you'd like to do (start a cut, add footage, or a one-off task), and hands you to the right place. Less daunting than typing from scratch.
+- **Cut from a script.** Hand ButterCut a written script and it finds the footage that delivers each line, then builds the cut in script order.
+- **Silence a clip in a cut.** Cuts now have the ability to mute clips. Handy for B-roll and multi-track work.
+- **More resilient installs.** Setup now leaves a small note (`.buttercut_env`) recording how it installed Ruby, Python, and WhisperX on your Mac, so future sessions can use it to find ButterCut dependencies — one of several setup resiliency improvements.
 - A missing ffmpeg/ffprobe now fails fast with a clear "run the setup skill" error instead of a cryptic command-not-found buried in subprocess output. The contact-sheet skill's repair instructions point at the `setup` skill accordingly.
 - Setup now pins WhisperX to the tested combination (`whisperx==3.4.2`, `pyannote-audio==3.4.0` — matching `requirements.txt`), so fresh installs can't drift onto untested releases (`pyannote-audio` 4.x breaks whisperx 3.4.2).
 - ffmpeg/ffprobe calls now resolve through `MediaTools`: static builds placed in the gitignored `dependencies/` directory take precedence, falling back to PATH. Nothing changes if you don't use `dependencies/` — existing installs keep their PATH ffmpeg.
 - Libraries now include a `misc/` directory for project-tied one-off artifacts. New libraries get it automatically (it's part of `Library::SUBDIRS`); existing libraries get it created on demand the first time the `misc-task` skill needs it. A new gitignored top-level `misc/` directory holds standalone one-off task output, organized as `misc/<date>/<task>/`.
+
+#### Fixed
+- **Premiere clips fill the frame.** Footage shot at a different size than your sequence now scales to fit when you export to Premiere, matching how Final Cut and Resolve already behaved.
 
 ## [0.7.2] - 2026-06-02
 

--- a/lib/buttercut/version.rb
+++ b/lib/buttercut/version.rb
@@ -1,5 +1,5 @@
 class ButterCut
-  VERSION = "0.7.2"
+  VERSION = "0.8.0"
   EDITION = :core # :core for open-source ButterCut, :pro for ButterCut Pro
 
   def self.pro?

--- a/skills/cut/SKILL.md
+++ b/skills/cut/SKILL.md
@@ -1,17 +1,16 @@
 ---
 name: cut
-description: Build a cut from a library — scene, selects, roughcut, or custom task. Starts by asking what kind of cut the user wants, then works with them to determine what they want to create. Always exports a file for Final Cut, Premiere, or Resolve at the end. Use when the user asks for a "roughcut", "sequence", "scene", "selects", or any other cut-shaped output.
+description: Build a cut from a library — scene, selects, roughcut, custom task, or an edit from a written script. Starts by asking what kind of cut the user wants, then works with them to determine what they want to create. Use when the user asks for a "roughcut", "sequence", "scene", "selects", "edit from a script", or any other cut-shaped output.
 ---
 
 # Skill: Cut
 
-Build a timeline from a library. This skill is the entry point for four kinds of work — the first decision is which one.
+This skill builds a timeline from a library.
 
 ## 1. Confirm the library and pre-flight readiness
 You need a library before any cut work. If one is already in context from the current conversation, use it. Otherwise show recent libraries (`ruby lib/buttercut/library.rb recent 5`) and let the user pick.
 
-Once the library name is known, check if the library is ready (video processing complete).
-
+Once the library name is known, check if the library is ready (all footage processed).
 ```bash
 ruby lib/buttercut/library.rb <name> ready
 ```
@@ -21,20 +20,22 @@ Exit code `0` means the library is ready for cut building (`Library.ready?` is t
 ## 2. Determine Task Type
 Ask the user with `AskUserQuestion` tool if available. Otherwise ask in text in this order.
 
-Ask plainly. "Roughcut" in the user's opening request is trained vocabulary, not a confirmed choice — present the four options and let them pick. Don't explain to the user why you're asking, and don't apologize for re-asking; the question stands on its own.
+Ask plainly. "Roughcut" in the user's opening request is trained vocabulary, not a confirmed choice — present the options and let them pick. Don't explain to the user why you're asking, and don't apologize for re-asking; the question stands on its own.
 
 You're going to be tempted here to just move forward and assume the user really wants a story shaped roughcut, but they're just using this term loosely. You **absolutely must** tell them the next statement and question before moving forward:
 
 If the library is processed, tell them that it's ready and the number of clips that are processed. Then ask them what kind of cut they want. Again, they probably said "roughcut", but we've just trained them on that word. **You must ask.**
 
-Example framing: "Library is ready. (93/93 clips fully processed.). What kind of cut do you want to build — scene, selects, roughcut, or custom?"
+Example framing: "Library is ready. All footage processed. What kind of cut do you want to build?"
 
-1. **Scene** — one beat or moment, typically 30–60s.
-2. **Selects / Find clips** — a flat reel of clips matching some criteria (best takes, mentions of a topic, B-roll on a theme). Length follows the footage.
-3. **Roughcut** — a story-shaped cut, 2–8 minutes. Goes through full planning + a sub-agent build.
-4. **Custom task** — anything else the user describes.
+Options:
+1. **Scene** — One story beat, typically 30–90s.
+2. **Selects / Find clips** — Flat reel of clips matching some criteria (best takes, mentions of a topic, B-roll on a theme).
+3. **Script Edit** — Give ButterCut a written script and the agent will find the footage and edit to the script.
+4. **Custom task** — Anything else you want.
+5. **Agent Roughcut** — A full story-shaped cut. Plan with the agent and then let a sub agent make most of the decisions. (Experimental and can use a lot of tokens)
 
-The roughcut path runs a deeper flow because the agent needs to explore the library broadly, read many summaries, generate fresh contact sheets, and shape a narrative across many clips. The other three paths the main thread handles directly with the user.
+The roughcut path runs a deeper flow because the agent needs to explore the library broadly, read many summaries, generate fresh contact sheets, and shape a narrative across many clips. The other four paths the main thread handles directly with the user.
 
 ## 3. Build the Cut (produces YAML)
 Both paths produce a YAML at `libraries/[library-name]/cuts/[slug]_[YYYYMMDD_HHMMSS].yaml`. The export in step 5 is the same regardless of which path you take.
@@ -52,7 +53,7 @@ Single-track: clips play in sequence and each carries its own audio.
 ### Roughcut path
 Read `skills/cut/roughcut_path.md` and follow it.
 
-### Scene / Selects / Custom path
+### Scene / Selects / Custom / Script path
 Read `skills/cut/direct_path.md` and follow it.
 
 ## 4. Determine the Editing Application

--- a/skills/cut/direct_path.md
+++ b/skills/cut/direct_path.md
@@ -1,15 +1,22 @@
-# Direct Path (Scene / Selects / Custom)
+# Direct Path (Scene / Selects / Custom / Script)
 
-The Scene / Selects / Custom branch of `skills/cut/SKILL.md` step 3. Run this when the user picked Scene, Selects, or Custom in step 2. By the time you're here, the library is already confirmed and ready (SKILL.md step 1). Editor resolution happens after the YAML is built (SKILL.md step 4) — don't ask about it yet.
+The Scene / Selects / Custom / Script branch of `skills/cut/SKILL.md` step 3. Run this when the user picked Scene, Selects, Script Edit, or Custom in step 2. By the time you're here, the library is already confirmed and ready (SKILL.md step 1). Editor resolution happens after the YAML is built (SKILL.md step 4) — don't ask about it yet.
 
-These three task types share one flow because the build mechanism is the same — main thread, conversational YAML, no sub-agent. Only the content of the conversation differs (beats for a scene, criteria for selects, free-form for custom).
+These task types share one flow because the build mechanism is the same — main thread, conversational YAML, no sub-agent. Only the content of the conversation differs (beats for a scene, criteria for selects, free-form for custom, the written script for a script edit).
 
 ## Build the YAML conversationally
-Stay in the main thread. Talk with the user about what they want — beats for a scene, criteria for selects, whatever shape the custom task has. Build the YAML iteratively at `libraries/[library-name]/cuts/[slug]_[YYYYMMDD_HHMMSS].yaml`, showing each revision back to the user as it grows. Keep revising until the user explicitly approves that it's ready to export.
+Stay in the main thread. Talk with the user about what they want — beats for a scene, criteria for selects, whatever shape the custom task has. Build the YAML iteratively at `libraries/[library-name]/cuts/[slug]_[YYYYMMDD_HHMMSS].yaml`, showing each revision back to the user as it grows, typically as a table like shape. Keep revising until the user explicitly approves that it's ready to export.
 
 The YAML shape — output path, top-level fields, per-clip fields, timestamp format, dialogue-correction policy — is in `skills/cut/cut_yaml_schema.md`. Read it once, then build the file conversationally with the user.
 
 For selects work specifically, set `description` to the selection criteria (e.g. "All mentions of Claude Code across interview footage") so the cut is recognizable when the user opens the timeline.
+
+### Edit from a script
+The user already has a written script and wants the cut to follow it line for line. First get the script: they either paste it into the chat, or point you at a file — read it with the Read tool. If they describe a script but haven't given it to you yet, ask them to paste it or hand over the file path before you go further.
+
+Once you have the script, walk it top to bottom and find the footage that delivers each line or beat. Start with the per-clip summaries in `summaries/`, then grep the transcripts (`rg "<a phrase from the script>" libraries/<name>/transcripts/`) to pin the exact clip and timecode where a line is spoken. Build the cut in script order — one clip per beat, trimmed to the in/out points that cover the scripted line.
+
+Set `description` to something that names the script (e.g. "Cut following the launch-video script"). Where the script calls for a line you can't find in the footage, don't invent or force a near-match — list those gaps for the user and let them decide whether to drop the line, reshoot, or swap in something close. Keep revising with the user until they approve the cut.
 
 ## Return to SKILL.md
 When the user approves the YAML, continue at step 5 of `SKILL.md` (Export the YAML) with the YAML path.

--- a/skills/update-buttercut/SKILL.md
+++ b/skills/update-buttercut/SKILL.md
@@ -40,6 +40,9 @@ git diff <sha-from-step-1>..HEAD -- CHANGELOG.md
 ```
 The added changelog lines are already written for users — recap them in a sentence or two, the way release notes read, leading with what they can do now ("ButterCut now handles photos — drop stills into a library and use them in cuts"). Then:
 
+- **Mind the edition split.** A release section may group changes under `### ButterCut (free)` and `### ButterCut Pro`. How you recap the Pro lines depends on the edition you found at the top of this skill (`ruby lib/buttercut/library.rb edition`):
+  - On a **Pro** install (`pro`), the user has both — recap free and Pro changes together as things they can now do.
+  - On a **core** install (`core`), the user only received the free changes. Recap those as "you can now…", then add the Pro ones as a light, optional heads-up — not as something they have — e.g. "Also new in ButterCut Pro: multi-track timelines and a live preview panel, more at buttercut.io." Keep it to one sentence, never pushy, and skip it entirely if the diff brought no `### ButterCut Pro` lines.
 - If the changelog didn't change, say they're up to date with the latest behind-the-scenes improvements — don't enumerate what those were.
 - Never mention branches, commits, shas, tests, version files, migrations, or `main` in the recap.
 - Don't quote version numbers unless the pull brought in a new numbered release section in the changelog. Numbered releases only happen when a batch of changes is publicized as one; between releases the version file lags behind `main` by design, so "still on 0.7.2" is meaningless to the user.


### PR DESCRIPTION
Releases ButterCut 0.8.0 (free/open-source edition). The CHANGELOG entry is shared byte-for-byte with ButterCut Pro and labels which changes are in the free edition vs Pro, so the open-source changelog also acts as a soft pointer to the paid upgrade.

**Not published by this PR.** Merging only lands the bump on `main`. Tag `v0.8.0` + GitHub release are separate steps via the `release` skill.

## Commits
- Add a "cut from a script" option to the cut skill (backport of Pro's `d7e5a7b`)
- Surface ButterCut Pro features to free users in the update recap
- Bump version to 0.8.0

## Changelog (0.8.0)

### ButterCut (free)

**New & Improved**
- **Add photos to your libraries.** Still images (JPEG/PNG) alongside video; summarize and use them in a cut.
- **Put stills in your cuts.** Hold a photo/title card for a set time; exports correctly sized to Final Cut, Premiere, Resolve.
- **Set your timeline's frame rate and size.** A cut can spell out export frame rate/resolution (matters for all-photo cuts).
- **Silence a clip in a cut.** Mute a clip's audio while keeping the picture.
- **Start from a home menu.** Type "buttercut"/"bc" to be welcomed and routed to the right skill.
- **Cut from a script.** Hand ButterCut a written script; it finds the footage per line and builds in script order, flagging gaps.
- **Misc tasks now have a home.** One-offs save into `misc/` instead of bloating the library.

**Changed**
- **Premiere clips fill the frame.** Off-size footage now scales to fit on Premiere export (matching FCP/Resolve).
- Setup leaves a `.buttercut_env` note so later sessions find Ruby/Python/WhisperX; clear "run setup" error on missing ffmpeg; WhisperX pinned; ffmpeg/ffprobe resolve via `MediaTools` (`dependencies/` then PATH); libraries gain a `misc/` dir.

### ButterCut Pro
- **Multi-track timelines.** Lay B-roll/cutaways over a continuing voiceover (free stays single-track).
- **Live preview inside Claude.** Browse clips/cuts and hand work back to ButterCut in a panel.
- **One-step setup, no Homebrew.** Pinned, checksum-verified FFmpeg into the ButterCut folder; no admin password.
- **Bring your projects over.** Pro setup offers to import your open-source libraries.

## Tests
`bundle exec rspec` — 314 examples, 0 failures.
