### PR TITLE
Harden exports against stale media paths (pre-flight, phantom /Volumes detection, verify_media + relink)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ ruby lib/buttercut/library.rb migrate                    # runs every scripts/NN
 ruby lib/buttercut/library.rb <name> summary             # JSON: metadata + clip-completion breakdown
 ruby lib/buttercut/library.rb <name> incomplete_media    # JSON: clips still missing artifacts, with which fields are missing
 ruby lib/buttercut/library.rb <name> unsupported_media   # JSON: entries whose extension no editor imports natively (legacy footage to convert-and-swap)
+ruby lib/buttercut/library.rb <name> verify_media        # JSON: do the source files still resolve? If anything is missing/phantom, read skills/cut/missing_footage.md and follow it
 ruby lib/buttercut/library.rb <name> ready               # exit 0 = ready to build a cut, 1 = not. Raises if a migration script should be run.
 
 # Understand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ButterCut Pro & Core
 
+#### Added
+- **Exports now catch unplugged or renamed footage before an XML ships**, with new tools to help the agent reconnect moved footage.
+
 #### Fixed
 - **Final Cut Camera (iPhone) exports now import into Final Cut Pro cleanly.** The app records true 30/60fps media with drop-frame timecode; the exporter skipped the drop-frame correction for those files, so Final Cut rejected every clip ("Invalid edit with no respective media"). Thanks to @acreagetcg for the report and diagnosis.
 

--- a/lib/buttercut/export_core.rb
+++ b/lib/buttercut/export_core.rb
@@ -4,6 +4,8 @@
 require 'date'
 require 'yaml'
 require_relative '../buttercut'
+require_relative 'library'
+require_relative 'media_verifier'
 
 class Export
   EDITOR_LABELS = {
@@ -32,6 +34,7 @@ class Export
     media_paths = index_media_paths(library)
     clips       = build_clips(roughcut, media_paths)
 
+    ensure_cut_media_paths_live!(clips)
     write_xml(clips, @editor, roughcut['timeline'])
     validate_fcpxml(@output_path) if @editor == :fcpx
     @output_path
@@ -46,13 +49,25 @@ class Export
   end
 
   def load_library(roughcut_path)
-    match = roughcut_path.match(%r{libraries/([^/]+)/cuts})
-    raise "Could not extract library name from path: #{roughcut_path}" unless match
-
-    library_yaml = "libraries/#{match[1]}/library.yaml"
+    library_yaml = "libraries/#{library_name(roughcut_path)}/library.yaml"
     raise "Library file not found: #{library_yaml}" unless File.exist?(library_yaml)
 
     load_yaml(library_yaml)
+  end
+
+  def library_name(roughcut_path)
+    roughcut_path[%r{libraries/([^/]+)/cuts}, 1] ||
+      raise("Could not extract library name from path: #{roughcut_path}")
+  end
+
+  def ensure_cut_media_paths_live!(clips)
+    paths = clips.map { |clip| clip[:path] }.uniq
+    verifier = MediaVerifier.new(paths)
+    return if verifier.ok?
+
+    raise "#{verifier.problem_summary(total: paths.size)} " \
+          "Run `ruby lib/buttercut/library.rb #{library_name(@roughcut_path)} verify_media` to see the files, " \
+          'then read skills/cut/missing_footage.md and follow it.'
   end
 
   def index_media_paths(library)

--- a/lib/buttercut/library.md
+++ b/lib/buttercut/library.md
@@ -72,6 +72,7 @@ ruby lib/buttercut/library.rb <name> exists       # exit 0 if it exists, 1 if no
 ruby lib/buttercut/library.rb <name> summary      # JSON: metadata + per-type counts + clip-completion breakdown
 ruby lib/buttercut/library.rb <name> incomplete_media
 ruby lib/buttercut/library.rb <name> unsupported_media   # JSON: entries whose extension no editor imports natively
+ruby lib/buttercut/library.rb <name> verify_media        # JSON: do the source files still resolve? On missing/phantom, read skills/cut/missing_footage.md
 ruby lib/buttercut/library.rb <name> ready        # exit 0 if every clip is ready for a cut, 1 if not
 ruby lib/buttercut/library.rb update_checked      # record that you just checked for a newer ButterCut
 ruby lib/buttercut/library.rb edition             # print which ButterCut edition this is (core or pro)
@@ -111,6 +112,20 @@ source footage on disk.
 library whose config was never filled in. `editor` is validated against
 `fcpx|premiere|resolve` and `transcript_refinement` is coerced to a real
 boolean.
+
+### Verify and relink source paths
+
+```bash
+ruby lib/buttercut/library.rb <name> verify_media                       # JSON health report
+ruby lib/buttercut/library.rb <name> relink <old_prefix> <new_prefix>   # rewrite drifted paths (confirm first)
+```
+
+`verify_media` is read-only — it flags each media path `ok`/`missing`/`phantom`
+(a stale `/Volumes` path resolving to a leftover boot-disk folder, which a bare
+existence check misses) and suggests a prefix `relink` for the misses. `relink`
+rewrites a moved prefix — segment-boundary aware, all-or-nothing, never automatic:
+propose a suggestion, let the user confirm, then re-export. The JSON report shape
+and the phantom/suggestion rules live in the [`MediaVerifier`](media_verifier.rb) comment.
 
 ### Mark files done
 ```bash

--- a/lib/buttercut/library.rb
+++ b/lib/buttercut/library.rb
@@ -12,6 +12,7 @@ require 'shellwords'
 require 'yaml'
 
 require_relative 'media_tools'
+require_relative 'media_verifier'
 require_relative 'version'
 
 class Library
@@ -309,6 +310,53 @@ class Library
     end
   end
 
+  # Read-only report on whether every source file still resolves. See MediaVerifier.
+  def verify_media
+    MediaVerifier.new(media.map { |m| m['path'] }).report
+  end
+
+  # Rewrite media paths whose drive prefix moved. Never automatic (the user
+  # confirms a verify_media suggestion first) and all-or-nothing.
+  def relink!(old_prefix, new_prefix)
+    old = old_prefix.to_s.chomp('/')
+    new = new_prefix.to_s.chomp('/')
+    raise ArgumentError, 'relink requires <old_prefix> <new_prefix>' if old.empty? || new.empty?
+
+    meds = media
+    if meds.none? { |m| under_prefix?(m['path'], old) }
+      already = meds.count { |m| under_prefix?(m['path'], new) }
+      raise ArgumentError, "no media paths under #{old} (and none under #{new}) — " \
+                           'run verify_media and check the suggested prefix' if already.zero?
+
+      puts "#{@name}: already relinked — #{already} media #{pluralize(already, 'path')} under #{new}; nothing to do"
+      return self
+    end
+
+    rewritten = 0
+    mutate do |library|
+      targets = library['media'].select { |m| under_prefix?(m['path'], old) }
+      # Pre-lock read raced a concurrent writer — bail before the unconditional write.
+      raise ArgumentError, "no media paths under #{old} — re-run verify_media" if targets.empty?
+
+      plan = targets.map { |m| [m, rewrite_prefix(m['path'], old, new)] }
+      # Full statuses, not bare File.exist? — existence alone is fooled by a
+      # phantom volume (a squatter copy on the boot disk), the exact trap
+      # relink exists to fix.
+      bad = MediaVerifier.new(plan.map(&:last)).problems
+      unless bad.empty?
+        listed = bad.map { |b| "  #{b['path']} (#{b['status']})" }.join("\n")
+        raise ArgumentError, "relink aborted — #{bad.size} rewritten " \
+                             "#{pluralize(bad.size, 'path')} don't resolve to real footage " \
+                             "(statuses per skills/cut/missing_footage.md):\n#{listed}"
+      end
+
+      plan.each { |m, path| m['path'] = path }
+      rewritten = plan.size
+    end
+    puts "#{@name}: relinked #{rewritten} media #{pluralize(rewritten, 'path')} from #{old} to #{new}"
+    self
+  end
+
   # Mark `media_filenames` complete for one field. Validates each file exists
   # on disk before writing — atomicity is preserved by building the full plan
   # first and only mutating the YAML once every check passes.
@@ -517,6 +565,11 @@ class Library
 
   def pluralize(count, word) = "#{word}#{'s' unless count == 1}"
 
+  # Segment-boundary match: `/a/b` matches `/a/b` and `/a/b/…`, never `/a/bc`.
+  def under_prefix?(path, prefix) = path == prefix || path.to_s.start_with?("#{prefix}/")
+
+  def rewrite_prefix(path, old, new) = path == old ? new : new + path[old.length..]
+
   def merged_media(data)
     data['media'].map do |m|
       m.merge('filename' => self.class.filename_of(m),
@@ -700,6 +753,7 @@ if __FILE__ == $PROGRAM_NAME
       <name> summary                                  — JSON snapshot (media_count + per-type counts + incomplete breakdown)
       <name> incomplete_media                         — JSON array of incomplete clips
       <name> unsupported_media                        — JSON array of entries whose extension no editor imports natively
+      <name> verify_media                             — JSON report: media paths still resolve? On missing/phantom, read skills/cut/missing_footage.md
       <name> pending <field>                          — JSON array of clips still missing one field (only types the field applies to)
       <name> ready                                    — exits 0 if every clip is ready for roughcut, 1 otherwise
       <name> field_path <field> <clip>                — canonical path for a clip's artifact (e.g. summary → summaries/summary_<clip>.md)
@@ -707,6 +761,7 @@ if __FILE__ == $PROGRAM_NAME
     Writes:
       <name> add_media <path>...                      — append media records (type inferred from extension; video: #{Library::MEDIA_TYPES['video'][:extensions].join('/')}; image: #{Library::MEDIA_TYPES['image'][:extensions].join('/')})
       <name> remove_media <files>                     — drop entries + delete their artifacts (source footage untouched)
+      <name> relink <old_prefix> <new_prefix>         — rewrite media paths under old_prefix to new_prefix (segment-aware, all-or-nothing; propose from verify_media, user confirms)
       <name> update_metadata <key> <value...>         — set footage_summary, user_context, language, editor, or transcript_refinement
       <name> complete <field> <files>                 — mark files done for one field
       <name> reset <field> [<field>...]               — wipe one or more phases
@@ -785,6 +840,8 @@ if __FILE__ == $PROGRAM_NAME
       puts JSON.pretty_generate(library.incomplete_media)
     when 'unsupported_media'
       puts JSON.pretty_generate(library.unsupported_media)
+    when 'verify_media'
+      puts JSON.pretty_generate(library.verify_media)
     when 'pending'
       field, = rest
       raise ArgumentError, 'pending requires <field>' if field.nil?
@@ -805,6 +862,14 @@ if __FILE__ == $PROGRAM_NAME
       raise ArgumentError, 'remove_media requires <files>' if rest.empty?
 
       library.remove_media!(split_files.call(rest))
+    when 'relink'
+      # Volume names contain spaces ("Andrew SSD") — an unquoted call must fail
+      # here, not downstream with a misleading "no media paths under /Volumes/Andrew".
+      unless rest.size == 2
+        raise ArgumentError, 'relink requires exactly <old_prefix> <new_prefix> — quote prefixes containing spaces'
+      end
+
+      library.relink!(*rest)
     when 'update_metadata'
       key, *value_parts = rest
       raise ArgumentError, 'update_metadata requires <key> <value>' if key.nil? || value_parts.empty?

--- a/lib/buttercut/media_verifier.rb
+++ b/lib/buttercut/media_verifier.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# Verifies that a set of media paths still resolve where the library expects,
+# and — for `/Volumes` drives that have drifted — suggests a relink.
+#
+# Two macOS failure modes motivate this:
+#   * A drive renamed at mount time: a leftover `/Volumes/Andrew SSD` folder makes
+#     macOS mount the real drive as `/Volumes/Andrew SSD 1`, so stored paths miss.
+#   * The nastier variant: files copied INTO that leftover `/Volumes/Andrew SSD`
+#     folder — which lives on the internal boot disk — while the drive was
+#     unplugged. The stale path resolves (`File.exist?` is true) but points at
+#     the wrong copy. A bare existence check passes; this is the "phantom" case.
+#
+# Read-only: inspects the filesystem, never writes. Both the export pre-flight
+# and `Library#verify_media` build one over a list of paths.
+# `root_dev` and `volumes_root` are injectable so the whole thing is testable in
+# a tmpdir without fabricating device numbers.
+class MediaVerifier
+  def initialize(paths, root_dev: nil, volumes_root: '/Volumes')
+    @paths = Array(paths)
+    @volumes_root = volumes_root.to_s.chomp('/')
+    # The boot-disk baseline is the device volumes_root itself lives on — not
+    # `/`, which on APFS can be a sealed system snapshot with a different dev
+    # than the Data volume `/Volumes` is firmlinked into. A folder created
+    # inside /Volumes shares its parent's device; a real mount has its own.
+    @root_dev = root_dev || device_of(@volumes_root)
+  end
+
+  # [{ 'filename', 'path', 'status' }] in input order; status ∈ ok|missing|phantom.
+  def media
+    @media ||= @paths.map do |path|
+      { 'filename' => File.basename(path), 'path' => path, 'status' => status_of(path) }
+    end
+  end
+
+  def ok?      = media.all? { |m| m['status'] == 'ok' }
+  def problems = media.reject { |m| m['status'] == 'ok' }
+
+  # The full read-only report `verify_media` prints as JSON.
+  def report
+    {
+      'media' => media,
+      'ok_count' => count('ok'),
+      'missing_count' => count('missing'),
+      'phantom_count' => count('phantom'),
+      'phantom_volumes' => phantom_volumes,
+      'suggested_relinks' => suggested_relinks
+    }
+  end
+
+  # Distinct volume-root prefixes (`/Volumes/<X>`) that are leftover squatter
+  # folders on the boot disk.
+  def phantom_volumes
+    media.filter_map { |m| volume_prefix(m['path']) if m['status'] == 'phantom' }.uniq
+  end
+
+  # Prefix remaps that would fix the MISSING files (phantoms excluded — divergent
+  # copies need a human). One entry per old prefix, only when all its misses agree.
+  def suggested_relinks
+    media.select { |m| m['status'] == 'missing' }
+         .group_by { |m| volume_prefix(m['path']) }
+         .filter_map do |old_prefix, entries|
+           next unless old_prefix
+
+           targets = entries.map { |m| remap_target(old_prefix, m['path']) }
+           next if targets.any?(&:nil?) || targets.uniq.size != 1
+
+           { 'from' => old_prefix, 'to' => targets.first, 'resolves' => entries.size }
+         end
+  end
+
+  # A grouped, editor-friendly sentence for the export pre-flight failure. The
+  # caller appends the verify_media/relink pointer (it knows the library name).
+  def problem_summary(total:)
+    bad = problems.size
+    clause = bad == 1 ? "source file isn't where the library expects it" : "source files aren't where the library expects them"
+    msg = +"#{bad} of #{total} #{clause}."
+
+    prefixes = problems.map { |m| volume_prefix(m['path']) }.uniq
+    msg << " They're all under #{prefixes.first}/ — is that drive plugged in, or has it been renamed?" if prefixes.size == 1 && prefixes.first
+
+    unless phantom_volumes.empty?
+      verb = phantom_volumes.size == 1 ? 'is a leftover folder' : 'are leftover folders'
+      msg << " Note: #{phantom_volumes.join(', ')} #{verb} on this Mac's internal disk, not the real drive."
+    end
+    msg
+  end
+
+  private
+
+  def count(status) = media.count { |m| m['status'] == status }
+
+  def status_of(path)
+    return 'missing' unless File.exist?(path)
+    return 'phantom' if phantom?(path)
+
+    'ok'
+  end
+
+  def phantom?(path)
+    vol = volume_prefix(path)
+    return false unless vol
+
+    # Cached per volume — a library's clips overwhelmingly share one drive, so
+    # this is 3 syscalls per volume instead of per file.
+    @squatter ||= Hash.new { |cache, v| cache[v] = squatter_folder?(v) }
+    @squatter[vol]
+  end
+
+  # Phantom = the volume root `/Volumes/<X>` is a real (non-symlink) dir on the boot
+  # device — a leftover mount folder, not the drive (a symlinked root reads ok).
+  def squatter_folder?(vol)
+    return false if File.symlink?(vol)
+    return false unless File.directory?(vol)
+
+    File.stat(vol).dev == @root_dev
+  rescue SystemCallError
+    false
+  end
+
+  # `/Volumes/<X>` for a path under volumes_root, else nil.
+  def volume_prefix(path)
+    return nil unless under_volumes?(path)
+
+    name = path.delete_prefix("#{@volumes_root}/").split('/').first
+    return nil if name.nil? || name.empty?
+
+    File.join(@volumes_root, name)
+  end
+
+  def under_volumes?(path) = path.to_s.start_with?("#{@volumes_root}/")
+
+  # The single other mounted volume holding this file's tail (its remap target),
+  # or nil when zero or >1 match. Symlinked, non-dir, and boot-device volumes
+  # are skipped upstream.
+  def remap_target(old_prefix, path)
+    tail = path.delete_prefix("#{old_prefix}/")
+    return nil if tail == path # not actually under old_prefix
+
+    hits = mounted_volumes.reject { |vol| vol == old_prefix }
+                          .select { |vol| File.exist?(File.join(vol, tail)) }
+    hits.size == 1 ? hits.first : nil
+  end
+
+  # Real mounts only: a `/Volumes` entry on the boot device is another leftover
+  # squatter folder — a copy found inside one must never become a relink target.
+  # One unreadable entry (a stale network mount, say) is skipped on its own —
+  # it must not wipe out every other volume's suggestion.
+  def mounted_volumes
+    @mounted_volumes ||= volumes_entries.filter_map do |name|
+      vol = File.join(@volumes_root, name)
+      vol if real_mount?(vol)
+    end
+  end
+
+  def volumes_entries
+    Dir.children(@volumes_root)
+  rescue SystemCallError
+    []
+  end
+
+  def real_mount?(vol)
+    return false if File.symlink?(vol) || !File.directory?(vol)
+
+    File.stat(vol).dev != @root_dev
+  rescue SystemCallError
+    false
+  end
+
+  # A missing volumes_root (non-Mac test envs) falls back to `/` — no path can
+  # sit under it anyway, so phantom detection is inert there.
+  def device_of(dir)
+    File.stat(dir).dev
+  rescue SystemCallError
+    File.stat('/').dev
+  end
+end

--- a/skills/cut/SKILL.md
+++ b/skills/cut/SKILL.md
@@ -38,7 +38,7 @@ Options:
 The roughcut path runs a deeper flow because the agent needs to explore the library broadly, read many summaries, generate fresh contact sheets, and shape a narrative across many clips. The other four paths the main thread handles directly with the user.
 
 ## 3. Build the Cut (produces YAML)
-Both paths produce a YAML at `libraries/[library-name]/cuts/[slug]_[YYYYMMDD_HHMMSS].yaml`. The export in step 5 is the same regardless of which path you take.
+Both paths produce a YAML at `libraries/[library-name]/cuts/[slug]_[YYYYMMDD_HHMMSS].yaml`.
 
 ### What a cut can express
 A quick menu for shaping the cut with the user. Full field list and formats: `skills/cut/cut_yaml_schema.md`.
@@ -56,14 +56,23 @@ Read `skills/cut/roughcut_path.md` and follow it.
 ### Scene / Selects / Custom / Script path
 Read `skills/cut/direct_path.md` and follow it.
 
-## 4. Determine the Editing Application
+## 4. Verify the footage is reachable
+The export reads every source file the cut references, so before exporting confirm the footage is actually live — a drive can be unplugged or renamed since the library was built:
+```bash
+ruby lib/buttercut/library.rb <name> verify_media
+```
+Every clip `ok`? Continue. If any come back `missing` or `phantom`, don't export — read `skills/cut/missing_footage.md` and follow it to reconnect the footage first.
+
+Planning and building a cut don't need the drive plugged in — only the export does. So this check lives here, right before export, not at the start: the user can play with cuts on an unplugged drive and only reconnect when they're ready to hand a timeline to their editor.
+
+## 5. Determine the Editing Application
 Now that the cut YAML exists, resolve one editor value for the export:
 1. If `library.yaml` has `editor` set, use it.
 2. Otherwise fall back to `libraries/settings.yaml`'s `editor` and write the value back to `library.yaml`.
 3. If neither has one, ask the user (Final Cut Pro X / Adobe Premiere Pro / DaVinci Resolve), then save the choice to both `library.yaml` and `libraries/settings.yaml`.
 
-## 5. Export the YAML
-Run the export with the editor resolved in step 4 and the YAML produced in step 3:
+## 6. Export the Cut
+Run the export with the editor resolved in step 5 and the YAML produced in step 3:
 
 ```bash
 # Final Cut Pro X
@@ -76,7 +85,7 @@ ruby lib/buttercut/export.rb --editor premiere libraries/[library-name]/cuts/[sl
 ruby lib/buttercut/export.rb --editor resolve libraries/[library-name]/cuts/[slug]_[timestamp].yaml libraries/[library-name]/cuts/[slug]_[timestamp].xml
 ```
 
-## 6. Copy XML to Desktop (if enabled)
+## 7. Copy File to Desktop (if enabled)
 Check `libraries/settings.yaml` for `save_to_desktop_after_export`:
 1. If the key is `true`, copy the exported XML to `~/Desktop/` so it's easy to grab and import into the editor.
 2. If the key is `false`, skip this step.
@@ -88,10 +97,10 @@ cp [library xml path] ~/Desktop/
 
 The library copy stays as the canonical artifact; the desktop copy is a convenience drop.
 
-## 7. Backup the Library
+## 8. Backup Library
 Run the `backup-library` skill. This snapshots the entire library directory so progress can be restored if needed.
 
-## 8. Report Results
+## 9. Report Results
 Surface the path to the XML — the library path, or the desktop path if that's enabled. For roughcuts, also include very abbreviated editorial notes from the sub-agent's return message; small fixes you can do directly in the YAML and re-export without another sub-agent. **Do not include the YAML path** — it's an internal build artifact, not something the user opens.
 
 Include the one-line import instruction for the editor used:
@@ -100,7 +109,7 @@ Include the one-line import instruction for the editor used:
 - **Adobe Premiere Pro:** Open the cut in Premiere with File → Import, then select the XML file
 - **DaVinci Resolve:** Open the cut in Resolve with File → Import → Timeline, then select the XML file
 
-## 9. Open in Editor (if enabled)
+## 10. Open in Editor (if enabled)
 Check `libraries/settings.yaml` for `open_in_editor_after_export`:
 1. If the key is `true`, open the exported file directly in the user's editor.
 2. If the key is `false`, skip this step.
@@ -121,7 +130,7 @@ open -a "DaVinci Resolve" [xml path]
 
 If this is enabled, tell them "I've opened the file for you in __application_name__. Let me know if I can help with anything else."
 
-Use the desktop copy path if step 6 placed one there; otherwise use the library path.
+Use the desktop copy path if step 7 placed one there; otherwise use the library path.
 
 
 ## Guidelines

--- a/skills/cut/missing_footage.md
+++ b/skills/cut/missing_footage.md
@@ -1,0 +1,39 @@
+# When footage isn't where the library expects it
+
+`verify_media` reported `missing` or `phantom` clips. Don't export against them — a
+cut that references files the editor can't find imports as offline (red) media.
+Reconnect the footage first, then re-verify and export.
+
+## What the statuses mean
+
+- `missing` — the file isn't at its stored path. Usually the drive is unplugged, or
+  it remounted under a new name (macOS mounts a drive whose name is squatted by a
+  leftover folder as `<name> 1` — e.g. `MyDrive` becomes `MyDrive 1`).
+- `phantom` — the path *does* resolve, but to a leftover `/Volumes/<name>` folder on
+  the internal boot disk rather than the real drive. This is the dangerous one: the
+  files there may be a stale or partial copy made while the drive was unplugged, so a
+  plain "does it exist?" check is fooled.
+
+## Fixing missing footage (the common case)
+
+1. Ask the user to plug in or remount the drive, then re-run `verify_media`.
+2. If it still misses and the report has a `suggested_relinks` entry, the drive
+   likely remounted under a new name. Show the user the mapping (e.g.
+   `/Volumes/MyDrive` → `/Volumes/MyDrive 1`) and, **only after they confirm**, run:
+   ```bash
+   ruby lib/buttercut/library.rb <name> relink <old_prefix> <new_prefix>
+   ```
+   Then re-run `verify_media` to confirm everything is `ok` before exporting.
+
+**Never relink automatically.** Paths are the user's data; a silent rewrite could
+point the library at a divergent copy of the footage.
+
+## Fixing a phantom volume
+
+When the report lists `phantom_volumes`, a leftover `/Volumes/<name>` folder on the
+internal disk is squatting the drive's real name. The clean fix is to eject the
+drive, delete that folder, and remount so the drive reclaims its name.
+
+**Look inside the folder before deleting it.** If it holds files, that's footage
+someone rescued there while the drive was unplugged — not junk. Surface it to the
+user and let them decide; never delete a non-empty phantom folder.

--- a/spec/buttercut/export_spec.rb
+++ b/spec/buttercut/export_spec.rb
@@ -174,6 +174,37 @@ RSpec.describe Export do
     end
   end
 
+  describe 'media pre-flight' do
+    it 'exports cleanly when every source file is present' do
+      cut = { 'clips' => [{ 'source_file' => 'MVI_0309_720p.mov', 'in_point' => 0, 'out_point' => 1 }] }
+      within_export_sandbox(cut: cut, media: [clip_a]) do |cut_path, out|
+        expect { perform(cut_path, out) }.not_to raise_error
+        expect(File.exist?(out)).to be(true)
+      end
+    end
+
+    it 'fails fast (before ffprobe) when a single source file has moved' do
+      cut = { 'clips' => [{ 'source_file' => 'C2407.MP4', 'in_point' => 0, 'out_point' => 2 }] }
+      within_export_sandbox(cut: cut, media: ['/Volumes/ButterCut Spec Drive/CAC/C2407.MP4']) do |cut_path, out|
+        expect { perform(cut_path, out) }
+          .to raise_error(/1 of 1 source file isn't where the library expects/)
+        expect(File.exist?(out)).to be(false)
+      end
+    end
+
+    it 'groups several missing files under their shared volume and names verify_media' do
+      cut = { 'clips' => [
+        { 'source_file' => 'C2407.MP4', 'in_point' => 0, 'out_point' => 2 },
+        { 'source_file' => 'C2408.MP4', 'in_point' => 0, 'out_point' => 2 }
+      ] }
+      media = ['/Volumes/ButterCut Spec Drive/CAC/C2407.MP4', '/Volumes/ButterCut Spec Drive/CAC/C2408.MP4']
+      within_export_sandbox(cut: cut, media: media) do |cut_path, out|
+        expect { perform(cut_path, out) }
+          .to raise_error(/2 of 2 source files.*under \/Volumes\/ButterCut Spec Drive\/.*verify_media/m)
+      end
+    end
+  end
+
   describe 'editor targets' do
     let(:cut) do
       { 'clips' => [{ 'source_file' => 'MVI_0309_720p.mov', 'in_point' => 0, 'out_point' => 2 }] }

--- a/spec/buttercut/library_spec.rb
+++ b/spec/buttercut/library_spec.rb
@@ -360,6 +360,134 @@ RSpec.describe Library do
     end
   end
 
+  describe '#verify_media' do
+    # Deep phantom/suggestion coverage lives in media_verifier_spec (it injects
+    # the root-device and /Volumes seams). Here we just confirm Library wires its
+    # media paths through and hands back the report shape.
+    it 'reports ok and missing statuses with counts' do
+      present = File.join(@libraries_root, 'src', 'here.mov')
+      FileUtils.mkdir_p(File.dirname(present))
+      FileUtils.touch(present)
+      write_library(media: [
+                      video_entry('here.mov', path: present),
+                      video_entry('gone.mov', path: File.join(@libraries_root, 'src', 'gone.mov'))
+                    ])
+
+      report = Library.find(library_name).verify_media
+
+      expect(report['media'].map { |m| m['status'] }).to eq(%w[ok missing])
+      expect(report['ok_count']).to eq(1)
+      expect(report['missing_count']).to eq(1)
+      expect(report).to include('phantom_volumes' => [], 'suggested_relinks' => [])
+    end
+
+    it 'makes no relink suggestion for a missing non-/Volumes path' do
+      write_library(media: [video_entry('gone.mov', path: File.join(@libraries_root, 'gone.mov'))])
+
+      expect(Library.find(library_name).verify_media['suggested_relinks']).to be_empty
+    end
+  end
+
+  describe '#relink!' do
+    # Stand in for a drive mounted at <root>/<vol>, holding clips under CAC/.
+    def make_drive(vol, *names)
+      names.each do |name|
+        path = File.join(@libraries_root, vol, 'CAC', name)
+        FileUtils.mkdir_p(File.dirname(path))
+        FileUtils.touch(path)
+      end
+    end
+
+    def clip_path(vol, name) = File.join(@libraries_root, vol, 'CAC', name)
+
+    it 'rewrites matching paths when every new target exists' do
+      make_drive('drive 1', 'a.mov', 'b.mov') # the drive remounted here
+      old = File.join(@libraries_root, 'drive')
+      new = File.join(@libraries_root, 'drive 1')
+      write_library(media: [
+                      video_entry('a.mov', path: clip_path('drive', 'a.mov')),
+                      video_entry('b.mov', path: clip_path('drive', 'b.mov'))
+                    ])
+
+      Library.find(library_name).relink!(old, new)
+
+      expect(load_yaml['media'].map { |m| m['path'] })
+        .to eq([clip_path('drive 1', 'a.mov'), clip_path('drive 1', 'b.mov')])
+    end
+
+    it 'does not match a longer sibling prefix (segment boundary)' do
+      make_drive('Andrew SSD NEW', 'a.mov')
+      old = File.join(@libraries_root, 'Andrew SSD')
+      new = File.join(@libraries_root, 'Andrew SSD NEW')
+      sibling = clip_path('Andrew SSD 1', 'b.mov') # must be left alone
+      write_library(media: [
+                      video_entry('a.mov', path: clip_path('Andrew SSD', 'a.mov')),
+                      video_entry('b.mov', path: sibling)
+                    ])
+
+      Library.find(library_name).relink!(old, new)
+
+      expect(load_yaml['media'].map { |m| m['path'] })
+        .to eq([clip_path('Andrew SSD NEW', 'a.mov'), sibling])
+    end
+
+    it 'aborts all-or-nothing when any rewritten target is missing' do
+      make_drive('drive 1', 'a.mov') # b.mov absent at the new location
+      old = File.join(@libraries_root, 'drive')
+      new = File.join(@libraries_root, 'drive 1')
+      write_library(media: [
+                      video_entry('a.mov', path: clip_path('drive', 'a.mov')),
+                      video_entry('b.mov', path: clip_path('drive', 'b.mov'))
+                    ])
+
+      expect { Library.find(library_name).relink!(old, new) }
+        .to raise_error(ArgumentError, /relink aborted/)
+      expect(load_yaml['media'].map { |m| m['path'] })
+        .to eq([clip_path('drive', 'a.mov'), clip_path('drive', 'b.mov')]) # untouched
+    end
+
+    it 'is an idempotent no-op when paths already sit under the new prefix' do
+      old = File.join(@libraries_root, 'drive')
+      new = File.join(@libraries_root, 'drive 1')
+      write_library(media: [video_entry('a.mov', path: clip_path('drive 1', 'a.mov'))])
+
+      expect { Library.find(library_name).relink!(old, new) }.not_to raise_error
+      expect(load_yaml['media'].first['path']).to eq(clip_path('drive 1', 'a.mov'))
+    end
+
+    it 'raises when the prefix matches neither old nor new (typo)' do
+      write_library(media: [video_entry('a.mov', path: clip_path('drive', 'a.mov'))])
+
+      expect { Library.find(library_name).relink!('/Volumes/Typo', '/Volumes/AlsoTypo') }
+        .to raise_error(ArgumentError, /no media paths under/)
+    end
+
+    it 'aborts when a rewritten target only resolves into a phantom boot-disk folder' do
+      # A real phantom needs /Volumes device topology, so stub the verifier
+      # relink! builds over the rewritten paths instead of standing one up.
+      make_drive('drive 1', 'a.mov')
+      old = File.join(@libraries_root, 'drive')
+      new = File.join(@libraries_root, 'drive 1')
+      write_library(media: [video_entry('a.mov', path: clip_path('drive', 'a.mov'))])
+      phantom = { 'filename' => 'a.mov', 'path' => clip_path('drive 1', 'a.mov'), 'status' => 'phantom' }
+      allow(MediaVerifier).to receive(:new).and_return(instance_double(MediaVerifier, problems: [phantom]))
+
+      expect { Library.find(library_name).relink!(old, new) }
+        .to raise_error(ArgumentError, /relink aborted.*\(phantom\)/m)
+      expect(load_yaml['media'].first['path']).to eq(clip_path('drive', 'a.mov')) # untouched
+    end
+
+    it 'returns self for chaining' do
+      make_drive('drive 1', 'a.mov')
+      old = File.join(@libraries_root, 'drive')
+      new = File.join(@libraries_root, 'drive 1')
+      write_library(media: [video_entry('a.mov', path: clip_path('drive', 'a.mov'))])
+      lib = Library.find(library_name)
+
+      expect(lib.relink!(old, new)).to be(lib)
+    end
+  end
+
   describe '#unsupported_media' do
     it 'surfaces entries whose extension no editor imports natively' do
       write_library(media: [
@@ -1062,6 +1190,25 @@ RSpec.describe Library do
       age_stamp(Library::UPDATE_CHECK_INTERVAL + 60)
       FileUtils.touch(File.join(@repo_root, Library::DEVELOPER_FLAG_FILE))
       expect { Library.check_for_update!(repo_root: @repo_root) }.not_to raise_error
+    end
+  end
+
+  describe 'CLI relink arity guard' do
+    # The guard lives in the CLI dispatch (not relink!), so exercise the real
+    # script. stub_const doesn't cross the process boundary — the library has
+    # to exist under the repo's actual libraries/ (gitignored; cleaned up here).
+    it 'rejects a wrong argument count with the quote-your-prefixes message' do
+      cli = File.expand_path('../../lib/buttercut/library.rb', __dir__)
+      lib_dir = File.expand_path('../../libraries/cli-relink-arity-spec', __dir__)
+      FileUtils.mkdir_p(lib_dir)
+      File.write(File.join(lib_dir, 'library.yaml'), { 'media' => [] }.to_yaml)
+
+      out = `ruby #{Shellwords.escape(cli)} cli-relink-arity-spec relink /Volumes/Andrew SSD /Volumes/Other 2>&1`
+
+      expect($CHILD_STATUS.exitstatus).to eq(1)
+      expect(out).to include('quote prefixes containing spaces')
+    ensure
+      FileUtils.rm_rf(lib_dir)
     end
   end
 

--- a/spec/buttercut/media_verifier_spec.rb
+++ b/spec/buttercut/media_verifier_spec.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+require_relative '../../lib/buttercut/media_verifier'
+
+# All examples run inside a tmpdir that stands in for `/Volumes` (injected via
+# `volumes_root:`), and most inject `root_dev:` so phantom detection is
+# deterministic: the "boot device" is always the dev of the tmp files we create.
+# One example omits root_dev on purpose, pinning the production default to the
+# device volumes_root itself lives on.
+RSpec.describe MediaVerifier do
+  around do |example|
+    Dir.mktmpdir('media-verifier-') do |root|
+      @volumes = root
+      example.run
+    end
+  end
+
+  # The device the tmpdir sits on — stand-in for the internal boot disk.
+  let(:root_dev) { File.stat(@volumes).dev }
+
+  def vol(*parts) = File.join(@volumes, *parts)
+
+  # Create a file (and its parent dirs) at <volumes>/<rel>, return the path.
+  def touch(rel)
+    path = vol(rel)
+    FileUtils.mkdir_p(File.dirname(path))
+    FileUtils.touch(path)
+    path
+  end
+
+  def verify(paths, **opts)
+    MediaVerifier.new(paths, root_dev: root_dev, volumes_root: @volumes, **opts)
+  end
+
+  # Pretend the boot disk is elsewhere, so the tmp volumes read as real external
+  # mounts (by default they'd all sit on root_dev and read as squatter folders).
+  def verify_external(paths) = verify(paths, root_dev: root_dev + 1)
+
+  describe 'status' do
+    it 'reports an existing file on a non-root device as ok' do
+      path = touch('Andrew SSD/CAC/C2407.MP4')
+      report = verify_external([path]).report
+
+      expect(report['media'].first['status']).to eq('ok')
+      expect(report['ok_count']).to eq(1)
+    end
+
+    it 'reports a nonexistent path as missing' do
+      report = verify([vol('Andrew SSD/gone.MP4')]).report
+
+      expect(report['media'].first['status']).to eq('missing')
+      expect(report['missing_count']).to eq(1)
+    end
+
+    it 'derives the default boot-device baseline from volumes_root itself, not `/`' do
+      # On APFS `/` can be a sealed snapshot on a different device than the
+      # Data volume /Volumes is firmlinked into; keying off `/` would miss
+      # squatter folders entirely. No root_dev injected — this exercises the
+      # production default against a squatter dir sharing volumes_root's device.
+      path = touch('Andrew SSD/CAC/C2407.MP4')
+
+      report = MediaVerifier.new([path], volumes_root: @volumes).report
+
+      expect(report['media'].first['status']).to eq('phantom')
+      expect(report['phantom_volumes']).to eq([vol('Andrew SSD')])
+    end
+
+    it 'reports a file in a leftover boot-disk folder as phantom' do
+      path = touch('Andrew SSD/CAC/C2407.MP4') # the volume root is a real dir on root_dev
+
+      report = verify([path]).report
+
+      expect(report['media'].first['status']).to eq('phantom')
+      expect(report['phantom_count']).to eq(1)
+      expect(report['phantom_volumes']).to eq([vol('Andrew SSD')])
+    end
+
+    it 'never flags a symlinked volume root as phantom, even on the root device' do
+      # `/Volumes/Macintosh HD -> /` is a symlink; a legit path under it resolves
+      # to the boot device but must read ok, not phantom.
+      real = Dir.mktmpdir('real-boot-')
+      FileUtils.mkdir_p(File.join(real, 'Users/andrew'))
+      FileUtils.touch(File.join(real, 'Users/andrew/footage.mov'))
+      File.symlink(real, vol('Macintosh HD'))
+
+      report = verify([vol('Macintosh HD/Users/andrew/footage.mov')]).report
+
+      expect(report['media'].first['status']).to eq('ok')
+      expect(report['phantom_volumes']).to be_empty
+    ensure
+      FileUtils.remove_entry(real)
+    end
+
+    it 'treats a non-/Volumes path only by existence (never phantom)' do
+      Dir.mktmpdir do |elsewhere|
+        present = File.join(elsewhere, 'a.mov')
+        FileUtils.touch(present)
+        report = verify([present, File.join(elsewhere, 'gone.mov')]).report
+
+        expect(report['media'].map { |m| m['status'] }).to eq(%w[ok missing])
+        expect(report['suggested_relinks']).to be_empty
+      end
+    end
+  end
+
+  describe 'suggested_relinks' do
+    # Suggestion targets must be real mounts, hence verify_external throughout.
+    it 'suggests the sibling volume when every miss agrees' do
+      touch('Andrew SSD 1/CAC/C2407.MP4')
+      touch('Andrew SSD 1/CAC/C2408.MP4')
+      report = verify_external([vol('Andrew SSD/CAC/C2407.MP4'), vol('Andrew SSD/CAC/C2408.MP4')]).report
+
+      expect(report['suggested_relinks']).to eq(
+        [{ 'from' => vol('Andrew SSD'), 'to' => vol('Andrew SSD 1'), 'resolves' => 2 }]
+      )
+    end
+
+    it 'makes no suggestion when the tail exists under two volumes (ambiguous)' do
+      touch('DriveA/CAC/C2407.MP4')
+      touch('DriveB/CAC/C2407.MP4')
+      report = verify_external([vol('Andrew SSD/CAC/C2407.MP4')]).report
+
+      expect(report['suggested_relinks']).to be_empty
+    end
+
+    it 'makes no suggestion when the misses disagree on a target' do
+      touch('Andrew SSD 1/a/x.MP4') # a/x.MP4 only under "Andrew SSD 1"
+      touch('Andrew SSD 2/b/y.MP4') # b/y.MP4 only under "Andrew SSD 2"
+      report = verify_external([vol('Andrew SSD/a/x.MP4'), vol('Andrew SSD/b/y.MP4')]).report
+
+      expect(report['suggested_relinks']).to be_empty
+    end
+
+    it 'skips a symlinked volume when probing for a sibling' do
+      # A `Macintosh HD -> /`-style symlink child must not manufacture a hit.
+      real = Dir.mktmpdir('real-boot-')
+      FileUtils.mkdir_p(File.join(real, 'CAC'))
+      FileUtils.touch(File.join(real, 'CAC/C2407.MP4')) # exists via the symlink
+      File.symlink(real, vol('Macintosh HD'))
+
+      report = verify_external([vol('Andrew SSD/CAC/C2407.MP4')]).report
+
+      expect(report['suggested_relinks']).to be_empty
+    ensure
+      FileUtils.remove_entry(real)
+    end
+
+    it 'skips an unreadable /Volumes entry instead of dropping every suggestion' do
+      touch('Andrew SSD 1/CAC/C2407.MP4')
+      flaky = vol('Flaky NAS')
+      FileUtils.mkdir_p(flaky)
+      allow(File).to receive(:stat).and_call_original
+      allow(File).to receive(:stat).with(flaky).and_raise(Errno::EIO)
+
+      report = verify_external([vol('Andrew SSD/CAC/C2407.MP4')]).report
+
+      expect(report['suggested_relinks']).to eq(
+        [{ 'from' => vol('Andrew SSD'), 'to' => vol('Andrew SSD 1'), 'resolves' => 1 }]
+      )
+    end
+
+    it 'never suggests a boot-device squatter folder as a relink target' do
+      # The missing file's tail exists — but inside another leftover folder on
+      # the boot disk (default root_dev), not on a real mount. Suggesting it
+      # would point the library at a squatter copy.
+      touch('Rescued Copies/CAC/C2407.MP4')
+      report = verify([vol('Andrew SSD/CAC/C2407.MP4')]).report
+
+      expect(report['suggested_relinks']).to be_empty
+    end
+
+    it 'never suggests a relink for a phantom file (divergent-copy guard)' do
+      touch('Andrew SSD/CAC/C2407.MP4')   # phantom: real folder on root_dev
+      touch('Andrew SSD 1/CAC/C2407.MP4') # a sibling copy exists
+      report = verify([vol('Andrew SSD/CAC/C2407.MP4')]).report
+
+      expect(report['media'].first['status']).to eq('phantom')
+      expect(report['suggested_relinks']).to be_empty
+    end
+  end
+
+  describe '#problem_summary' do
+    it 'names the shared volume when every problem is under one prefix' do
+      summary = verify([vol('Andrew SSD/a.MP4'), vol('Andrew SSD/b.MP4')]).problem_summary(total: 3)
+
+      expect(summary).to include('2 of 3 source files')
+      expect(summary).to include("under #{vol('Andrew SSD')}/")
+    end
+
+    it 'drops the shared-volume clause when prefixes differ' do
+      summary = verify([vol('DriveA/a.MP4'), vol('DriveB/b.MP4')]).problem_summary(total: 2)
+
+      expect(summary).not_to include('all under')
+    end
+
+    it 'calls out a phantom volume as a leftover folder on the internal disk' do
+      path = touch('Andrew SSD/CAC/C2407.MP4') # real dir on root_dev → phantom
+
+      summary = verify([path]).problem_summary(total: 1)
+
+      expect(summary).to include("#{vol('Andrew SSD')} is a leftover folder on this Mac's internal disk")
+    end
+  end
+
+  describe '#ok?' do
+    it 'is true only when every path resolves cleanly' do
+      present = touch('Andrew SSD/a.MP4')
+      expect(verify_external([present]).ok?).to be(true)
+      expect(verify_external([present, vol('Andrew SSD/gone.MP4')]).ok?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
Catches renamed or unplugged drives **before** an XML ships — an editor-friendly error and a two-command recovery loop instead of a raw mid-export ffprobe crash.

## The problem

macOS renames drives at mount time: a leftover `/Volumes/Andrew SSD` folder makes the real drive mount as `/Volumes/Andrew SSD 1`, so a library's stored paths stop pointing at the footage. And a bare `File.exist?` misses the nastiest variant — files copied *into* that leftover boot-disk folder while the drive was unplugged, where the stale path resolves to the wrong copy.

## What changed

**`MediaVerifier`** (new) — classifies each media path `ok | missing | phantom` and suggests prefix relinks.
- *Phantom* = the `/Volumes/<X>` volume root is a real (non-symlink) folder on the boot device. Checking the volume root, not the file, keeps legitimate paths under symlinked roots (`/Volumes/Macintosh HD -> /`) from being falsely flagged.
- Suggestions cover missing files only (a phantom's copy elsewhere is a divergence for a human to reconcile), and probe only real mounts — symlinked, non-directory, and boot-device `/Volumes` entries are never suggested as targets.

**`Library` commands** — `verify_media` (read-only JSON report) and `relink <old> <new>` (rewrites drifted paths through the existing `mutate`/flock path: segment-boundary aware, all-or-nothing, never automatic). Re-running a completed relink is a friendly no-op; a prefix matching neither old nor new fails loudly, as does an unquoted space-containing volume name.

**Export pre-flight** — after `build_clips`, before ffprobe: any missing/phantom path raises a grouped message pointing at `verify_media` and `skills/cut/missing_footage.md`.

**Docs & skill** — `missing_footage.md` owns the recovery procedure (relink flow, phantom-folder fix, and the look-inside-the-folder-first rule so rescued footage isn't deleted as junk); AGENTS.md, library.md, the CLI usage text, and the export error all point there instead of restating it. The cut skill verifies footage right before export, so cuts can still be planned with the drive unplugged.

## Recovery loop

`verify_media` → show the suggested mapping → user confirms → `relink <old> <new>` → re-export.
