### PR TITLE
core: Fix drop-frame timecode on integer-rate media

### DIFF
--- a/lib/buttercut/editor_base_core.rb
+++ b/lib/buttercut/editor_base_core.rb
@@ -169,7 +169,7 @@ class ButterCut
       rate_num, rate_denom = frame_rate(video_path).split('/').map(&:to_i)
       return "0s" if rate_denom.zero? || rate_num.zero?
 
-      drop_frame = drop_frame_timecode?(timecode, rate_num, rate_denom, fps_nominal)
+      drop_frame = drop_frame_timecode?(timecode, fps_nominal)
 
       total_frames = if drop_frame
         drop_frames_per_minute = drop_frames_for_rate(fps_nominal)
@@ -189,10 +189,17 @@ class ButterCut
       "#{start_num / divisor}/#{start_denom / divisor}s"
     end
 
-    def drop_frame_timecode?(timecode, rate_num, rate_denom, fps_nominal)
-      return false unless timecode.include?(';')
-      return false unless fps_nominal == 30 || fps_nominal == 60
-      ntsc_drop_frame_rate?(rate_num, rate_denom)
+    # Drop-frame is a frame-NUMBERING scheme in the timecode digits, not a
+    # playback rate: a ";" means the digits skip 2 (or 4) frame numbers each
+    # non-tenth minute, and the skipped numbers must be subtracted however the
+    # clip plays back. Apple's Final Cut Camera records "29.97" media that
+    # ffprobe and Final Cut both rate as true 30/1 while its timecode stays
+    # drop-frame — gating this on an NTSC fractional rate turned those digits
+    # into frame counts up to a full minute past the media, and Final Cut
+    # dropped every clip as "invalid edit with no respective media". The ";"
+    # plus a 30/60 frame quanta is the whole test.
+    def drop_frame_timecode?(timecode, fps_nominal)
+      timecode.include?(';') && (fps_nominal == 30 || fps_nominal == 60)
     end
 
     # NTSC fractional rates (29.97 / 59.94) that use drop-frame timecode.

--- a/spec/buttercut/fcpx_spec.rb
+++ b/spec/buttercut/fcpx_spec.rb
@@ -216,6 +216,45 @@ RSpec.describe ButterCut::FCPX do
         expect(xml).to match(/<asset-clip[^>]*start="8999991\/2500s"/)
       end
     end
+
+    # Apple's Final Cut Camera records "29.97" as true 30/1 media (variable
+    # frame rate on an integer tick) while still numbering its timecode
+    # drop-frame. The dropped frame numbers must be subtracted even though the
+    # rate isn't NTSC fractional — Final Cut anchors the media at that frame
+    # count times 1/30 (verified against Final Cut Pro 12.3's own XML export;
+    # skipping the subtraction shifted every in-point a minute past the media
+    # and Final Cut dropped the clips as "invalid edit with no respective
+    # media").
+    context 'with drop-frame timecode on integer-rate media (Final Cut Camera)' do
+      let(:fcc_path) { '/tmp/fcc_2997.mov' }
+      let(:fcc_metadata) do
+        build_metadata(
+          frame_rate: '30/1',
+          duration_seconds: 37.302,
+          timecode: '16:37:10;02'
+        )
+      end
+
+      before do
+        allow_any_instance_of(ButterCut::FCPX).to receive(:extract_metadata_from_ffprobe).and_return(fcc_metadata)
+      end
+
+      it 'subtracts the dropped frame numbers at the reported integer rate' do
+        generator = ButterCut::FCPX.new([{ path: fcc_path }])
+
+        # 16:37:10;02 → 1794902 nominal frames − 1796 dropped = 1793106 → ÷30
+        expect(generator.clip_timecode_fraction(fcc_path)).to eq('298851/5s')
+      end
+
+      it 'anchors the asset and asset-clip at the drop-frame-corrected start' do
+        generator = ButterCut::FCPX.new([{ path: fcc_path }])
+        xml = generator.to_xml
+        asset_id = asset_id_for(generator, fcc_path)
+
+        expect(xml).to match(/<asset id="#{Regexp.escape(asset_id)}"[^>]*start="298851\/5s"/)
+        expect(xml).to match(/<asset-clip[^>]*start="298851\/5s"/)
+      end
+    end
   end
 
   describe '#generate_uuid' do


### PR DESCRIPTION
## Summary

Fix the drop-frame timecode conversion for media whose reported frame rate is integer (30/1, 60/1).

Apple's Final Cut Camera iPhone app records "29.97" as true 30/1 media (variable frame rate on an integer tick) while numbering its timecode drop-frame (`16:37:10;02`). The converter required an NTSC fractional rate (30000/1001) before subtracting dropped frame numbers, so those files' timecodes read up to a full minute past the media. Final Cut rejected every clip on import — "Invalid edit with no respective media" — and produced an empty timeline.

Drop-frame is a frame-numbering scheme, not a playback rate: subtract the dropped frame numbers whenever the timecode carries the ";" marker and a 30/60 frame quanta, and convert frames to seconds at the reported rate.

## Verification

- Export Final Cut Pro 12.3's own XML for the affected clips: FCP anchors the media at the drop-frame-corrected frame count times 1/30. ButterCut now emits the identical value (298851/5s for a 16:37:10;02 clip).
- Re-import the generated timeline into FCP 12.3: no warnings, all clips placed, inspector in-points frame-exact.
- Add a regression spec pinned to FCP's exact value; full suite passes (342 examples).

Real NTSC cameras (true 30000/1001 media) keep their existing behavior — the DF spec expectations are unchanged.