### PR TITLE
fix(security): escape shell interpolation in ffprobe and xmllint calls

### DIFF
--- a/lib/buttercut/editor_base_core.rb
+++ b/lib/buttercut/editor_base_core.rb
@@ -534,7 +534,7 @@ class ButterCut
     end
 
     def extract_metadata_from_ffprobe(video_path)
-      json_output = `#{Shellwords.escape(MediaTools.ffprobe)} -v quiet -print_format json -show_format -show_streams "#{video_path}" 2>&1`
+      json_output = `#{Shellwords.escape(MediaTools.ffprobe)} -v quiet -print_format json -show_format -show_streams #{Shellwords.escape(video_path)} 2>&1`
 
       if $?.exitstatus != 0
         raise "Failed to extract metadata from #{video_path}: #{json_output}"

--- a/lib/buttercut/export_core.rb
+++ b/lib/buttercut/export_core.rb
@@ -3,6 +3,7 @@
 
 require 'date'
 require 'yaml'
+require 'shellwords'
 require_relative '../buttercut'
 
 class Export
@@ -124,7 +125,7 @@ class Export
     return puts "⚠ DTD not found at #{dtd_path}; skipping validation." unless File.exist?(dtd_path)
     return puts '⚠ xmllint not found; skipping validation.' unless system('command -v xmllint > /dev/null 2>&1')
 
-    output = `xmllint --noout --dtdvalid "#{dtd_path}" "#{xml_path}" 2>&1`
+    output = `xmllint --noout --dtdvalid #{Shellwords.escape(dtd_path)} #{Shellwords.escape(xml_path)} 2>&1`
     if $?.success?
       puts '✓ FCPXML validates against FCPXMLv1_12.dtd'
     else


### PR DESCRIPTION
## Security fix: shell command injection via unescaped path interpolation

Two ``Kernel#` `` (backtick) shell-outs interpolate an untrusted path without escaping. Ruby backticks invoke `/bin/sh -c`, so command substitution `$(...)`, backticks, and a `"` breakout all fire inside the double quotes.

### 1. `lib/buttercut/editor_base_core.rb:537` — ffprobe (High)

```ruby
`#{Shellwords.escape(MediaTools.ffprobe)} -v quiet -print_format json -show_format -show_streams "#{video_path}" 2>&1`
```

The binary is escaped, but `video_path` is interpolated raw inside double quotes. `video_path` is `clip[:path]`, which `Export#index_media_paths` copies **verbatim** from `library.yaml`'s `media[].path` (no filesystem re-canonicalization; the only validation is `Pathname#absolute?`, which any `/…`-prefixed payload passes). It reaches the sink during `ButterCut.new` on the **standard export flow** — no destructive user action required.

**Impact:** exporting a shared or downloaded library whose `library.yaml` contains e.g. `path: /tmp/a$(touch /tmp/pwned).mov` executes arbitrary commands with the user's privileges (the command substitution runs before ffprobe, regardless of whether the file exists). A crafted media *filename* is a plausible variant. The three sibling ffprobe/ffmpeg shell-outs (`library.rb:189`, `contact_sheet.rb:123` and `:329`) already escape their paths — this call is the lone exception.

### 2. `lib/buttercut/export_core.rb:127` — xmllint (Medium)

`validate_fcpxml` interpolates the output path into an `xmllint` backtick the same way. `dtd_path` is a constant, but `xml_path` (the output path) is unescaped.

### Fix

Escape both interpolated paths with `Shellwords.escape` (matching the existing pattern), and add the missing `require 'shellwords'` to `export_core.rb`. No behavior change for legitimate paths.

---

No `SECURITY.md` / private reporting channel was found on the repo, so I'm disclosing via this fix PR rather than sitting on it — happy to coordinate differently if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
