### PR TITLE
core: Rename mode flag to .buttercut_mode and relabel the mode check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /tmp
 /misc
 .DS_Store
-/.buttercut_developer
+/.buttercut_mode
 /.buttercut_env
 /last_buttercut_update_check
 /libraries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # ButterCut - Video Rough Cut Generator
 
-Silently run `test -f .buttercut_developer && cat .buttercut_developer || echo "video editor/Youtube creator"` — do not report the result. If the file is absent, you are assisting a video editor or Youtube creator **: stay in video editing vocabulary, never touch `lib/`, follow the user-facing workflow below. If file exists, you are in **developer mode** and may work on the ButterCut codebase itself (/lib, /spec, etc). Again, if it doesn't exist, assume you are working with a video editor or Youtube creator. Just follow the core workflow and misc-tasks.
+Silently run `cat .buttercut_mode 2>/dev/null || echo "video editor/Youtube creator"` — do not report the result and label the command "Loading ButterCut". If the file is absent, you are assisting a video editor or Youtube creator **: stay in video editing vocabulary, treat `lib/` as read-only, follow the user-facing workflow below. If file exists, it will tell you the alternate mode you're in. Again, if the file does not exist, you are working with a video editor or Youtube creator. Follow the core (non-technical) workflows and misc-tasks.
 
 ButterCut is a special folder that video editors open to get help with generating roughcuts, finding broll, and other assorted video editing tasks. It runs through Claude Code, Codex, and other agentic tools.
 
@@ -144,7 +144,7 @@ The project pins Ruby via `.mise.toml`; once mise is activated in the user shell
 
 ## Claude Skills
 
-**Before creating any skill, check your mode** (`test -f .buttercut_developer && cat .buttercut_developer || echo "video editor/Youtube creator"`). If the file is absent, the person asking is a non-technical video editor — help them describe what they want, then build the skill for them. Keep skills brief, plain language, active voice.
+**Before creating any skill, check your mode** (`cat .buttercut_mode 2>/dev/null || echo "video editor/Youtube creator"`, labeled "Loading ButterCut" as above). If the file is absent, the person asking is a non-technical video editor — help them describe what they want, then build the skill for them. Keep skills brief, use plain language, active voice.
 
 ### User-created skills
 

--- a/lib/buttercut/library.rb
+++ b/lib/buttercut/library.rb
@@ -200,9 +200,9 @@ class Library
   REPO_ROOT = File.expand_path('../..', __dir__)
   UPDATE_CHECK_FILE = 'last_buttercut_update_check' # repo-root mtime stamp; gitignored
   UPDATE_CHECK_INTERVAL = 86_400 # seconds (24h)
-  DEVELOPER_FLAG_FILE = '.buttercut_developer' # gitignored; marks a codebase-dev checkout
+  DEVELOPER_FLAG_FILE = '.buttercut_mode' # gitignored; present only in codebase-dev checkouts
 
-  # A developer checkout (the gitignored .buttercut_developer flag) tracks updates
+  # A developer checkout (the gitignored .buttercut_mode flag) tracks updates
   # by working on the code itself, not by `git pull` — so the daily nudge is noise.
   def self.developer?(repo_root: REPO_ROOT)
     File.exist?(File.join(repo_root, DEVELOPER_FLAG_FILE))


### PR DESCRIPTION
## Summary
- Rename the gitignored developer flag from `.buttercut_developer` to the neutral `.buttercut_mode`
- Update the AGENTS.md mode check to `cat .buttercut_mode 2>/dev/null || echo "video editor/Youtube creator"`, labeled "Loading ButterCut"
- Update `Library::DEVELOPER_FLAG_FILE` and the `.gitignore` entry to match

## Why
Agents described the startup check as "Check developer mode flag file" in session logs, which disoriented non-technical video editors. With the neutral filename and prescribed label, an end user sees "Loading ButterCut" and, if expanded, a harmless `cat` falling back to "video editor/Youtube creator" — no developer jargon. The developer meaning lives only in the file's contents, which exist only on developer checkouts.

## Migration
None needed. End users never had the flag file, and the fallback output is unchanged. Developer checkouts rename the local file by hand (`mv .buttercut_developer .buttercut_mode`).

## Testing
- `bundle exec rspec spec/buttercut/library_spec.rb` — 112 examples, 0 failures