### PR TITLE
Add Export end-to-end specs and NTSC sequence coverage

### DIFF
--- a/spec/buttercut/export_spec.rb
+++ b/spec/buttercut/export_spec.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'nokogiri'
+require 'tempfile'
+require_relative '../../lib/buttercut/export'
+
+# End-to-end coverage of the Export entrypoint the cut skill shells out to:
+# cut YAML + library.yaml → editor XML. Runs real ffprobe over the small
+# committed fixture clips (23.976 fps, 1280x720, 48 kHz, no embedded timecode),
+# so the numbers below are real frame math: at 23.976 a 2.0s trim rounds to
+# 48 frames (1001/500s) and a 1.0s in-point to 24 frames (1001/1000s).
+RSpec.describe Export do
+  let(:clip_a) { fixture_media('MVI_0309_720p.mov') } # 4.202s
+  let(:clip_b) { fixture_media('MVI_0323_720p.mov') } # 6.044s
+
+  def perform(cut_path, out_path, editor: 'fcpx')
+    silence_stdout do
+      described_class.perform(roughcut_path: cut_path, output_path: out_path, editor: editor)
+    end
+  end
+
+  def parse(path) = Nokogiri::XML(File.read(path))
+
+  # A real PNG for image-clip examples, generated once — nothing large enters git.
+  before(:context) do
+    @stills_dir = Dir.mktmpdir('export-spec-stills')
+    @still_path = File.join(@stills_dir, 'title card.png')
+    ok = system(MediaTools.ffmpeg, '-y', '-f', 'lavfi', '-i', 'color=c=red:size=320x180',
+                '-frames:v', '1', @still_path, out: File::NULL, err: File::NULL)
+    raise "Could not generate still fixture with ffmpeg" unless ok && File.exist?(@still_path)
+  end
+
+  after(:context) { FileUtils.remove_entry(@stills_dir) }
+
+  describe 'argument validation' do
+    it 'requires roughcut_path, output_path, and editor' do
+      expect { described_class.new(roughcut_path: nil, output_path: 'o.xml', editor: 'fcpx') }
+        .to raise_error(ArgumentError, /roughcut_path/)
+      expect { described_class.new(roughcut_path: 'c.yaml', output_path: '', editor: 'fcpx') }
+        .to raise_error(ArgumentError, /output_path/)
+      expect { described_class.new(roughcut_path: 'c.yaml', output_path: 'o.xml', editor: nil) }
+        .to raise_error(ArgumentError, /editor/)
+    end
+
+    it 'rejects an unknown editor by name' do
+      expect { described_class.new(roughcut_path: 'c.yaml', output_path: 'o.xml', editor: 'avid') }
+        .to raise_error(ArgumentError, /Unknown editor 'avid'/)
+    end
+
+    it 'accepts editor names case-insensitively' do
+      expect { described_class.new(roughcut_path: 'c.yaml', output_path: 'o.xml', editor: 'FCPX') }
+        .not_to raise_error
+    end
+  end
+
+  describe 'input errors' do
+    it 'raises when the rough cut file does not exist' do
+      cut = { 'clips' => [] }
+      within_export_sandbox(cut: cut, media: [clip_a]) do |_cut_path, out|
+        expect { perform('libraries/export-sandbox/cuts/nope.yaml', out) }
+          .to raise_error(/Rough cut file not found/)
+      end
+    end
+
+    it 'raises when the cut path is not inside libraries/<name>/cuts' do
+      Dir.mktmpdir do |dir|
+        stray = File.join(dir, 'cut.yaml')
+        File.write(stray, { 'clips' => [] }.to_yaml)
+        expect { perform(stray, File.join(dir, 'out.xml')) }
+          .to raise_error(/Could not extract library name/)
+      end
+    end
+
+    it 'raises when the library.yaml is missing' do
+      cut = { 'clips' => [] }
+      within_export_sandbox(cut: cut, media: [clip_a]) do |cut_path, out|
+        File.delete('libraries/export-sandbox/library.yaml')
+        expect { perform(cut_path, out) }.to raise_error(/Library file not found/)
+      end
+    end
+  end
+
+  describe 'clip building' do
+    it 'maps in/out points to source trim and timeline duration' do
+      cut = { 'clips' => [
+        { 'source_file' => 'MVI_0309_720p.mov', 'in_point' => '00:00:00', 'out_point' => '00:00:02' },
+        { 'source_file' => 'MVI_0323_720p.mov', 'in_point' => '00:00:01', 'out_point' => '00:00:03' }
+      ] }
+      within_export_sandbox(cut: cut, media: [clip_a, clip_b]) do |cut_path, out|
+        perform(cut_path, out)
+        clips = parse(out).xpath('//spine/asset-clip')
+
+        expect(clips.length).to eq(2)
+        expect(clips[0]['duration']).to eq('1001/500s')  # 2.0s → 48 frames
+        expect(clips[1]['offset']).to eq('1001/500s')    # placed right after clip 1
+        expect(clips[1]['start']).to eq('1001/1000s')    # 1.0s in-point → 24 frames
+        expect(clips[1]['duration']).to eq('1001/500s')
+      end
+    end
+
+    it 'accepts bare numeric and decimal-second in/out points' do
+      cut = { 'clips' => [
+        { 'source_file' => 'MVI_0323_720p.mov', 'in_point' => '00:00:01.5', 'out_point' => 4 }
+      ] }
+      within_export_sandbox(cut: cut, media: [clip_b]) do |cut_path, out|
+        perform(cut_path, out)
+        clip = parse(out).at_xpath('//spine/asset-clip')
+
+        expect(clip['start']).to eq('3003/2000s')   # 1.5s → 36 frames
+        expect(clip['duration']).to eq('1001/400s') # 2.5s → 60 frames
+      end
+    end
+
+    it 'passes mute through so the clip is silenced outright' do
+      cut = { 'clips' => [
+        { 'source_file' => 'MVI_0309_720p.mov', 'in_point' => 0, 'out_point' => 2, 'mute' => true }
+      ] }
+      within_export_sandbox(cut: cut, media: [clip_a]) do |cut_path, out|
+        perform(cut_path, out)
+        volume = parse(out).at_xpath('//spine/asset-clip/adjust-volume')
+
+        expect(volume['amount']).to eq('-96db')
+      end
+    end
+
+    it 'skips a clip whose source_file is not in the library, with a warning' do
+      cut = { 'clips' => [
+        { 'source_file' => 'MVI_0309_720p.mov', 'in_point' => 0, 'out_point' => 2 },
+        { 'source_file' => 'not_in_library.mov', 'in_point' => 0, 'out_point' => 2 }
+      ] }
+      within_export_sandbox(cut: cut, media: [clip_a]) do |cut_path, out|
+        stderr = capture_stderr { perform(cut_path, out) }
+
+        expect(stderr).to include('not_in_library.mov')
+        expect(parse(out).xpath('//spine/asset-clip').length).to eq(1)
+      end
+    end
+
+    it 'warns about an unsupported extension and exports it as video anyway' do
+      Dir.mktmpdir do |dir|
+        mkv = File.join(dir, 'legacy_clip.mkv')
+        FileUtils.cp(clip_a, mkv) # .mov bytes — ffprobe reads the content fine
+        cut = { 'clips' => [{ 'source_file' => 'legacy_clip.mkv', 'in_point' => 0, 'out_point' => 2 }] }
+        within_export_sandbox(cut: cut, media: [mkv]) do |cut_path, out|
+          stderr = capture_stderr { perform(cut_path, out) }
+
+          expect(stderr).to include('outside the supported formats')
+          expect(parse(out).xpath('//spine/asset-clip').length).to eq(1)
+        end
+      end
+    end
+
+    it 'requires a duration on image clips' do
+      cut = { 'clips' => [{ 'source_file' => 'title card.png' }] }
+      within_export_sandbox(cut: cut, media: [@still_path]) do |cut_path, out|
+        expect { perform(cut_path, out) }
+          .to raise_error(/missing a required 'duration:'/)
+      end
+    end
+
+    it 'exports an image clip as a timeless still held for the cut duration' do
+      cut = { 'clips' => [
+        { 'source_file' => 'MVI_0309_720p.mov', 'in_point' => 0, 'out_point' => 2 },
+        { 'source_file' => 'title card.png', 'duration' => 3 }
+      ] }
+      within_export_sandbox(cut: cut, media: [clip_a, @still_path]) do |cut_path, out|
+        perform(cut_path, out)
+        still = parse(out).at_xpath('//spine/video')
+
+        expect(still['name']).to eq('title card.png')
+        expect(still['duration']).to eq('3003/1000s') # 3.0s → 72 frames at 23.976
+      end
+    end
+  end
+
+  describe 'editor targets' do
+    let(:cut) do
+      { 'clips' => [{ 'source_file' => 'MVI_0309_720p.mov', 'in_point' => 0, 'out_point' => 2 }] }
+    end
+
+    it 'writes xmeml version 5 for resolve' do
+      within_export_sandbox(cut: cut, media: [clip_a]) do |cut_path, out|
+        perform(cut_path, out, editor: 'resolve')
+        doc = parse(out)
+
+        expect(doc.at_xpath('/xmeml')['version']).to eq('5')
+        expect(doc.xpath('//clipitem').length).to eq(2) # video + linked audio
+      end
+    end
+
+    it 'writes xmeml for premiere without rotating upright footage' do
+      within_export_sandbox(cut: cut, media: [clip_a]) do |cut_path, out|
+        perform(cut_path, out, editor: 'premiere')
+        xml = File.read(out)
+
+        expect(xml).to include('<xmeml version="5">')
+        expect(xml).not_to include('Basic Motion')
+      end
+    end
+
+    it 'produces fcpx output that validates against the FCPXML 1.8 DTD' do
+      skip 'xmllint not available' unless system('command -v xmllint > /dev/null 2>&1')
+      dtd = File.expand_path('../../dtd/FCPXMLv1_8.dtd', __dir__)
+      skip 'DTD not present' unless File.exist?(dtd)
+
+      mixed = { 'clips' => [
+        { 'source_file' => 'MVI_0309_720p.mov', 'in_point' => 0, 'out_point' => 2 },
+        { 'source_file' => 'title card.png', 'duration' => 3 }
+      ] }
+      within_export_sandbox(cut: mixed, media: [clip_a, @still_path]) do |cut_path, out|
+        perform(cut_path, out)
+
+        expect(system('xmllint', '--noout', '--dtdvalid', dtd, out,
+                      out: File::NULL, err: File::NULL)).to be(true)
+      end
+    end
+  end
+
+  describe 'timeline block' do
+    it 'pins the output format from the cut YAML for an image-only cut' do
+      cut = {
+        'timeline' => { 'frame_rate' => 25, 'width' => 1920, 'height' => 1080 },
+        'clips' => [{ 'source_file' => 'title card.png', 'duration' => 2 }]
+      }
+      within_export_sandbox(cut: cut, media: [@still_path]) do |cut_path, out|
+        perform(cut_path, out)
+        format = parse(out).at_xpath('//format[@id="r1"]')
+
+        expect(format['frameDuration']).to eq('1/25s')
+        expect(format['width']).to eq('1920')
+        expect(format['height']).to eq('1080')
+      end
+    end
+  end
+
+  it 'returns the output path' do
+    cut = { 'clips' => [{ 'source_file' => 'MVI_0309_720p.mov', 'in_point' => 0, 'out_point' => 1 }] }
+    within_export_sandbox(cut: cut, media: [clip_a]) do |cut_path, out|
+      expect(perform(cut_path, out)).to eq(out)
+    end
+  end
+end

--- a/spec/buttercut/fcp7_spec.rb
+++ b/spec/buttercut/fcp7_spec.rb
@@ -115,4 +115,125 @@ RSpec.describe ButterCut::FCP7 do
       expect(clipitem).not_to include('audiolevels')
     end
   end
+
+  # NTSC fractional rates (29.97/23.976) are what most real camera footage
+  # shoots, and the 1001-denominator math is where xmeml frame drift hides:
+  # the timebase must round to a whole number, <ntsc> must flag the fraction,
+  # and drop-frame timecode must subtract the dropped frame numbers.
+  describe 'NTSC fractional-rate sequences' do
+    require 'nokogiri'
+
+    let(:df_a_path) { '/tmp/fcp7_ntsc_a.mov' } # 29.97 DF, 1-hour source timecode
+    let(:df_b_path) { '/tmp/fcp7_ntsc_b.mov' } # 29.97, no timecode
+    let(:ndf_path)  { '/tmp/fcp7_ntsc_23976.mov' } # 23.976 NDF
+    let(:pal_path)  { '/tmp/fcp7_pal.mov' } # 25 fps, integer rate
+
+    let(:ntsc_metadata_by_path) do
+      {
+        df_a_path => build_metadata(duration_seconds: 4.0, frame_rate: '30000/1001', timecode: '01:00:00;00'),
+        df_b_path => build_metadata(duration_seconds: 2.0, frame_rate: '30000/1001'),
+        ndf_path => build_metadata(duration_seconds: 4.0, frame_rate: '24000/1001', timecode: '01:00:00:00'),
+        pal_path => build_metadata(duration_seconds: 2.0, frame_rate: '25/1')
+      }
+    end
+
+    before do
+      allow_any_instance_of(described_class).to receive(:extract_metadata_from_ffprobe) do |_instance, path|
+        ntsc_metadata_by_path.fetch(path)
+      end
+    end
+
+    context 'with a 29.97 drop-frame sequence' do
+      let(:doc) do
+        Nokogiri::XML(described_class.new([
+          { path: df_a_path },
+          { path: df_b_path, start_at: 1.0, duration: 1.0 }
+        ]).to_xml)
+      end
+
+      it 'rounds the sequence timebase to 30 and flags NTSC' do
+        rate = doc.at_xpath('/xmeml/sequence/rate')
+        expect(rate.at_xpath('timebase').text).to eq('30')
+        expect(rate.at_xpath('ntsc').text).to eq('TRUE')
+      end
+
+      it 'marks the sequence timecode drop-frame' do
+        timecode = doc.at_xpath('/xmeml/sequence/timecode')
+        expect(timecode.at_xpath('displayformat').text).to eq('DF')
+        expect(timecode.at_xpath('frame').text).to eq('0')
+      end
+
+      it 'converts whole-second trims into 29.97 frame counts' do
+        # clip_a full 4.0s → 119.88 exact frames, rounded to 120.
+        first = doc.at_xpath('//clipitem[@id="clipitem-video-1"]')
+        expect(first.at_xpath('start').text).to eq('0')
+        expect(first.at_xpath('end').text).to eq('120')
+
+        # clip_b: 1.0s in-point → 30 frames, 1.0s duration → 30 frames.
+        second = doc.at_xpath('//clipitem[@id="clipitem-video-2"]')
+        expect(second.at_xpath('start').text).to eq('120')
+        expect(second.at_xpath('end').text).to eq('150')
+        expect(second.at_xpath('in').text).to eq('30')
+        expect(second.at_xpath('out').text).to eq('60')
+
+        expect(doc.at_xpath('/xmeml/sequence/duration').text).to eq('150')
+      end
+
+      it 'writes the drop-frame source timecode as a dropped frame count' do
+        # 01:00:00;00 DF: 108000 nominal frames minus 2 × (60 − 6) dropped = 107892.
+        file_timecode = doc.at_xpath('//clipitem[@id="clipitem-video-1"]/file/timecode')
+        expect(file_timecode.at_xpath('frame').text).to eq('107892')
+        expect(file_timecode.at_xpath('displayformat').text).to eq('DF')
+      end
+    end
+
+    context 'with a 23.976 non-drop sequence' do
+      let(:doc) { Nokogiri::XML(described_class.new([{ path: ndf_path }]).to_xml) }
+
+      it 'rounds the timebase to 24, flags NTSC, and stays non-drop' do
+        rate = doc.at_xpath('/xmeml/sequence/rate')
+        expect(rate.at_xpath('timebase').text).to eq('24')
+        expect(rate.at_xpath('ntsc').text).to eq('TRUE')
+        expect(doc.at_xpath('/xmeml/sequence/timecode/displayformat').text).to eq('NDF')
+      end
+
+      it 'counts source timecode frames at the nominal rate' do
+        # 01:00:00:00 NDF at nominal 24 → 86400 frames; 4.0s → 96 frames.
+        file_timecode = doc.at_xpath('//clipitem[@id="clipitem-video-1"]/file/timecode')
+        expect(file_timecode.at_xpath('frame').text).to eq('86400')
+        expect(doc.at_xpath('/xmeml/sequence/duration').text).to eq('96')
+      end
+    end
+
+    context 'with a PAL asset cut into a 29.97 sequence' do
+      let(:doc) do
+        Nokogiri::XML(described_class.new([
+          { path: df_a_path },
+          { path: pal_path }
+        ]).to_xml)
+      end
+
+      it 'keeps the sequence NTSC while the PAL file keeps its own integer rate' do
+        sequence_rate = doc.at_xpath('/xmeml/sequence/rate')
+        expect(sequence_rate.at_xpath('timebase').text).to eq('30')
+        expect(sequence_rate.at_xpath('ntsc').text).to eq('TRUE')
+
+        pal_file_rate = doc.at_xpath('//clipitem[@id="clipitem-video-2"]/file/rate')
+        expect(pal_file_rate.at_xpath('timebase').text).to eq('25')
+        expect(pal_file_rate.at_xpath('ntsc').text).to eq('FALSE')
+      end
+
+      it 'trims in source frames but places on the timeline in sequence frames' do
+        # The 2.0s PAL clip is 50 source frames (25 fps) but occupies 60
+        # timeline frames (29.97): in/out count the file, start/end the sequence.
+        pal_clip = doc.at_xpath('//clipitem[@id="clipitem-video-2"]')
+        expect(pal_clip.at_xpath('in').text).to eq('0')
+        expect(pal_clip.at_xpath('out').text).to eq('50')
+        expect(pal_clip.at_xpath('start').text).to eq('120')
+        expect(pal_clip.at_xpath('end').text).to eq('180')
+
+        expect(doc.at_xpath('/xmeml/sequence/duration').text).to eq('180')
+      end
+    end
+  end
 end

--- a/spec/support/export_sandbox.rb
+++ b/spec/support/export_sandbox.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+require 'yaml'
+require 'stringio'
+
+# Builds a throwaway on-disk library + cut YAML for the Export specs. Export
+# resolves `libraries/<name>/library.yaml` relative to the working directory,
+# so the sandbox chdirs into a temp dir shaped like a real ButterCut install.
+module ExportSandbox
+  MEDIA_DIR = File.expand_path('../fixtures/media', __dir__)
+
+  def fixture_media(filename) = File.join(MEDIA_DIR, filename)
+
+  # Yields [relative cut path, absolute output path] from inside the sandbox.
+  def within_export_sandbox(cut:, media:, library: 'export-sandbox')
+    Dir.mktmpdir do |dir|
+      cuts_dir = File.join(dir, 'libraries', library, 'cuts')
+      FileUtils.mkdir_p(cuts_dir)
+      File.write(File.join(dir, 'libraries', library, 'library.yaml'),
+                 { 'media' => media.map { |path| { 'path' => path } } }.to_yaml)
+      File.write(File.join(cuts_dir, 'cut.yaml'), cut.to_yaml)
+      Dir.chdir(dir) do
+        yield File.join('libraries', library, 'cuts', 'cut.yaml'), File.join(dir, 'output.xml')
+      end
+    end
+  end
+
+  # Export reports skipped clips with `warn`; capture them for assertion.
+  def capture_stderr
+    original = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = original
+  end
+end
+
+RSpec.configure { |config| config.include ExportSandbox }


### PR DESCRIPTION
Close the two biggest gaps in the XML test coverage.

## Export specs

Create end-to-end specs for the `Export` entrypoint the cut skill shells out to — previously untested in either edition. A sandbox helper builds a throwaway `libraries/<name>/cuts/` install on disk, and the specs run real ffprobe over the committed fixture clips:

- Map in/out points to source trims and timeline durations with real 23.976 frame math.
- Cover bare-numeric and decimal-second timecodes, mute, image stills, the `timeline:` block, and all three editor targets.
- Validate exported Final Cut XML against the committed FCPXML 1.8 DTD.
- Lock in the current skip-with-warning behavior for clips whose source file is missing from the library, so a change there cannot slip through silently.

## NTSC sequence coverage

Add fractional-rate coverage to the FCP7/xmeml spec, which previously tested integer rates only:

- 29.97 drop-frame sequences: timebase rounds to 30, `<ntsc>` flags TRUE, and `01:00:00;00` writes as 107,892 frames after subtracting dropped frame numbers.
- 23.976 non-drop sequences with source timecode counted at the nominal rate.
- A PAL asset cut into a 29.97 sequence: in/out count source frames while start/end count sequence frames.

No new media enters the repo — the specs use the existing committed fixture clips, stubbed ffprobe metadata, and a throwaway PNG generated at test time.