### PR TITLE
core: conform Final Cut Camera drop-frame source in FCPX export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ButterCut Pro & Core
+
+#### Fixed
+- **Final Cut Camera (iPhone) footage now imports into Final Cut Pro cleanly.** Clips shot with Apple's Final Cut Camera companion app tag themselves as 29.97 drop-frame even though the file itself is flat 30fps. ButterCut's Final Cut export didn't account for this mismatch, so Final Cut would reject some of the clips on import ("Invalid edit with no respective media"). Exports now conform the timeline the same way Final Cut itself does when you import that footage directly.
+
 ## [0.8.0] - 2026-06-26
 
 **ButterCut gets Multi-track editing, a new Preview app, and better support for misc production tasks**

--- a/lib/buttercut/editor_base_core.rb
+++ b/lib/buttercut/editor_base_core.rb
@@ -189,13 +189,38 @@ class ButterCut
       "#{start_num / divisor}/#{start_denom / divisor}s"
     end
 
-    def drop_frame_timecode?(timecode, rate_num, rate_denom, fps_nominal)
+    # The tmcd atom's drop-frame flag (surfaced by ffprobe as a ';' frame
+    # separator) is authoritative on its own — Final Cut Camera on iPhone
+    # tags clips this way even when the container's measured rate reads as a
+    # flat 30/60 rather than the NTSC 30000/1001 fraction, and Final Cut Pro
+    # honors the flag over the measured rate when it re-resolves the source.
+    # rate_num/rate_denom are accepted for signature stability but no longer
+    # gate the decision.
+    def drop_frame_timecode?(timecode, _rate_num = nil, _rate_denom = nil, fps_nominal)
       return false unless timecode.include?(';')
-      return false unless fps_nominal == 30 || fps_nominal == 60
-      ntsc_drop_frame_rate?(rate_num, rate_denom)
+      fps_nominal == 30 || fps_nominal == 60
     end
 
-    # NTSC fractional rates (29.97 / 59.94) that use drop-frame timecode.
+    # Whether a source file's own embedded timecode is drop-frame — the
+    # single source of truth `build_asset_map` and `format_frame_rate` both
+    # read from, so the DF/NDF decision is made exactly once per file.
+    def clip_uses_drop_frame_timecode?(video_path)
+      timecode = clip_timecode_string(video_path)
+      return false if timecode.nil? || timecode.strip.empty?
+
+      fps_nominal = nominal_frame_rate(video_path)
+      return false if fps_nominal <= 0
+
+      rate_num, rate_denom = frame_rate(video_path).split('/').map(&:to_i)
+      return false if rate_denom.zero? || rate_num.zero?
+
+      drop_frame_timecode?(timecode, rate_num, rate_denom, fps_nominal)
+    end
+
+    # NTSC fractional rates (29.97 / 59.94) that use drop-frame timecode —
+    # exact-match gate used by the xmeml generators (FCP7/Premiere/Resolve)
+    # for their own DF/NDF flagging, which is a separate, established
+    # convention from FCPX's `drop_frame_timecode?` above.
     def ntsc_drop_frame_rate?(rate_num, rate_denom)
       (rate_num == 30000 && rate_denom == 1001) || (rate_num == 60000 && rate_denom == 1001)
     end
@@ -256,8 +281,21 @@ class ButterCut
       first_video_path ? video_height(first_video_path) : 1080
     end
 
+    # Drop-frame source (Final Cut Camera's iPhone convention) conforms the
+    # sequence to the proper NTSC fraction (30000/1001 / 60000/1001) rather
+    # than the source's own flat measured rate — matching what Final Cut
+    # itself builds when you import the same footage natively, and what its
+    # importer expects to see when resolving an FCPXML against the file's
+    # own embedded timecode.
     def format_frame_rate
-      @timeline[:frame_rate] || (first_video_path ? frame_rate(first_video_path) : '24/1')
+      return @timeline[:frame_rate] if @timeline[:frame_rate]
+      return '24/1' unless first_video_path
+
+      if clip_uses_drop_frame_timecode?(first_video_path)
+        nominal_frame_rate(first_video_path) == 60 ? '60000/1001' : '30000/1001'
+      else
+        frame_rate(first_video_path)
+      end
     end
 
     def format_frame_duration
@@ -448,6 +486,8 @@ class ButterCut
             timecode: clip_timecode_fraction(media_file_path),
             frame_duration: frame_duration(media_file_path),
             frame_rate: frame_rate(media_file_path),
+            nominal_frame_rate: nominal_frame_rate(media_file_path),
+            drop_frame: clip_uses_drop_frame_timecode?(media_file_path),
             rotation: video_rotation(media_file_path),
             color_space: color_space(media_file_path)
           )

--- a/lib/buttercut/fcpx_core.rb
+++ b/lib/buttercut/fcpx_core.rb
@@ -26,6 +26,8 @@ class ButterCut
       timestamped_project_name = "#{project_basename} #{timestamp_suffix}"
 
       still_format_ids = build_still_format_ids(asset_map)
+      @native_format_ids = build_native_format_ids(asset_map, timeline_frame_duration)
+      sequence_tc_format = @native_format_ids.empty? ? nil : 'NDF'
 
       builder = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
         xml.fcpxml(version: '1.12') do
@@ -49,6 +51,25 @@ class ButterCut
               )
             end
 
+            # Per-asset native-rate formats: only emitted when a clip's own
+            # frame rate differs from the sequence's — e.g. Final Cut
+            # Camera's iPhone footage, which tags itself as a 29.97 drop-
+            # frame project while the actual media is flat 30fps. Final Cut
+            # cross-checks an asset-clip's declared rate against the file's
+            # own embedded timing on import; reusing the sequence's format
+            # for a mismatched clip gets the edit rejected ("Invalid edit
+            # with no respective media"), which is exactly the failure mode
+            # this fixes.
+            @native_format_ids.each_value do |entry|
+              xml.format(
+                id: entry[:id],
+                frameDuration: entry[:frame_duration],
+                width: format_width,
+                height: format_height,
+                colorSpace: format_color_space
+              )
+            end
+
             # Since fcpxml 1.9 an asset points at its file through a
             # media-rep child, not a src attribute.
             asset_map.each_value do |asset|
@@ -67,6 +88,7 @@ class ButterCut
                   xml.send('media-rep', kind: 'original-media', src: asset[:file_url])
                 end
               else
+                native_entry = @native_format_ids[asset[:frame_duration]]
                 xml.asset(
                   id: asset[:asset_id],
                   name: asset[:filename],
@@ -75,7 +97,7 @@ class ButterCut
                   audioRate: asset[:audio_rate],
                   hasAudio: '1',
                   hasVideo: '1',
-                  format: FORMAT_ID,
+                  format: native_entry ? native_entry[:id] : FORMAT_ID,
                   duration: asset[:asset_duration]
                 ) do
                   xml.send('media-rep', kind: 'original-media', src: asset[:file_url])
@@ -87,7 +109,9 @@ class ButterCut
           xml.library(location: './') do
             xml.event(name: project_basename, uid: event_uid) do
               xml.project(name: timestamped_project_name, uid: project_uid, modDate: '2025-10-31 17:25:16 GMT-7') do
-                xml.sequence(duration: sequence_duration, format: FORMAT_ID, tcStart: '0s', audioRate: '48k') do
+                sequence_attrs = { duration: sequence_duration, format: FORMAT_ID, tcStart: '0s', audioRate: '48k' }
+                sequence_attrs[:tcFormat] = sequence_tc_format if sequence_tc_format
+                xml.sequence(**sequence_attrs) do
                   xml.spine do
                     emit_spine(xml, timeline_clips)
                   end
@@ -128,12 +152,26 @@ class ButterCut
       attrs[:audioRole] = 'dialogue' unless still
       attrs[:lane] = lane if lane
 
+      # A clip whose native rate differs from the sequence's (see
+      # `build_native_format_ids`) needs to point at its own format resource
+      # and tell Final Cut how to conform it — otherwise the asset-clip's
+      # declared timing silently disagrees with the file's own embedded
+      # rate and Final Cut rejects the edit on import. (tcFormat is valid
+      # per the FCPXML 1.12 DTD but Final Cut's own importer flags it as an
+      # unexpected value on asset-clip at this version, so it's omitted here
+      # — the format + conform-rate pairing is what actually fixes import.)
+      native_entry = !still && @native_format_ids[clip[:asset][:frame_duration]]
+      attrs[:format] = native_entry[:id] if native_entry
+
       if still
         # No audio → no adjust-volume child; stay self-closing when there are
         # no connected clips to nest.
         block_given? ? xml.video(**attrs) { yield } : xml.video(**attrs)
       else
         xml.send('asset-clip', **attrs) do
+          if native_entry
+            xml.send('conform-rate', srcFrameRate: clip[:asset][:nominal_frame_rate].to_s)
+          end
           xml.send('adjust-volume', amount: clip_volume_adjustment(clip))
           yield if block_given?
         end
@@ -156,6 +194,24 @@ class ButterCut
 
         key = [asset[:width], asset[:height]]
         ids[key] ||= "r_still_#{asset[:width]}x#{asset[:height]}"
+      end
+    end
+
+    # One extra format resource per unique native frame rate that differs
+    # from the sequence's own — keyed by the asset's `frame_duration` string
+    # (e.g. "1/30s") → {id:, frame_duration:}. Empty for the common case
+    # where every clip already matches the sequence rate, so this changes
+    # nothing about existing single-rate cuts.
+    def build_native_format_ids(asset_map, timeline_frame_duration)
+      asset_map.each_value.with_object({}) do |asset, ids|
+        next if asset[:type] == 'image'
+        next if asset[:frame_duration].nil? || asset[:frame_duration] == timeline_frame_duration
+        next if ids.key?(asset[:frame_duration])
+
+        ids[asset[:frame_duration]] = {
+          id: "r_native_#{ids.size + 1}",
+          frame_duration: asset[:frame_duration]
+        }
       end
     end
   end


### PR DESCRIPTION
## Summary
- Final Cut Camera (Apple's iPhone companion app) tags clips as 29.97 drop-frame even though the container measures a flat 30fps. FCPX export declared a flat-rate timeline regardless, which disagrees with what Final Cut's own importer expects from the file's embedded timecode — surfacing as "Invalid edit with no respective media" on import, for whichever clips' numbers didn't happen to already line up by luck.
- Drop-frame detection now trusts the tmcd drop-frame flag alone, rather than also requiring an exact 29.97 measured rate.
- The sequence conforms to `30000/1001` when the first clip is drop-frame tagged, matching what Final Cut itself builds when you import the same footage natively.
- A clip whose native rate differs from the sequence gets its own `<format>` resource plus a `<conform-rate>` tag, so Final Cut retimes it instead of rejecting the edit.
- Restored `ntsc_drop_frame_rate?` as its own method — the xmeml generators (FCP7/Premiere/Resolve) call it directly for their own, unrelated DF/NDF flagging. An earlier version of this fix removed it; the full spec suite caught the regression before it landed here.
- Affects both Core and Pro — the changed files (`editor_base_core.rb`, `fcpx_core.rb`) are shared by both editions.

## Test plan
- [x] `bundle exec rspec` — 340 examples, same 3 pre-existing failures as `main` (unrelated: an edition-string check and two migration-script subshell issues), zero regressions from this change
- [x] `bundle exec rspec spec/buttercut/fcpx_spec.rb spec/buttercut/export_spec.rb spec/buttercut/fcp7_spec.rb spec/buttercut/premiere_spec.rb spec/buttercut/generator_stills_spec.rb` — 114 examples, 0 failures
- [x] Reimported a real cut built from unmodified Final Cut Camera iPhone footage into Final Cut Pro — zero import warnings, all clips resolved at the correct positions (previously 5 of 7 clips failed with "Invalid edit with no respective media")