### PR TITLE
core: Derive FCPXML formats from probed source metadata

### DIFF
--- a/lib/buttercut/editor_base_core.rb
+++ b/lib/buttercut/editor_base_core.rb
@@ -82,8 +82,17 @@ class ButterCut
       extract_metadata(video_path)['streams'].find { |s| s['codec_type'] == 'video' }
     end
 
+    # Audio codecs ffmpeg cannot decode. iPhone spatial recordings carry a
+    # 4-channel APAC stream alongside the plain stereo track; Apple happens
+    # to order the stereo track first, but don't rely on that — skip past
+    # undecodable streams explicitly. If a file somehow has only undecodable
+    # audio, fall back to the first stream: it still marks the asset as
+    # having audio, and the editors decode APAC themselves.
+    UNDECODABLE_AUDIO_CODECS = %w[apac].freeze
+
     def audio_stream(video_path)
-      extract_metadata(video_path)['streams'].find { |s| s['codec_type'] == 'audio' }
+      streams = extract_metadata(video_path)['streams'].select { |s| s['codec_type'] == 'audio' }
+      streams.find { |s| !UNDECODABLE_AUDIO_CODECS.include?(s['codec_name']) } || streams.first
     end
 
     def video_width(video_path)
@@ -215,11 +224,26 @@ class ButterCut
       end
     end
 
-    # Color space is currently always emitted as Rec. 709; non-709 sources
-    # (HDR / Rec. 2020, P3) are not yet mapped. Takes a path for signature
-    # parity with the other per-clip metadata accessors.
-    def color_space(_video_path)
-      "1-1-1 (Rec. 709)"
+    # FCPXML colorSpace strings are "primaries-transfer-matrix" code triples.
+    # Rec. 2020 sources split by transfer curve; everything else (including
+    # sources with no color metadata, and image-only timelines with no video
+    # path at all) keeps the Rec. 709 label ButterCut has always written.
+    # Final Cut's own exports label Apple Log media "9-1-9 (Rec. 2020)" —
+    # bt2020 primaries with an unflagged transfer — verified on FCP 12.3.
+    REC_709_COLOR_SPACE = "1-1-1 (Rec. 709)".freeze
+    REC_2020_COLOR_SPACE = "9-1-9 (Rec. 2020)".freeze
+    REC_2020_HDR_COLOR_SPACES = {
+      'smpte2084' => '9-16-9 (Rec. 2020 PQ)',
+      'arib-std-b67' => '9-18-9 (Rec. 2020 HLG)'
+    }.freeze
+
+    def color_space(video_path)
+      return REC_709_COLOR_SPACE if video_path.nil?
+
+      stream = video_stream(video_path)
+      return REC_709_COLOR_SPACE unless stream['color_primaries'] == 'bt2020'
+
+      REC_2020_HDR_COLOR_SPACES.fetch(stream['color_transfer'], REC_2020_COLOR_SPACE)
     end
 
     def duration_to_fraction(video_path)

--- a/lib/buttercut/fcpx_core.rb
+++ b/lib/buttercut/fcpx_core.rb
@@ -26,6 +26,7 @@ class ButterCut
       timestamped_project_name = "#{project_basename} #{timestamp_suffix}"
 
       still_format_ids = build_still_format_ids(asset_map)
+      video_format_ids = build_video_format_ids(asset_map)
 
       builder = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |xml|
         xml.fcpxml(version: '1.12') do
@@ -37,6 +38,21 @@ class ButterCut
               frameDuration: format_frame_duration,
               colorSpace: format_color_space
             )
+
+            # Sources that don't match the timeline format get their own
+            # format resource, so Final Cut sees each asset's real dimensions,
+            # frame rate, and color space instead of the timeline's.
+            video_format_ids.each do |(width, height, frame_duration, color_space), format_id|
+              next if format_id == FORMAT_ID
+
+              xml.format(
+                id: format_id,
+                height: height,
+                width: width,
+                frameDuration: frame_duration,
+                colorSpace: color_space
+              )
+            end
 
             # Stills use a rate-undefined format (one per unique dimensions):
             # no frameDuration — that's what marks the asset as timeless.
@@ -75,7 +91,7 @@ class ButterCut
                   audioRate: asset[:audio_rate],
                   hasAudio: '1',
                   hasVideo: '1',
-                  format: FORMAT_ID,
+                  format: video_format_ids.fetch(video_format_key(asset)),
                   duration: asset[:asset_duration]
                 ) do
                   xml.send('media-rep', kind: 'original-media', src: asset[:file_url])
@@ -146,6 +162,30 @@ class ButterCut
       return MUTE_VOLUME_ADJUSTMENT if clip.dig(:clip_definition, :mute)
 
       volume_adjustment
+    end
+
+    # One format resource per distinct video spec, keyed
+    # [width, height, frame duration, color space] → format id. Assets whose
+    # spec matches the timeline format reuse it (FORMAT_ID), keeping the
+    # common single-source-format export unchanged.
+    def build_video_format_ids(asset_map)
+      timeline_key = [format_width, format_height, format_frame_duration, format_color_space]
+      asset_map.each_value.with_object(timeline_key => FORMAT_ID) do |asset, ids|
+        next if asset[:type] == 'image'
+
+        ids[video_format_key(asset)] ||= video_format_id(asset)
+      end
+    end
+
+    def video_format_key(asset)
+      [asset[:width], asset[:height], asset[:frame_duration], asset[:color_space]]
+    end
+
+    # Deterministic, human-readable id: "r_fmt_3840x2160_1000_30000_9-1-9".
+    def video_format_id(asset)
+      rate = asset[:frame_duration].delete_suffix('s').tr('/', '_')
+      color = asset[:color_space][/[\d-]+/]
+      "r_fmt_#{asset[:width]}x#{asset[:height]}_#{rate}_#{color}"
     end
 
     # One rate-undefined format resource per unique still dimensions, keyed

--- a/spec/buttercut/fcpx_spec.rb
+++ b/spec/buttercut/fcpx_spec.rb
@@ -5,25 +5,23 @@ RSpec.describe ButterCut::FCPX do
   let(:clips) { [{ path: video_file_path }] }
   let(:gh5_video_path) { File.expand_path('../fixtures/media/P1044376_timecode_fixture.mov', __dir__) }
 
-  def build_metadata(frame_rate:, duration_seconds:, width: 1280, height: 720, sample_rate: '48000', timecode: nil)
+  def build_metadata(frame_rate:, duration_seconds:, width: 1280, height: 720, sample_rate: '48000',
+                     timecode: nil, color_primaries: 'bt709', color_transfer: 'bt709', audio_streams: nil)
     video_stream = {
       'codec_type' => 'video',
       'width' => width,
       'height' => height,
       'r_frame_rate' => frame_rate,
       'color_space' => 'bt709',
-      'color_primaries' => 'bt709',
-      'color_transfer' => 'bt709'
+      'color_primaries' => color_primaries,
+      'color_transfer' => color_transfer
     }
     video_stream['tags'] = { 'timecode' => timecode } if timecode
 
-    audio_stream = {
-      'codec_type' => 'audio',
-      'sample_rate' => sample_rate
-    }
+    audio_streams ||= [{ 'codec_type' => 'audio', 'sample_rate' => sample_rate }]
 
     {
-      'streams' => [video_stream, audio_stream],
+      'streams' => [video_stream, *audio_streams],
       'format' => {
         'duration' => duration_seconds.to_s,
         'tags' => timecode ? { 'timecode' => timecode } : {}
@@ -254,6 +252,91 @@ RSpec.describe ButterCut::FCPX do
         expect(xml).to match(/<asset id="#{Regexp.escape(asset_id)}"[^>]*start="298851\/5s"/)
         expect(xml).to match(/<asset-clip[^>]*start="298851\/5s"/)
       end
+    end
+  end
+
+  describe '#color_space' do
+    let(:hdr_path) { '/tmp/hdr_clip.mov' }
+
+    def stub_color(primaries, transfer)
+      metadata = build_metadata(
+        frame_rate: '30/1',
+        duration_seconds: 10.0,
+        color_primaries: primaries,
+        color_transfer: transfer
+      )
+      allow_any_instance_of(ButterCut::FCPX).to receive(:extract_metadata_from_ffprobe).and_return(metadata)
+      ButterCut::FCPX.new([{ path: hdr_path }])
+    end
+
+    it 'maps Rec. 709 sources to the 1-1-1 triple' do
+      generator = stub_color('bt709', 'bt709')
+      expect(generator.color_space(hdr_path)).to eq('1-1-1 (Rec. 709)')
+    end
+
+    it 'maps HLG sources to the 9-18-9 triple' do
+      generator = stub_color('bt2020', 'arib-std-b67')
+      expect(generator.color_space(hdr_path)).to eq('9-18-9 (Rec. 2020 HLG)')
+    end
+
+    it 'maps PQ sources to the 9-16-9 triple' do
+      generator = stub_color('bt2020', 'smpte2084')
+      expect(generator.color_space(hdr_path)).to eq('9-16-9 (Rec. 2020 PQ)')
+    end
+
+    it 'maps Rec. 2020 sources without a transfer flag (Apple Log) to the 9-1-9 triple' do
+      generator = stub_color('bt2020', nil)
+      expect(generator.color_space(hdr_path)).to eq('9-1-9 (Rec. 2020)')
+    end
+
+    it 'falls back to Rec. 709 when color metadata is missing' do
+      generator = stub_color(nil, nil)
+      expect(generator.color_space(hdr_path)).to eq('1-1-1 (Rec. 709)')
+    end
+
+    it 'falls back to Rec. 709 for a nil path (image-only timelines)' do
+      generator = stub_color('bt2020', nil)
+      expect(generator.color_space(nil)).to eq('1-1-1 (Rec. 709)')
+    end
+
+    it 'stamps the mapped color space onto the emitted format' do
+      generator = stub_color('bt2020', 'arib-std-b67')
+      expect(generator.to_xml).to include('colorSpace="9-18-9 (Rec. 2020 HLG)"')
+    end
+  end
+
+  describe '#audio_stream' do
+    let(:spatial_path) { '/tmp/spatial_clip.mov' }
+
+    def stub_audio_streams(audio_streams)
+      metadata = build_metadata(
+        frame_rate: '30/1',
+        duration_seconds: 10.0,
+        audio_streams: audio_streams
+      )
+      allow_any_instance_of(ButterCut::FCPX).to receive(:extract_metadata_from_ffprobe).and_return(metadata)
+      ButterCut::FCPX.new([{ path: spatial_path }])
+    end
+
+    it 'skips undecodable APAC spatial streams even when they come first' do
+      generator = stub_audio_streams([
+        { 'codec_type' => 'audio', 'codec_name' => 'apac', 'sample_rate' => '44100' },
+        { 'codec_type' => 'audio', 'codec_name' => 'pcm_s16le', 'sample_rate' => '48000' }
+      ])
+      expect(generator.audio_stream(spatial_path)['codec_name']).to eq('pcm_s16le')
+      expect(generator.audio_sample_rate(spatial_path)).to eq('48000')
+    end
+
+    it 'falls back to the first audio stream when every stream is undecodable' do
+      generator = stub_audio_streams([
+        { 'codec_type' => 'audio', 'codec_name' => 'apac', 'sample_rate' => '48000' }
+      ])
+      expect(generator.audio_stream(spatial_path)['codec_name']).to eq('apac')
+    end
+
+    it 'returns nil when the file has no audio streams' do
+      generator = stub_audio_streams([])
+      expect(generator.audio_stream(spatial_path)).to be_nil
     end
   end
 
@@ -522,6 +605,60 @@ RSpec.describe ButterCut::FCPX do
         xml = generator.to_xml
         asset_id = asset_id_for(generator, clip_b_path)
         expect(xml).to match(/ref="#{Regexp.escape(asset_id)}"[^>]*start="1001\/30000s"/)
+      end
+    end
+
+    describe 'per-asset format resources' do
+      let(:clip_709_path) { '/tmp/clip_709.mov' }
+      let(:clip_hdr_path) { '/tmp/clip_hdr.mov' }
+      let(:metadata_by_path) do
+        {
+          clip_709_path => build_metadata(
+            frame_rate: '24000/1001',
+            duration_seconds: 6.0
+          ),
+          clip_hdr_path => build_metadata(
+            frame_rate: '30/1',
+            duration_seconds: 2.0,
+            width: 3840,
+            height: 2160,
+            color_primaries: 'bt2020',
+            color_transfer: nil
+          )
+        }
+      end
+
+      before do
+        allow_any_instance_of(ButterCut::FCPX).to receive(:extract_metadata_from_ffprobe) do |_instance, path|
+          metadata_by_path.fetch(path)
+        end
+      end
+
+      it 'gives a source that differs from the timeline its own format resource' do
+        generator = ButterCut::FCPX.new([{ path: clip_709_path }, { path: clip_hdr_path }])
+        xml = generator.to_xml
+
+        expect(xml).to include('<format id="r_fmt_3840x2160_1_30_9-1-9" height="2160" width="3840" ' \
+                               'frameDuration="1/30s" colorSpace="9-1-9 (Rec. 2020)"/>')
+        hdr_asset_id = asset_id_for(generator, clip_hdr_path)
+        expect(xml).to match(/<asset id="#{Regexp.escape(hdr_asset_id)}"[^>]*format="r_fmt_3840x2160_1_30_9-1-9"/)
+      end
+
+      it 'keeps the timeline sequence and matching assets on the timeline format' do
+        generator = ButterCut::FCPX.new([{ path: clip_709_path }, { path: clip_hdr_path }])
+        xml = generator.to_xml
+
+        expect(xml).to include('<sequence duration=')
+        expect(xml).to match(/<sequence [^>]*format="r1"/)
+        first_asset_id = asset_id_for(generator, clip_709_path)
+        expect(xml).to match(/<asset id="#{Regexp.escape(first_asset_id)}"[^>]*format="r1"/)
+      end
+
+      it 'emits a single format when every source matches the timeline' do
+        generator = ButterCut::FCPX.new([{ path: clip_709_path }, { path: clip_709_path }])
+        xml = generator.to_xml
+
+        expect(xml.scan(/<format /).length).to eq(1)
       end
     end
   end


### PR DESCRIPTION
## What changed

- Map probed color primaries and transfer to the FCPXML colorSpace triple — Rec. 2020 (9-1-9), HLG (9-18-9), PQ (9-16-9) — instead of hardcoding Rec. 709. Final Cut labels Apple Log media 9-1-9 (Rec. 2020) in its own exports (verified against FCP 12.3's XML).
- Emit one format resource per distinct video spec (dimensions, frame rate, color space), so mixed-rate and mixed-color timelines declare each asset's real format instead of stamping the timeline format on every asset. Sources that match the timeline still reuse r1, keeping single-format exports byte-identical.
- Skip Apple's undecodable APAC spatial audio stream when probing audio instead of relying on Apple's stream ordering, with a fallback to the first audio stream.

## Why

Final Cut Camera (and stock iPhone) footage records HLG or Apple Log in Rec. 2020; the exporter labeled everything Rec. 709, so HDR footage imported with the wrong color tag. Mixed-rate timelines also mislabeled every asset with the timeline format, and iPhone 16 spatial recordings carry a 4-channel APAC stream ffmpeg cannot decode.

## Notes for review

- Follow-up to #123 from the Final Cut Camera investigation.
- 355 examples, 0 failures. Single-format exports stay byte-identical (the full-project fixture specs pass unchanged).
- Final Cut import verification of a mixed-format timeline (24/60/30fps, Rec. 2020) is pending.