### PR TITLE
Create Editor Integration Tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ Writes (`add_media`, `remove_media`, `complete`, `update_metadata`), destructive
 ## Project Structure
 - `skills/` - Skills for AI-powered workflow (symlinked from `.claude/skills/` so Claude Code, Codex, and other agents that read top-level `skills/` natively all find them)
 - `spec/` - RSpec test suite
+- `qa/` - Developer-only editor round-trip integration tests — imports the exports into the real editors (see `qa/editor-roundtrip.md`; never run in video-editor sessions)
 - `templates/` - Library and project templates
 - `dependencies/` - Optional static ffmpeg/ffprobe binaries (gitignored). `lib/buttercut/media_tools.rb` resolves binaries here first, then falls back to PATH; if a binary is in neither place it raises a clear error pointing at the `setup` skill.
 - `libraries/` - Working directory for user's video projects (gitignored)

--- a/qa/editor-roundtrip.md
+++ b/qa/editor-roundtrip.md
@@ -147,6 +147,57 @@ waveforms); a human can eyeball the whole thing in under a minute. This tier
 costs tokens/attention — use it when Tier 1 passes but you're chasing a
 content-level doubt, or as a pre-release once-over.
 
+### Driving Tier 2 agent-side (recipes verified 2026-07-12)
+
+The `integration-tests` skill (`skills/integration-tests/`) wraps both tiers —
+it runs `run_all.rb` and then drives this visual pass using the recipes below,
+which it carries as helper scripts (`resolve_park.rb`, `fcp_park.rb`,
+`premiere_open_all.rb`, `mouse.js`). This section documents the underlying
+technique.
+
+A full agent pass (30 positions × 3 editors) has been run from an agent shell
+with Accessibility + Screen Recording permission. What to check: each clip
+row at `record_in`, a middle frame, and `record_out − 1` (`record_out` itself
+already shows the *next* clip); at timeline frame `t` the ticker must read
+`F(row_in + t − record_in)`. One full-window screenshot per scenario covers
+the waveform column — and mute, invisible to Resolve's and Premiere's APIs,
+IS visible on their timelines: the muted clip draws a flat audio waveform,
+and a held still is a video clip with no audio beneath it. (FCP's mute is
+already covered structurally by the re-export's `adjust-volume`.)
+
+Parking the playhead, per editor:
+
+- **Resolve (free edition):** same job-file pattern as the dump script — an
+  in-app "park" Lua in the Fusion `Scripts/Utility/` folder reads a frame
+  number, computes NDF timecode at the nominal integer rate from
+  `GetStartFrame()`, calls `timeline:SetCurrentTimecode(tc)`, and writes a
+  readback report; triggered by the same Workspace > Scripts menu click. The
+  Scripts menu re-scans only when opened, so after installing a new script
+  open the Workspace menu once and retry. NDF-at-nominal is exact here only
+  because the QA timelines start at 0 and run under a minute; drop-frame
+  timelines read back with `;` separators — compare digits only.
+- **FCP:** reopen `fcp/buttercut-qa-import.fcpbundle` with `open`, then open
+  the project by double-clicking its browser row — System Events' `click at`
+  only sends an AXPress, so a real double-click needs a CGEvent with
+  `kCGMouseEventClickState` set (JXA + ObjC bridge). Park with Cmd+2 (focus
+  the timeline), ⌃P, typed `m ss ff` digits, Return. Free boundary
+  confirmation: FCP's viewer draws corner "L" badges on a clip's first/last
+  frame and sprocket-hole borders at media limits.
+- **Premiere:** render a variant of the dump jsx that imports *every*
+  scenario XML into one scratch project, opens each sequence
+  (`app.project.openSequence`), saves, and does **not** close — all scenarios
+  become timeline tabs in a single launch, and quitting afterwards is
+  dialog-free because the project was saved. Park by clicking the Program
+  monitor's timecode field, typing digits, Enter.
+
+Screenshots: `screencapture -x -R x,y,w,h` takes points (image px ÷ 2 on a
+2× retina display); crop tight to the viewer so the ticker is legible.
+
+Both Tier-1 legs keep only the last imported scenario (scratch
+projects/libraries are deleted on each run), so for Resolve and FCP work
+scenario-by-scenario: re-run that scenario's Tier-1 leg to import it, then
+walk its positions.
+
 ## Edition notes (core vs Pro)
 
 The suite and fixture are identical in both editions — keep them byte-identical
@@ -166,6 +217,15 @@ dumps include every track).
 - **Resolve: menu item missing** — the Scripts menu re-scans on open; if
   "ButterCut QA Dump" isn't listed, the auto-install failed (check
   `~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Utility/`).
+- **Resolve: `source_out` mismatch on media with embedded timecode** —
+  Resolve's `GetSourceStartFrame`/`GetSourceEndFrame` convert through the
+  media's embedded start timecode, and each endpoint independently picks up a
+  ±1 rounding (observed on qa_filmF: raw spans of 192 for a 192-frame clip
+  but 121 for a 120-frame one). `verify_resolve.rb` absorbs that jitter by
+  deriving the out-point from `left_offset` + the record span, so a
+  comparator failure here means the raw span disagreed by *more* than ±1 —
+  a real retime/conform problem, not the rounding. Confirm visually (Tier 2)
+  before blaming the export.
 - **FCP: aborts at "Open Library" dialog** — FCP's import dialog changed, or
   a modal (update prompt, etc.) was in the way. Run once by hand to see what's
   on screen; the runner's AppleScript lives inline in `verify_fcp.rb`.

--- a/qa/editor-roundtrip.md
+++ b/qa/editor-roundtrip.md
@@ -1,0 +1,228 @@
+# Editor round-trip QA — import the exports into the real editors
+
+Integration tests for the one promise ButterCut can't verify in RSpec: that the
+XML we export actually **imports into Final Cut Pro, DaVinci Resolve, and
+Premiere and builds the timeline the cut described** — right clips, right
+order, right trims, frame-accurately.
+
+**Developer-only.** Run this in a `*-developer` checkout (`.buttercut_mode`
+present) on a Mac with the editors installed. It never belongs in a video
+editor's session, and it can't run in CI (no editors there). Run it before a
+release and after touching anything in the export pipeline (`lib/buttercut/
+export*.rb`, `editor_base*`, `fcpx*`, `fcp7*`, `premiere.rb`, `resolve.rb`) or
+timecode/frame-rate math.
+
+Both editions carry this suite unchanged — run it in `buttercut-developer` and
+`buttercut-pro-developer` separately. The fixture library is gitignored and
+regenerated per run, so the clones never share state.
+
+## How it verifies (the trick)
+
+The fixture footage is **self-identifying**: every frame of every synthetic
+clip burns in its clip letter, source timecode, and source frame number over a
+solid per-clip color, and each clip has a distinct per-second beep pattern so
+even the audio waveforms are tellable apart on sight. Ground truth lives in
+the pixels, not in metadata — a bug that inserts the wrong clip (or the right
+clip at the wrong offset) cannot look correct, because the frame on screen
+literally names the source position it came from.
+
+On top of that, the expected timelines are computed with plain arithmetic from
+literal tables (`qa/scripts/generate_qa_fixture.rb`), deliberately **not**
+with `lib/buttercut`'s own timecode math, so an exporter bug can't cancel
+itself out in the expectation. Trims are written in frames — the native unit —
+so the math stays exact even at fractional NTSC rates.
+
+## Scenarios
+
+The suite is a matrix of scenario cuts × editors. Tiers: `:fast` scenarios run
+on every `run_all.rb`; `:full` scenarios join in with `--full` (run the full
+tier before merging anything that touches the export pipeline or timecode
+math). The registry lives in `qa_helpers.rb` (names + tiers); each scenario's
+definition lives in the generator's literal tables.
+
+| Scenario | Tier | Timeline | Covers |
+|---|---|---|---|
+| canonical-30 | fast | 30 fps 1280×720 | trims, mute, a held still, out-of-order sources |
+| ntsc-2997-df | full | 29.97 | drop-frame embedded timecode starting 2 frames before the 01:00:00 skip (qa_ntscD), NDF timecode at the same fractional rate (qa_ntscE), same source used twice |
+| film-23976 | full | 23.976 | embedded SMPTE start `21:44:10:09` (qa_filmF — the `base_timecode + in_point` anchoring with a non-zero base), a no-timecode source at a fractional rate, an in-point of 0 |
+
+The canonical cut (30 fps, 1280×720, 690 frames total):
+
+| # | Source          | Timeline frames | Source frames | Notes            |
+|---|-----------------|-----------------|---------------|------------------|
+| 1 | qa_clipB.mov    | 0–180           | 300–480       | green, double beeps |
+| 2 | qa_clipA.mov    | 180–300         | 60–180        | red, **muted**   |
+| 3 | qa_title_card.png | 300–450       | —             | yellow still, 5 s |
+| 4 | qa_clipC.mov    | 450–690         | 15–255        | blue, long beeps |
+
+These tables are illustrative snapshots — the generator's literal tables own
+the numbers. After a run, the generated `expected_<scenario>.json` and
+`expected_visuals.md` in the fixture library are canonical; if you extend the
+fixture, don't hand-sync these tables.
+
+How the embedded-timecode scenarios verify: ButterCut anchors each FCPXML clip
+at `asset start timecode + in-point`, while FCP's re-export carries FCP's
+*own* reading of the media's timecode in the asset's `start`. The FCP verifier
+subtracts the two, so a ButterCut base-timecode bug (wrong drop-frame
+subtraction, wrong rate) shows up as a source_in/source_out frame mismatch.
+The FCP7 XML legs check the file-relative `<in>/<out>` frames plus the
+separately-written `<timecode><frame>` base.
+
+## Tier 1 — deterministic run (no tokens, no eyeballs)
+
+From the repo root:
+
+```bash
+ruby qa/scripts/run_all.rb           # fast tier: the canonical scenario
+ruby qa/scripts/run_all.rb --full    # every scenario in the matrix
+```
+
+That regenerates the fixture (`libraries/qa-editor-roundtrip/`), exports every
+scenario in all three formats through the shipped CLI
+(`lib/buttercut/export.rb`, which also DTD-validates the FCPXML), then runs
+one verifier per installed editor per scenario and prints a PASS/FAIL matrix.
+Individual legs (no args = the canonical scenario; pass an export + expected
+pair for any other):
+
+```bash
+ruby qa/scripts/verify_resolve.rb    # DaVinci Resolve
+ruby qa/scripts/verify_fcp.rb        # Final Cut Pro
+ruby qa/scripts/verify_premiere.rb   # Premiere
+ruby qa/scripts/verify_fcp.rb \
+  libraries/qa-editor-roundtrip/cuts/ntsc-2997-df_fcpx.fcpxml \
+  libraries/qa-editor-roundtrip/expected_ntsc-2997-df.json
+```
+
+Each leg imports the export into a scratch project/library inside the real
+editor, extracts what the editor actually built, normalizes it, and compares
+against the scenario's `expected_<scenario>.json` with
+`qa/scripts/compare_timeline.rb` (exact frame equality). The normalized dump
+is written next to the exports as `cuts/qa-actual_<scenario>_<editor>.json`
+for debugging.
+
+Runtime note: legs currently run once per scenario, so `--full` costs roughly
+one FCP round trip (~30 s) plus one Resolve import plus one full Premiere
+launch (~60 s) per scenario. When the matrix grows past a handful of
+scenarios, batch per editor — one Premiere launch importing every XML into
+one scratch project, one Resolve menu click walking a job list — before
+adding more cuts.
+
+| Leg | Mechanism | Checks | Can't observe |
+|---|---|---|---|
+| Resolve | In-app Lua script (`Workspace > Scripts > ButterCut QA Dump`, auto-installed to `~/Library/…/Fusion/Scripts/Utility/`, menu-clicked via System Events). Works on the free edition, where external scripting is unavailable. Imports into a scratch `buttercut-qa-<epoch>` project; previous ones are deleted. | fps, resolution, total length, per-clip record/source frame ranges, media paths, still handling | mute (API doesn't expose levels) |
+| Final Cut Pro | UI-driven round trip via System Events: `open` the .fcpxml → in the "Open Library" dialog use **New…** (never the library list — deterministic destination) → creates `buttercut-qa-import.fcpbundle` under the fixture's `fcp/` dir → FCP auto-selects the imported event → File > Export XML… → parse FCP's own re-serialization. Import is confirmed on the filesystem (event folder inside the bundle), never by trusting the UI. The QA library is closed afterwards; other libraries are never touched. | everything Resolve checks **plus mute** (re-export preserves `adjust-volume -96dB`) | — |
+| Premiere | Launch-time ExtendScript: Premiere only executes scripts at startup (`<binary> /C es.processFile <jsx>`), so the runner launches its own instance with a generated script that builds a scratch project, imports the FCP7 XML, walks the sequence, writes tick-exact JSON, closes the project unsaved; the runner then force-quits that instance. Aborts if Premiere is already running. | fps, resolution, total length, per-clip record/source frame ranges, media paths, stills | mute (levels live in an audio filter ExtendScript doesn't read) |
+
+Prerequisites:
+
+- All three editors installed (missing ones are reported SKIP).
+- **Accessibility permission** for the process running the scripts (the
+  Resolve menu click and all FCP driving go through System Events). If a leg
+  aborts on a menu click, grant the terminal/agent in System Settings >
+  Privacy & Security > Accessibility.
+- **Premiere must be closed** before its leg (the runner refuses to kill a
+  running instance — it can't know what's unsaved).
+- FCP and Resolve may be open or closed; the runners launch them if needed.
+  Expect apps to steal focus while the suite runs — don't type over it.
+
+## Tier 2 — visual verification (agent eyes or human eyes)
+
+The structural tier proves the editors *agree with us about the metadata*.
+The visual tier proves the right pixels/waveforms are actually on the
+timeline — this is what catches "metadata consistent but wrong media" bugs,
+and it's the only way to check mute where the API hides it.
+
+Open the imported timeline in the editor (after a Tier 1 run: Resolve's
+`buttercut-qa-*` project, FCP's `buttercut-qa-import` library, or re-run the
+Premiere import by hand) and check it against
+`libraries/qa-editor-roundtrip/expected_visuals.md`, which maps every timeline
+second to what must be on screen: background color, giant clip letter, the
+burned-in `SRC hh:mm:ss.f F<frame>` ticker (must match the source trim
+frame-accurately), and the waveform pattern (one beep/s = A, double = B,
+long = C; the muted clip shows **no** waveform level; the still is silent).
+
+An agent with screenshot ability works through it position by position
+(park the playhead at each row's start/middle/end, compare viewer + timeline
+waveforms); a human can eyeball the whole thing in under a minute. This tier
+costs tokens/attention — use it when Tier 1 passes but you're chasing a
+content-level doubt, or as a pre-release once-over.
+
+## Edition notes (core vs Pro)
+
+The suite and fixture are identical in both editions — keep them byte-identical
+(see "minimize Pro divergence"; edit in core, pull into Pro). Today Pro's
+export output for a single-track cut must match core's, so both editions run
+the same checks. When Pro-only export features ship (multi-timeline etc.), add
+Pro-only cut fixtures + expected files here behind an
+`if ButterCut.pro?` branch in the generator — the comparator and per-editor
+plumbing already handle multiple tracks on the dump side (Resolve/Premiere
+dumps include every track).
+
+## Troubleshooting
+
+- **Resolve: "No report … check Resolve's console"** — open Workspace >
+  Console inside Resolve; the Lua script prints its failure there. Usually the
+  job file is stale or the XML path moved.
+- **Resolve: menu item missing** — the Scripts menu re-scans on open; if
+  "ButterCut QA Dump" isn't listed, the auto-install failed (check
+  `~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Utility/`).
+- **FCP: aborts at "Open Library" dialog** — FCP's import dialog changed, or
+  a modal (update prompt, etc.) was in the way. Run once by hand to see what's
+  on screen; the runner's AppleScript lives inline in `verify_fcp.rb`.
+- **FCP: "Expected sidebar selection …"** — FCP stopped auto-selecting the
+  imported event. Select the event named after the fixture's first clip
+  (`qa_clipB`) manually and re-run, then fix the runner.
+- **Premiere: no report after 5 minutes** — either a first-run dialog blocked
+  startup (launch Premiere once by hand, dismiss everything, quit) or the
+  launch-script flag is gone. `/C es.processFile` rides ExtendScript, which
+  Adobe supports **through ~September 2026**; after that this leg must move to
+  a UXP panel (no unattended loader exists yet: panels load via the UXP
+  Developer Tool GUI + Settings > Plugins > "Enable developer mode"). The
+  Premiere DOM equivalents are documented — `Project.createProject`,
+  `project.importFiles`, `VideoTrack.getTrackItems`, `fs.writeFile` — so the
+  jsx translates nearly 1:1 when the time comes.
+- **Anything driving keystrokes lands in the wrong place** — something stole
+  focus mid-run (notification, user typing). Re-run the leg; the runners are
+  idempotent.
+
+## Extending the fixture
+
+The full matrix design (11 scenarios: PAL 25, 59.94, every supported
+container, geometry/rotation, audio edges, mixed-rate conform, VFR) lives in
+`tmp/plans/Expand-editor-roundtrip-test-matrix-2026-07-09.md`. To add a
+scenario: add its name + tier to `QaHarness::SCENARIOS`, its definition to the
+generator's `SCENARIOS` table (and any new media to `MEDIA_SPECS`) — the
+run_all loop, verifiers, and comparator need no changes for same-rate cuts.
+
+Worthwhile near-term additions:
+
+- a **non-ASCII filename** (`Titel Kärte.png`-style) to exercise the
+  percent-encoding path — one unescaped character imports as offline media,
+- **captions**, if exports ever embed the cut's `dialogue` text — that would
+  also give Tier 2 a text-vs-burned-in-frame cross-check,
+- a **render-and-retranscribe** deep tier: render the imported timeline out of
+  the editor, then ffprobe/whisper the render and assert the beep pattern /
+  spoken content order — proves final pixels+audio without anyone watching.
+
+## File map
+
+```
+qa/
+  editor-roundtrip.md                     ← this runbook
+  scripts/
+    generate_qa_fixture.rb                ← fixture library + cut + expected files
+    run_all.rb                            ← fixture → exports → all verifiers
+    qa_helpers.rb                         ← shared paths, editor registry, leg plumbing
+    compare_timeline.rb                   ← shared comparator (exact frames)
+    verify_resolve.rb                     ← Resolve leg (drives the in-app script)
+    resolve/ButterCut QA Dump.lua         ← runs inside Resolve, dumps timeline JSON
+    verify_fcp.rb                         ← FCP leg (System Events + re-export parse)
+    verify_premiere.rb                    ← Premiere leg (launch-time ExtendScript)
+    premiere/buttercut_qa_dump.jsx.template ← runs inside Premiere at launch
+libraries/qa-editor-roundtrip/            ← generated fixture (gitignored)
+  media/ …                                ← synthetic self-identifying footage
+  cuts/<scenario>.yaml + exports (<scenario>_<editor>.xml/.fcpxml) + qa-actual_*.json
+  expected_<scenario>.json                ← ground truth (frames)
+  expected_visuals.md                     ← ground truth (eyes), all scenarios
+  fcp/ …                                  ← FCP QA library bundle + re-exports
+```

--- a/qa/scripts/compare_timeline.rb
+++ b/qa/scripts/compare_timeline.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# Compares an editor's actual imported timeline against the fixture's
+# expected_<scenario>.json. Both sides use the same normalized shape; each
+# editor's verify_* runner is responsible for producing the actual half:
+#
+#   {
+#     "timeline" => { "frame_rate" => 30, "width" => 1280, "height" => 720, "total_frames" => 690 },
+#     "clips"    => [ { "source" => "qa_clipB.mov", "type" => "video",
+#                       "record_in" => 0, "record_out" => 180,
+#                       "source_in" => 300, "source_out" => 480,   # video only
+#                       "mute" => false },                          # only when observable
+#                     ... ]
+#   }
+#
+# Frame comparisons are exact — the fixture is built frame-aligned on purpose.
+# A key missing from an actual clip is reported as skipped, not failed: not
+# every editor exposes every fact (e.g. Resolve's API doesn't expose mute).
+#
+# CLI: ruby qa/scripts/compare_timeline.rb <expected.json> <actual.json>
+
+require 'json'
+
+module QaCompare
+  TIMELINE_KEYS = %w[frame_rate width height total_frames].freeze
+  CLIP_KEYS = %w[source type record_in record_out source_in source_out mute].freeze
+
+  module_function
+
+  def compare(expected, actual)
+    failures = []
+    skipped = []
+    checked = 0
+    check = lambda do |label, want, got|
+      checked += 1
+      failures << "#{label}: expected #{want.inspect}, got #{got.inspect}" unless values_match?(want, got)
+    end
+
+    TIMELINE_KEYS.each do |key|
+      got = actual.dig('timeline', key)
+      next skipped << "timeline.#{key}" if got.nil?
+
+      check.call("timeline.#{key}", expected.dig('timeline', key), got)
+    end
+
+    want_clips = expected.fetch('clips')
+    got_clips  = actual.fetch('clips', [])
+    check.call('clip count', want_clips.length, got_clips.length)
+
+    want_clips.zip(got_clips).each_with_index do |(want, got), i|
+      label = "clip #{i + 1} (#{want['source']})"
+      next failures << "#{label}: missing from imported timeline" if got.nil?
+
+      CLIP_KEYS.each do |key|
+        next unless want.key?(key)
+        next skipped << "#{label}.#{key}" unless got.key?(key)
+
+        check.call("#{label}.#{key}", want[key], got[key])
+      end
+    end
+
+    { 'pass' => failures.empty?, 'checked' => checked, 'failures' => failures, 'skipped' => skipped.sort }
+  end
+
+  # Editors return numbers as strings ("30", "720") or floats (30.0); compare
+  # numerically when both sides look numeric, exactly otherwise.
+  def values_match?(want, got)
+    if numeric?(want) && numeric?(got)
+      Float(want) == Float(got)
+    else
+      want.to_s == got.to_s
+    end
+  end
+
+  def numeric?(value)
+    value.is_a?(Numeric) || (value.is_a?(String) && Float(value, exception: false))
+  end
+
+  def report(result, label:)
+    status = result['pass'] ? 'PASS' : 'FAIL'
+    lines = ["#{status}: #{label} — #{result['checked']} checks, #{result['failures'].length} failures"]
+    result['failures'].each { |f| lines << "  ✗ #{f}" }
+    lines << "  (not observable in this editor: #{result['skipped'].join(', ')})" unless result['skipped'].empty?
+    lines.join("\n")
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  expected_path, actual_path = ARGV
+  abort 'Usage: ruby qa/scripts/compare_timeline.rb <expected.json> <actual.json>' unless expected_path && actual_path
+
+  result = QaCompare.compare(JSON.parse(File.read(expected_path)), JSON.parse(File.read(actual_path)))
+  puts QaCompare.report(result, label: "#{File.basename(actual_path)} vs #{File.basename(expected_path)}")
+  exit(result['pass'] ? 0 : 1)
+end

--- a/qa/scripts/generate_qa_fixture.rb
+++ b/qa/scripts/generate_qa_fixture.rb
@@ -1,0 +1,287 @@
+# frozen_string_literal: true
+
+# Generates the editor round-trip QA fixture: a throwaway library
+# (libraries/qa-editor-roundtrip/) holding synthetic, self-identifying footage,
+# one cut per scenario, and the ground-truth files the verifiers compare
+# against.
+#
+# The media identifies itself frame-by-frame — that's the whole trick. Each
+# video burns its clip letter, source timecode, and source frame number into
+# every frame, over a solid color unique to the clip, with a per-second beep
+# pattern unique to the clip (so waveforms are tellable apart on sight). A
+# timeline position can therefore be verified against what the editor actually
+# shows, not against metadata that could be wrong in the same way twice.
+#
+# Everything derives from the literal tables below (MEDIA_SPECS, SCENARIOS).
+# Trims are written in FRAMES — the native unit — and every expected-timeline
+# number is computed here with plain integer/rational arithmetic, deliberately
+# NOT with lib/buttercut's timecode math, so an exporter bug can't cancel
+# itself out in the expectation.
+#
+# Usage (from the repo root, either edition):
+#   ruby qa/scripts/generate_qa_fixture.rb
+#
+# Idempotent: an existing qa-editor-roundtrip library is deleted and rebuilt
+# (only when its sentinel file proves we generated it).
+
+require 'fileutils'
+require 'json'
+require 'yaml'
+require_relative 'qa_helpers'
+require_relative '../../lib/buttercut/media_tools'
+
+LIBRARY_DIR = QaHarness::FIXTURE_DIR
+MEDIA_DIR   = File.join(LIBRARY_DIR, 'media')
+SENTINEL    = File.join(LIBRARY_DIR, '.generated-by-buttercut-qa')
+FONT        = File.expand_path('../../lib/buttercut/Arimo-Regular.ttf', __dir__)
+
+CLIP_SECONDS = 24
+SIZE = { width: 1280, height: 720 }.freeze
+
+# The per-second beep signatures (aevalsrc gate expressions on mod(t,1)) —
+# the audible/visible-in-waveform fingerprint each clip reuses with its own
+# frequency.
+ONE_SHORT = ['lt(mod(t,1),0.12)', 'one short beep per second'].freeze
+TWO_SHORT = ['(lt(mod(t,1),0.08)+gt(mod(t,1),0.2)*lt(mod(t,1),0.28))', 'two short beeps per second'].freeze
+ONE_LONG  = ['lt(mod(t,1),0.4)', 'one long beep per second'].freeze
+
+# One entry per synthetic source file. `rate` is the exact frame rate the
+# clip is encoded at; `timecode` (optional) is burned into the container as
+# the SMPTE start timecode — a ";" separator marks drop-frame numbering.
+MEDIA_SPECS = {
+  'qa_clipA.mov' => { color: 'red',     letter: 'A', freq: 440, beep: ONE_SHORT, rate: '30/1' },
+  'qa_clipB.mov' => { color: 'green',   letter: 'B', freq: 660, beep: TWO_SHORT, rate: '30/1' },
+  'qa_clipC.mov' => { color: 'blue',    letter: 'C', freq: 880, beep: ONE_LONG,  rate: '30/1' },
+  # NTSC 29.97: D's drop-frame timecode starts 2 frames before the 01:00:00
+  # skip boundary, so its digits cross a drop; E is NDF at the same rate.
+  'qa_ntscD.mov' => { color: 'purple',  letter: 'D', freq: 520, beep: ONE_SHORT, rate: '30000/1001', timecode: '00:59:59;28' },
+  'qa_ntscE.mov' => { color: 'teal',    letter: 'E', freq: 700, beep: TWO_SHORT, rate: '30000/1001', timecode: '01:00:00:00' },
+  # 23.976 film rate: F carries an embedded SMPTE start (the real-world value
+  # from spec/fixtures/media/P1044376_timecode_fixture.mov); G has none, so
+  # the zero-base path runs at a fractional rate too.
+  'qa_filmF.mov' => { color: 'orange',  letter: 'F', freq: 480, beep: ONE_LONG,  rate: '24000/1001', timecode: '21:44:10:09' },
+  'qa_filmG.mov' => { color: 'magenta', letter: 'G', freq: 760, beep: ONE_SHORT, rate: '24000/1001' }
+}.freeze
+TITLE_CARD = 'qa_title_card.png'
+TITLE_CARD_SPEC = { color: 'yellow', text: 'TITLE CARD' }.freeze
+
+# The scenario cuts, in timeline order. Video trims are `in:`/`out:` in
+# SOURCE FRAMES; stills use `frames:` at the timeline rate. Every scenario
+# currently uses sources at the timeline's own rate (mixed-rate conform is a
+# future scenario with its own expected-behavior decision).
+SCENARIOS = {
+  'canonical-30' => {
+    rate: '30/1',
+    clips: [
+      { source: 'qa_clipB.mov', in: 300, out: 480 },
+      { source: 'qa_clipA.mov', in: 60,  out: 180, mute: true },
+      { source: TITLE_CARD,     frames: 150 },
+      { source: 'qa_clipC.mov', in: 15,  out: 255 }
+    ]
+  },
+  'ntsc-2997-df' => {
+    rate: '30000/1001',
+    clips: [
+      { source: 'qa_ntscD.mov', in: 30,  out: 210 },
+      { source: 'qa_ntscE.mov', in: 120, out: 300, mute: true },
+      { source: 'qa_ntscD.mov', in: 450, out: 600 }
+    ]
+  },
+  'film-23976' => {
+    rate: '24000/1001',
+    clips: [
+      { source: 'qa_filmF.mov', in: 48,  out: 240 },
+      { source: 'qa_filmG.mov', in: 0,   out: 120 },
+      { source: 'qa_filmF.mov', in: 360, out: 480 }
+    ]
+  }
+}.freeze
+
+unless SCENARIOS.keys.sort == QaHarness::SCENARIOS.keys.sort
+  abort "SCENARIOS here (#{SCENARIOS.keys.sort.join(', ')}) must match QaHarness::SCENARIOS " \
+        "(#{QaHarness::SCENARIOS.keys.sort.join(', ')})"
+end
+
+def rate_rational(rate) = Rational(*rate.split('/').map(&:to_i))
+
+def frames_to_seconds(frames, rate) = frames / rate_rational(rate)
+
+def hms(seconds)
+  whole = seconds.to_i
+  format('%02d:%02d:%09.6f', whole / 3600, (whole % 3600) / 60, (seconds % 60).to_f)
+end
+
+def run!(*cmd)
+  puts "  $ #{cmd.join(' ')[0, 160]}"
+  system(*cmd, exception: true)
+end
+
+# A scenario's clips enriched with frame counts and timeline positions,
+# computed once (plain arithmetic — see header) and shared by the cut,
+# expected-timeline, and expected-visuals sections below.
+def clip_rows(scenario)
+  cursor = 0
+  scenario[:clips].map do |clip|
+    unless clip[:frames] # video
+      spec = MEDIA_SPECS.fetch(clip[:source])
+      unless spec[:rate] == scenario[:rate]
+        abort "#{clip[:source]} is #{spec[:rate]} on a #{scenario[:rate]} timeline — " \
+              'same-rate sources only until the mixed-rate scenario lands'
+      end
+    end
+    frames = clip[:frames] || (clip[:out] - clip[:in])
+    row = clip.merge(frame_count: frames, record_in: cursor, record_out: cursor + frames)
+    cursor += frames
+    row
+  end
+end
+
+# ---------- 1. reset the fixture library ----------
+if File.exist?(LIBRARY_DIR)
+  unless File.exist?(SENTINEL)
+    abort "Refusing to delete #{LIBRARY_DIR}: no #{File.basename(SENTINEL)} sentinel. " \
+          'If this library is yours, remove it manually and re-run.'
+  end
+  FileUtils.rm_rf(LIBRARY_DIR)
+end
+
+puts "Creating library #{QaHarness::LIBRARY_NAME}..."
+Library.create(QaHarness::LIBRARY_NAME, language: 'en', editor: 'fcpx', transcript_refinement: false, media_paths: [])
+FileUtils.mkdir_p(MEDIA_DIR)
+File.write(SENTINEL, "Generated by qa/scripts/generate_qa_fixture.rb — safe to delete.\n")
+
+# ---------- 2. synthesize self-identifying media ----------
+abort "Font not found at #{FONT}" unless File.exist?(FONT)
+
+MEDIA_SPECS.each do |filename, spec|
+  beep_expr, beep_desc = spec[:beep]
+  puts "Generating #{filename} (#{spec[:color]}, '#{spec[:letter]}', #{spec[:rate]}#{spec[:timecode] ? ", tc #{spec[:timecode]}" : ''}, #{beep_desc})..."
+  big    = "drawtext=fontfile=#{FONT}:text='#{spec[:letter]}':fontsize=360:fontcolor=white@0.9:" \
+           'x=(w-tw)/2:y=(h-th)/2-60'
+  ticker = "drawtext=fontfile=#{FONT}:text='#{spec[:letter]} SRC %{pts\\:hms} F%{n}':fontsize=56:fontcolor=white:" \
+           'x=(w-tw)/2:y=h-th-32:box=1:boxcolor=black@0.65:boxborderw=12'
+  audio  = "aevalsrc=exprs='sin(2*PI*#{spec[:freq]}*t)*0.6*#{beep_expr}':sample_rate=48000:duration=#{CLIP_SECONDS}"
+  timecode_args = spec[:timecode] ? ['-timecode', spec[:timecode]] : []
+
+  run!(MediaTools.ffmpeg, '-y', '-loglevel', 'error',
+       '-f', 'lavfi', '-i', "color=c=#{spec[:color]}:size=#{SIZE[:width]}x#{SIZE[:height]}:rate=#{spec[:rate]}:duration=#{CLIP_SECONDS}",
+       '-f', 'lavfi', '-i', audio,
+       '-vf', "#{big},#{ticker}",
+       '-af', 'pan=stereo|c0=c0|c1=c0',
+       '-c:v', 'libx264', '-preset', 'ultrafast', '-pix_fmt', 'yuv420p', '-crf', '18',
+       *timecode_args,
+       '-c:a', 'pcm_s16le', '-shortest', File.join(MEDIA_DIR, filename))
+end
+
+puts "Generating #{TITLE_CARD} (#{TITLE_CARD_SPEC[:color]} still)..."
+run!(MediaTools.ffmpeg, '-y', '-loglevel', 'error',
+     '-f', 'lavfi', '-i', "color=c=#{TITLE_CARD_SPEC[:color]}:size=#{SIZE[:width]}x#{SIZE[:height]}",
+     '-vf', "drawtext=fontfile=#{FONT}:text='#{TITLE_CARD_SPEC[:text]}':fontsize=140:fontcolor=black:x=(w-tw)/2:y=(h-th)/2",
+     '-frames:v', '1', File.join(MEDIA_DIR, TITLE_CARD))
+
+library = Library.find(QaHarness::LIBRARY_NAME)
+library.add_media((MEDIA_SPECS.keys + [TITLE_CARD]).map { |f| File.join(MEDIA_DIR, f) })
+
+# ---------- 3. per-scenario cut, expected timeline, expected visuals ----------
+visuals = +<<~HEADER
+  # Expected visuals — #{QaHarness::LIBRARY_NAME}
+
+  What a correctly imported timeline shows at each position. `SRC` is the
+  burned-in media-relative ticker (`F<n>` = source frame number); it must match
+  the source trim frame-accurately regardless of any embedded start timecode.
+HEADER
+
+SCENARIOS.each do |name, scenario|
+  rate = scenario[:rate]
+  rational = rate_rational(rate)
+  rows = clip_rows(scenario)
+  total_frames = rows.last[:record_out]
+  rate_value = QaHarness.fps_value(rational)
+
+  cut_clips = rows.map do |row|
+    if row[:frames] # still image
+      { 'source_file' => row[:source], 'duration' => hms(frames_to_seconds(row[:frames], rate)),
+        'dialogue' => '',
+        'visual_description' => "[#{TITLE_CARD_SPEC[:color].capitalize} title card reading #{TITLE_CARD_SPEC[:text]}]" }
+    else
+      spec = MEDIA_SPECS.fetch(row[:source])
+      entry = { 'source_file' => row[:source],
+                'in_point' => hms(frames_to_seconds(row[:in], rate)),
+                'out_point' => hms(frames_to_seconds(row[:out], rate)),
+                'dialogue' => '',
+                'visual_description' => "[Solid #{spec[:color]} frame, giant letter #{spec[:letter]}, " \
+                                        'source timecode/frame ticker along the bottom]' }
+      entry['mute'] = true if row[:mute]
+      entry
+    end
+  end
+
+  cut = {
+    'description' => "QA editor round-trip scenario #{name} — see qa/editor-roundtrip.md",
+    # the cut carries the exact rate string ("30000/1001") for fractional
+    # rates; expected JSON carries the decimal editors report back
+    'timeline' => { 'frame_rate' => rational.denominator == 1 ? rational.to_i : rate,
+                    'width' => SIZE[:width], 'height' => SIZE[:height] },
+    'clips' => cut_clips,
+    'metadata' => { 'created_date' => Time.now.strftime('%Y-%m-%d %H:%M:%S'),
+                    'total_duration' => hms(frames_to_seconds(total_frames, rate)) }
+  }
+  File.write(QaHarness.cut_yaml(name), cut.to_yaml)
+
+  expected_clips = rows.each_with_index.map do |row, i|
+    entry = {
+      'n' => i + 1,
+      'source' => row[:source],
+      'type' => row[:frames] ? 'image' : 'video',
+      'record_in' => row[:record_in],
+      'record_out' => row[:record_out],
+      'mute' => !!row[:mute]
+    }
+    unless row[:frames]
+      entry['source_in']  = row[:in]
+      entry['source_out'] = row[:out]
+    end
+    entry
+  end
+
+  expected = {
+    'fixture' => QaHarness::LIBRARY_NAME,
+    'scenario' => name,
+    'generated_at' => Time.now.strftime('%Y-%m-%dT%H:%M:%S'),
+    'timeline' => { 'frame_rate' => rate_value, 'width' => SIZE[:width], 'height' => SIZE[:height],
+                    'total_frames' => total_frames },
+    'media_dir' => MEDIA_DIR,
+    'clips' => expected_clips
+  }
+  File.write(QaHarness.expected_json(name), JSON.pretty_generate(expected) + "\n")
+
+  visuals << "\n## #{name} (#{rate_value} fps, #{total_frames} frames)\n\n"
+  visuals << "| Timeline frames | Clip | Screen | SRC ticker frames | Audio / waveform |\n"
+  visuals << "|---|---|---|---|---|\n"
+  rows.each do |row|
+    row_range = "#{row[:record_in]}–#{row[:record_out]}"
+    if row[:frames]
+      visuals << "| #{row_range} | #{row[:source]} | #{TITLE_CARD_SPEC[:color]} #{TITLE_CARD_SPEC[:text]} | — | silence |\n"
+    else
+      spec = MEDIA_SPECS.fetch(row[:source])
+      _, beep_desc = spec[:beep]
+      audio = row[:mute] ? "MUTED — flat/no waveform (source had #{beep_desc})" : "#{beep_desc} (#{spec[:freq]} Hz)"
+      visuals << "| #{row_range} | #{row[:source]} | solid #{spec[:color]}, giant #{spec[:letter]} | F#{row[:in]} → F#{row[:out]} | #{audio} |\n"
+    end
+  end
+end
+
+File.write(File.join(LIBRARY_DIR, 'expected_visuals.md'), visuals)
+
+puts <<~DONE
+
+  ✓ Fixture ready.
+    Library:   #{LIBRARY_DIR}
+    Scenarios: #{SCENARIOS.keys.join(', ')}
+    Cuts:      #{QaHarness::CUTS_DIR}/<scenario>.yaml
+    Expected:  #{LIBRARY_DIR}/expected_<scenario>.json
+
+  Run the suite (from the repo root):
+    ruby qa/scripts/run_all.rb            # fast tier (canonical scenario)
+    ruby qa/scripts/run_all.rb --full     # every scenario
+DONE

--- a/qa/scripts/premiere/buttercut_qa_dump.jsx.template
+++ b/qa/scripts/premiere/buttercut_qa_dump.jsx.template
@@ -1,0 +1,121 @@
+// ButterCut QA Dump (Premiere) — ExtendScript, executed at app launch via:
+//   ".../Adobe Premiere Pro 2026" /C es.processFile <this file>
+// verify_premiere.rb copies this template to /tmp with the placeholders filled
+// in, launches Premiere with it, and polls for the report file.
+//
+// ExtendScript is ES3: no JSON object, hand-rolled serializer below. Times are
+// reported as tick strings (254,016,000,000 ticks/second) so the Ruby side can
+// do exact integer frame math instead of trusting float seconds.
+
+var XML_PATH = "__XML_PATH__";
+var REPORT_PATH = "__REPORT_PATH__";
+var PROJECT_PATH = "__PROJECT_PATH__";
+
+function esc(s) {
+  s = String(s);
+  var out = "";
+  for (var i = 0; i < s.length; i++) {
+    var c = s.charAt(i);
+    var code = s.charCodeAt(i);
+    if (c === '"') out += '\\"';
+    else if (c === "\\") out += "\\\\";
+    else if (c === "\n") out += "\\n";
+    else if (c === "\r") out += "\\r";
+    else if (c === "\t") out += "\\t";
+    else if (code < 32) out += "\\u" + ("000" + code.toString(16)).slice(-4);
+    else out += c;
+  }
+  return out;
+}
+
+function toJson(v) {
+  if (v === null || v === undefined) return "null";
+  var t = typeof v;
+  if (t === "number") return isFinite(v) ? String(v) : "null";
+  if (t === "boolean") return String(v);
+  if (t === "string") return '"' + esc(v) + '"';
+  if (v instanceof Array) {
+    var parts = [];
+    for (var i = 0; i < v.length; i++) parts.push(toJson(v[i]));
+    return "[" + parts.join(",") + "]";
+  }
+  var kv = [];
+  for (var k in v) if (v.hasOwnProperty(k)) kv.push('"' + esc(k) + '":' + toJson(v[k]));
+  return "{" + kv.join(",") + "}";
+}
+
+var report = { ok: false, stage: "start", script: "buttercut_qa_dump.jsx" };
+
+// Written to a temp file then renamed, so the Ruby poller never reads a
+// half-written report. (The runner deletes both paths before launch.)
+function save() {
+  var f = new File(REPORT_PATH + ".tmp");
+  f.encoding = "UTF-8";
+  f.open("w");
+  f.write(toJson(report));
+  f.close();
+  f.rename(new File(REPORT_PATH).name);
+}
+
+function dumpTracks(trackCollection) {
+  var tracks = [];
+  for (var t = 0; t < trackCollection.numTracks; t++) {
+    var track = trackCollection[t];
+    var items = [];
+    for (var c = 0; c < track.clips.numItems; c++) {
+      var k = track.clips[c];
+      var entry = {
+        name: k.name,
+        start_ticks: k.start.ticks,
+        end_ticks: k.end.ticks,
+        in_ticks: k.inPoint.ticks,
+        out_ticks: k.outPoint.ticks,
+        disabled: k.disabled ? true : false
+      };
+      try { entry.media_path = k.projectItem ? k.projectItem.getMediaPath() : null; } catch (e1) { entry.media_path = null; }
+      items.push(entry);
+    }
+    tracks.push({ index: t + 1, name: track.name, items: items });
+  }
+  return tracks;
+}
+
+try {
+  report.app_version = app.version;
+
+  // At launch there may be no open project; create a scratch one.
+  if (!app.project || !app.project.rootItem) {
+    report.stage = "newProject";
+    app.enableQE();
+    qe.newProject(PROJECT_PATH);
+  }
+  report.project_name = app.project.name;
+
+  report.stage = "import";
+  var ok = app.project.importFiles([XML_PATH], 1, app.project.rootItem, 0);
+  report.import_returned = ok ? true : false;
+
+  report.stage = "walk";
+  report.num_sequences = app.project.sequences.numSequences;
+  if (report.num_sequences < 1) throw new Error("no sequences after xmeml import");
+  var seq = app.project.sequences[0];
+  report.sequence = {
+    name: seq.name,
+    timebase_ticks_per_frame: String(seq.timebase),
+    width: seq.frameSizeHorizontal,
+    height: seq.frameSizeVertical,
+    end_ticks: String(seq.end)
+  };
+  report.video_tracks = dumpTracks(seq.videoTracks);
+  report.audio_tracks = dumpTracks(seq.audioTracks);
+
+  report.ok = true;
+  report.stage = "done";
+} catch (err) {
+  report.error = String(err);
+}
+
+save();
+
+// Close without saving so killing the app afterwards leaves no recovery state.
+try { app.project.closeDocument(0, 0); } catch (e2) {}

--- a/qa/scripts/qa_helpers.rb
+++ b/qa/scripts/qa_helpers.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+# Shared plumbing for the editor round-trip QA harness: the fixture's
+# canonical paths, the scenario and editor registries, and the small helpers
+# every verifier leg would otherwise copy-paste (arg parsing, condition
+# polling, osascript, and the write-dump/compare/report/exit tail).
+# Editor-specific driving stays in the verify_* scripts.
+
+require 'json'
+require 'open3'
+require_relative 'compare_timeline'
+require_relative '../../lib/buttercut/library'
+
+module QaHarness
+  REPO_ROOT    = File.expand_path('../..', __dir__)
+  LIBRARY_NAME = 'qa-editor-roundtrip'
+  FIXTURE_DIR  = File.join(Library::LIBRARIES_ROOT, LIBRARY_NAME)
+  CUTS_DIR     = File.join(FIXTURE_DIR, 'cuts')
+
+  # Every scenario cut, tagged by tier. :fast runs on every `run_all.rb`;
+  # :full scenarios join in with --full. The generator owns each scenario's
+  # actual definition (clips, media, expected math) under the same names.
+  SCENARIOS = {
+    'canonical-30' => :fast,
+    'ntsc-2997-df' => :full,
+    'film-23976'   => :full
+  }.freeze
+  DEFAULT_SCENARIO = 'canonical-30'
+
+  # One row per editor leg, in the order the legs run. Premiere is never
+  # pre-warmed: its leg must launch its own instance.
+  EDITORS = {
+    'resolve'  => { name: 'DaVinci Resolve', ext: '.xml',
+                    app: '/Applications/DaVinci Resolve/DaVinci Resolve.app',
+                    verifier: 'qa/scripts/verify_resolve.rb', prewarm: true },
+    'fcpx'     => { name: 'Final Cut Pro', ext: '.fcpxml',
+                    app: '/Applications/Final Cut Pro.app',
+                    verifier: 'qa/scripts/verify_fcp.rb', prewarm: true },
+    'premiere' => { name: 'Premiere', ext: '.xml',
+                    app: Dir.glob('/Applications/Adobe Premiere*/Adobe Premiere*.app').first,
+                    verifier: 'qa/scripts/verify_premiere.rb', prewarm: false }
+  }.freeze
+
+  module_function
+
+  def scenario_names(full: false)
+    full ? SCENARIOS.keys : SCENARIOS.filter_map { |name, tier| name if tier == :fast }
+  end
+
+  # 30 for whole rates, 29.97/23.976-style rounded decimals for NTSC — the one
+  # frame-rate normalization the generator and every verifier leg must share,
+  # because the comparison is exact.
+  def fps_value(fps) = fps.denominator == 1 ? fps.to_i : fps.to_f.round(3)
+
+  def cut_yaml(scenario) = File.join(CUTS_DIR, "#{scenario}.yaml")
+
+  def expected_json(scenario) = File.join(FIXTURE_DIR, "expected_#{scenario}.json")
+
+  def export_path(editor_key, scenario)
+    File.join(CUTS_DIR, "#{scenario}_#{editor_key}#{EDITORS.fetch(editor_key)[:ext]}")
+  end
+
+  def premiere_binary
+    app = EDITORS.dig('premiere', :app)
+    app && Dir.glob(File.join(app, 'Contents/MacOS/Adobe Premiere*')).first
+  end
+
+  def verify_args(editor_key)
+    xml_path      = File.expand_path(ARGV[0] || export_path(editor_key, DEFAULT_SCENARIO))
+    expected_path = File.expand_path(ARGV[1] || expected_json(DEFAULT_SCENARIO))
+    abort "No exported XML at #{xml_path} — run generate_qa_fixture.rb and export first" unless File.exist?(xml_path)
+    abort "No expected timeline at #{expected_path} — run generate_qa_fixture.rb first" unless File.exist?(expected_path)
+
+    [xml_path, expected_path]
+  end
+
+  def wait_until(tries:, interval: 1)
+    tries.times do
+      return true if yield
+
+      sleep interval
+    end
+    false
+  end
+
+  def run_osascript(body)
+    out, _err, status = Open3.capture3('osascript', '-', stdin_data: body)
+    [out.strip, status.success?]
+  end
+
+  def osascript(body)
+    out, ok = run_osascript(body)
+    abort "osascript failed: #{out}" unless ok
+
+    out
+  end
+
+  def osascript_true?(body) = run_osascript(body) == ['true', true]
+
+  # Launch `app_name` if `process` isn't running, then poll the AppleScript
+  # `ready_probe` (must return a boolean) until the app is driveable.
+  def ensure_app_ready(process:, app_name:, ready_probe:)
+    unless system('pgrep', '-xq', process)
+      puts "Launching #{app_name}..."
+      system('open', '-a', app_name) || abort("could not launch #{app_name}")
+    end
+    ready = wait_until(tries: 90, interval: 2) { osascript_true?(ready_probe) }
+    abort "#{app_name} never became ready after 3 minutes" unless ready
+  end
+
+  # The shared leg tail: dump goes next to the export (whose name already
+  # carries the scenario and editor), compare, report, exit 0/1.
+  def finish!(actual, xml_path:, expected_path:, label:)
+    actual_path = File.join(File.dirname(xml_path), "qa-actual_#{File.basename(xml_path, '.*')}.json")
+    File.write(actual_path, JSON.pretty_generate(actual) + "\n")
+
+    result = QaCompare.compare(JSON.parse(File.read(expected_path)), actual)
+    puts QaCompare.report(result, label: label)
+    puts "  actual: #{actual_path}"
+    exit(result['pass'] ? 0 : 1)
+  end
+end

--- a/qa/scripts/resolve/ButterCut QA Dump.lua
+++ b/qa/scripts/resolve/ButterCut QA Dump.lua
@@ -1,0 +1,176 @@
+-- ButterCut QA Dump
+-- Imports a ButterCut-exported timeline (FCPXML or FCP7 XML) into a scratch
+-- project and dumps what Resolve actually built as JSON, for the ButterCut
+-- editor round-trip QA harness (qa/editor-roundtrip.md in the ButterCut repo).
+--
+-- Runs INSIDE Resolve (Workspace > Scripts > ButterCut QA Dump) so it works on
+-- both the free edition and Studio, regardless of the external-scripting pref.
+--
+-- Contract:
+--   reads  /tmp/buttercut_qa_resolve_job.lua   -- written by the harness:
+--            return { xml_path = "/abs/path.xml", report_path = "/abs/report.json" }
+--   writes report_path (JSON) -- always, even on failure (ok=false + error)
+--
+-- Scratch projects are named buttercut-qa-<epoch>; previous buttercut-qa-*
+-- projects are deleted on each run. No other projects are ever touched.
+
+local JOB_PATH = "/tmp/buttercut_qa_resolve_job.lua"
+local FALLBACK_REPORT = "/tmp/buttercut_qa_resolve_report.json"
+
+-- ---------- tiny JSON emitter ----------
+local function json_escape(s)
+  s = s:gsub("\\", "\\\\"):gsub('"', '\\"'):gsub("\n", "\\n"):gsub("\r", "\\r"):gsub("\t", "\\t")
+  s = s:gsub("%c", function(c) return string.format("\\u%04x", c:byte()) end)
+  return s
+end
+
+local function to_json(v, indent)
+  indent = indent or ""
+  local t = type(v)
+  if v == nil then return "null" end
+  if t == "number" then
+    if v ~= v or v == math.huge or v == -math.huge then return "null" end
+    if v == math.floor(v) and math.abs(v) < 2^52 then return string.format("%d", v) end
+    return string.format("%.6f", v)
+  end
+  if t == "boolean" then return tostring(v) end
+  if t == "string" then return '"' .. json_escape(v) .. '"' end
+  if t == "table" then
+    local next_indent = indent .. "  "
+    if #v > 0 or next(v) == nil then -- array (or empty)
+      local parts = {}
+      for _, item in ipairs(v) do parts[#parts + 1] = next_indent .. to_json(item, next_indent) end
+      if #parts == 0 then return "[]" end
+      return "[\n" .. table.concat(parts, ",\n") .. "\n" .. indent .. "]"
+    end
+    local keys = {}
+    for k in pairs(v) do keys[#keys + 1] = k end
+    table.sort(keys)
+    local parts = {}
+    for _, k in ipairs(keys) do
+      parts[#parts + 1] = next_indent .. '"' .. json_escape(tostring(k)) .. '": ' .. to_json(v[k], next_indent)
+    end
+    return "{\n" .. table.concat(parts, ",\n") .. "\n" .. indent .. "}"
+  end
+  return '"' .. json_escape(tostring(v)) .. '"'
+end
+
+-- Written to a temp file then renamed, so the harness's existence poll never
+-- reads a half-written report.
+local function write_report(path, report)
+  local tmp = path .. ".tmp"
+  local f = io.open(tmp, "w")
+  if not f then return false end
+  f:write(to_json(report), "\n")
+  f:close()
+  return os.rename(tmp, path) == true
+end
+
+-- ---------- safe getters ----------
+local function safe(fn)
+  local ok, result = pcall(fn)
+  if ok then return result end
+  return nil
+end
+
+-- ---------- main ----------
+local report = { ok = false, script = "ButterCut QA Dump", ran_at = os.date("%Y-%m-%dT%H:%M:%S") }
+local report_path = FALLBACK_REPORT
+
+local function fail(msg)
+  report.ok = false
+  report.error = msg
+  write_report(report_path, report)
+  print("ButterCut QA Dump FAILED: " .. msg)
+end
+
+local job_chunk = loadfile(JOB_PATH)
+if not job_chunk then return fail("no job file at " .. JOB_PATH) end
+local job = job_chunk()
+if type(job) ~= "table" or not job.xml_path then return fail("job file malformed (need xml_path)") end
+report_path = job.report_path or FALLBACK_REPORT
+report.job = { xml_path = job.xml_path, report_path = report_path }
+
+local rv = resolve or (bmd and bmd.scriptapp("Resolve"))
+if not rv then return fail("no resolve object (run from Workspace > Scripts inside DaVinci Resolve)") end
+
+report.product = safe(function() return rv:GetProductName() end)
+report.resolve_version = safe(function() return rv:GetVersionString() end)
+
+local pm = rv:GetProjectManager()
+if not pm then return fail("GetProjectManager returned nil") end
+
+-- clean up previous QA scratch projects (only ours: buttercut-qa-*)
+local deleted = {}
+local existing = safe(function() return pm:GetProjectListInCurrentFolder() end) or {}
+for _, name in ipairs(existing) do
+  if type(name) == "string" and name:find("^buttercut%-qa%-") then
+    if safe(function() return pm:DeleteProject(name) end) then deleted[#deleted + 1] = name end
+  end
+end
+report.deleted_previous_qa_projects = deleted
+
+local project_name = "buttercut-qa-" .. tostring(os.time())
+local project = pm:CreateProject(project_name)
+if not project then return fail("CreateProject failed for " .. project_name) end
+report.project = project_name
+
+local mp = project:GetMediaPool()
+if not mp then return fail("GetMediaPool returned nil") end
+
+local timeline = mp:ImportTimelineFromFile(job.xml_path, {
+  timelineName = job.timeline_name or "buttercut-qa-timeline",
+  importSourceClips = true,
+})
+if not timeline then return fail("ImportTimelineFromFile returned nil for " .. job.xml_path) end
+
+report.timeline = {
+  name = safe(function() return timeline:GetName() end),
+  start_frame = safe(function() return timeline:GetStartFrame() end),
+  end_frame = safe(function() return timeline:GetEndFrame() end),
+  start_timecode = safe(function() return timeline:GetStartTimecode() end),
+  frame_rate = safe(function() return timeline:GetSetting("timelineFrameRate") end),
+  width = safe(function() return timeline:GetSetting("timelineResolutionWidth") end),
+  height = safe(function() return timeline:GetSetting("timelineResolutionHeight") end),
+}
+
+local function dump_track_items(track_type)
+  local tracks = {}
+  local count = safe(function() return timeline:GetTrackCount(track_type) end) or 0
+  for ti = 1, count do
+    local items = safe(function() return timeline:GetItemListInTrack(track_type, ti) end) or {}
+    local dumped = {}
+    for _, item in ipairs(items) do
+      local entry = {
+        name = safe(function() return item:GetName() end),
+        start = safe(function() return item:GetStart() end),
+        ["end"] = safe(function() return item:GetEnd() end),
+        duration = safe(function() return item:GetDuration() end),
+        source_start_frame = safe(function() return item:GetSourceStartFrame() end),
+        source_end_frame = safe(function() return item:GetSourceEndFrame() end),
+        left_offset = safe(function() return item:GetLeftOffset() end),
+      }
+      local mpi = safe(function() return item:GetMediaPoolItem() end)
+      if mpi then
+        entry.media_path = safe(function() return mpi:GetClipProperty("File Path") end)
+        entry.media_fps = safe(function() return mpi:GetClipProperty("FPS") end)
+        entry.media_type = safe(function() return mpi:GetClipProperty("Type") end)
+        entry.media_duration = safe(function() return mpi:GetClipProperty("Duration") end)
+      end
+      dumped[#dumped + 1] = entry
+    end
+    tracks[#tracks + 1] = { index = ti, name = safe(function() return timeline:GetTrackName(track_type, ti) end), items = dumped }
+  end
+  return tracks
+end
+
+report.video_tracks = dump_track_items("video")
+report.audio_tracks = dump_track_items("audio")
+report.subtitle_tracks = dump_track_items("subtitle")
+
+report.ok = true
+if not write_report(report_path, report) then
+  print("ButterCut QA Dump: could not write report to " .. report_path)
+else
+  print("ButterCut QA Dump: OK -> " .. report_path)
+end

--- a/qa/scripts/run_all.rb
+++ b/qa/scripts/run_all.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Runs the editor round-trip suite: fixture → exports → one verifier per
+# installed editor per scenario. This is the deterministic tier of
+# qa/editor-roundtrip.md — read that runbook for prerequisites, the visual
+# tier, and troubleshooting.
+#
+# Usage (from the repo root):
+#   ruby qa/scripts/run_all.rb [--full] [--skip-generate]
+#
+# Default runs the :fast scenarios (the canonical cut, <30s per editor);
+# --full adds every matrix scenario (frame rates, embedded timecode, …).
+# Runs every applicable leg even when an earlier one fails; exits non-zero if
+# any leg failed. Legs whose editor isn't installed are reported as SKIP.
+
+require_relative 'qa_helpers'
+require_relative '../../lib/buttercut/version'
+
+def run(desc, *cmd)
+  puts "\n=== #{desc}\n"
+  system(*cmd)
+end
+
+Dir.chdir(QaHarness::REPO_ROOT)
+
+scenarios = QaHarness.scenario_names(full: ARGV.include?('--full'))
+edition = "#{ButterCut::EDITION} #{ButterCut::VERSION}"
+installed = QaHarness::EDITORS.select { |_, leg| leg[:app] && File.exist?(leg[:app]) }
+puts "ButterCut edition under test: #{edition}"
+puts "Scenarios: #{scenarios.join(', ')}"
+
+# Pre-warm the GUI editors (background launch, no focus steal) so their cold
+# start overlaps the CPU-only fixture/export work instead of extending each leg.
+installed.each_value do |leg|
+  next unless leg[:prewarm]
+
+  system('open', '-g', '-a', leg[:name], out: File::NULL, err: File::NULL)
+end
+
+unless ARGV.include?('--skip-generate')
+  run('Generating fixture', 'ruby', 'qa/scripts/generate_qa_fixture.rb') || abort('fixture generation failed')
+end
+
+scenarios.each do |scenario|
+  cut = QaHarness.cut_yaml(scenario)
+  abort "No cut at #{cut}" unless File.exist?(cut)
+
+  installed.each_key do |editor|
+    run("Exporting #{scenario} for #{editor}",
+        'ruby', 'lib/buttercut/export.rb', '--editor', editor, cut, QaHarness.export_path(editor, scenario)) ||
+      abort("export failed for #{scenario}/#{editor}")
+  end
+end
+
+# Verify editor-by-editor so each app's scenarios run back to back (one warm
+# stretch per editor; Premiere still launches once per scenario — see the
+# runbook's batching note).
+results = QaHarness::EDITORS.flat_map do |editor, leg|
+  unless installed.key?(editor)
+    puts "\n=== #{leg[:name]}: SKIP (not installed)"
+    next scenarios.map { |scenario| ["#{leg[:name]} · #{scenario}", 'SKIP'] }
+  end
+
+  scenarios.map do |scenario|
+    ok = run("Verifying #{leg[:name]} · #{scenario}",
+             'ruby', leg[:verifier], QaHarness.export_path(editor, scenario), QaHarness.expected_json(scenario))
+    ["#{leg[:name]} · #{scenario}", ok ? 'PASS' : 'FAIL']
+  end
+end
+
+puts "\n#{'=' * 46}\nEditor round-trip results (#{edition}):"
+results.each { |name, status| puts format('  %-34s %s', name, status) }
+puts '=' * 46
+exit(results.none? { |_, s| s == 'FAIL' } ? 0 : 1)

--- a/qa/scripts/verify_fcp.rb
+++ b/qa/scripts/verify_fcp.rb
@@ -1,0 +1,341 @@
+# frozen_string_literal: true
+
+# Final Cut Pro leg of the editor round-trip QA harness: imports a
+# ButterCut-exported FCPXML into a dedicated throwaway FCP library, has FCP
+# re-export the imported event as XML, and verifies FCP's own re-serialization
+# frame-accurately against the fixture's expected_<scenario>.json.
+#
+# FCP has no scripting API for this, so the runner drives the UI blind via
+# System Events (Accessibility): menu clicks, save-panel keystrokes, and
+# sidebar-row reads. Every stage is confirmed on the filesystem (bundle event
+# folder appears, re-export lands) rather than by trusting the UI.
+#
+# The import destination is made deterministic by never choosing from FCP's
+# library list: the "Open Library" dialog's New… button creates a fresh
+# buttercut-qa-import library as part of the import itself.
+#
+# Usage (from the repo root; FCP may be closed — it will be launched):
+#   ruby qa/scripts/verify_fcp.rb [fcpxml_path] [expected_json_path]
+#
+# Leaves the buttercut-qa-import.fcpbundle on disk (closed in FCP) for manual
+# inspection; the next run deletes and recreates it. Requires Accessibility
+# permission for the terminal/agent process. Never touches other libraries.
+
+require 'fileutils'
+require 'json'
+require 'rexml/document' # stdlib rather than Nokogiri, so the leg runs with plain `ruby` (no bundle exec)
+require 'uri'
+require_relative 'qa_helpers'
+
+FCP_WORK_DIR = File.join(QaHarness::FIXTURE_DIR, 'fcp')
+QA_LIBRARY   = 'buttercut-qa-import'
+
+xml_path, expected_path = QaHarness.verify_args('fcpx')
+REEXPORT = "#{File.basename(xml_path, '.*')}-reexport"
+
+# ---------- fcpxml helpers ----------
+
+def rational_seconds(str)
+  return Rational(0) if str.nil? || str.empty?
+
+  Rational(str.delete_suffix('s')) # Kernel#Rational parses "3600" and "1001/30000" alike
+end
+
+def to_frames(rational, fps)
+  value = rational * fps
+  raise "#{rational} s is not frame-aligned at #{fps} fps" unless value.denominator == 1
+
+  value.to_i
+end
+
+def first_event_name(fcpxml_path)
+  doc = REXML::Document.new(File.read(fcpxml_path))
+  REXML::XPath.first(doc, '//event/@name')&.value or
+    abort("no <event> in #{fcpxml_path} — can't determine import event name")
+end
+
+def decoded_basename(file_url)
+  File.basename(URI.decode_uri_component(file_url.delete_prefix('file://')))
+end
+
+# Parses an FCP "Export XML" re-export (bare .fcpxml or .fcpxmld bundle) into
+# the normalized shape compare_timeline.rb expects.
+def parse_fcp_reexport(path)
+  path = File.join(path, 'Info.fcpxml') if File.directory?(path)
+  doc = REXML::Document.new(File.read(path))
+
+  formats = REXML::XPath.match(doc, '//resources/format').each_with_object({}) do |f, hash|
+    hash[f.attributes['id']] = {
+      frame_duration: rational_seconds(f.attributes['frameDuration']),
+      width: f.attributes['width']&.to_i,
+      height: f.attributes['height']&.to_i
+    }
+  end
+  # Each asset's own `start` is FCP's reading of the media's embedded start
+  # timecode; subtracting it from a clip's start yields the file-relative
+  # source in-point — and catches a ButterCut base-timecode bug, because the
+  # clip start came from our export while the asset start is FCP's own.
+  assets = REXML::XPath.match(doc, '//resources/asset').each_with_object({}) do |a, hash|
+    hash[a.attributes['id']] = {
+      source: decoded_basename(REXML::XPath.first(a, 'media-rep/@src')&.value.to_s),
+      start: rational_seconds(a.attributes['start'])
+    }
+  end
+
+  sequence = REXML::XPath.first(doc, '//project/sequence') or raise 'no <project><sequence> in re-export'
+  seq_format = formats.fetch(sequence.attributes['format'])
+  fps = (1 / seq_format[:frame_duration])
+  clips = []
+  REXML::XPath.first(sequence, 'spine').elements.each do |el|
+    offset   = rational_seconds(el.attributes['offset'])
+    duration = rational_seconds(el.attributes['duration'])
+    asset    = assets[el.attributes['ref']]
+    source   = asset&.fetch(:source) || el.attributes['name']
+    case el.name
+    when 'asset-clip'
+      start  = rational_seconds(el.attributes['start'] || '0s') - (asset&.fetch(:start) || Rational(0))
+      # Muted clips re-export as adjust-volume -96dB (the exporter's
+      # Fcpx::MUTE_VOLUME_ADJUSTMENT); anything ≤ -90 counts as muted — headroom
+      # for FCP's re-serialization without copying the lib constant here.
+      volume = REXML::XPath.first(el, 'adjust-volume/@amount')&.value.to_s
+      clips << { 'source' => source, 'type' => 'video',
+                 'record_in' => to_frames(offset, fps), 'record_out' => to_frames(offset + duration, fps),
+                 'source_in' => to_frames(start, fps), 'source_out' => to_frames(start + duration, fps),
+                 'mute' => volume.to_f <= -90 }
+    when 'video' # a held still
+      clips << { 'source' => source, 'type' => 'image',
+                 'record_in' => to_frames(offset, fps), 'record_out' => to_frames(offset + duration, fps),
+                 'mute' => false }
+    else
+      warn "  (ignoring unexpected spine element <#{el.name}>)"
+    end
+  end
+
+  {
+    'editor' => "Final Cut Pro (re-export #{doc.root.attributes['version']})",
+    'timeline' => { 'frame_rate' => QaHarness.fps_value(fps), 'width' => seq_format[:width], 'height' => seq_format[:height],
+                    'total_frames' => clips.map { |c| c['record_out'] }.max },
+    'clips' => clips
+  }
+end
+
+# ---------- System Events driving ----------
+
+FIND_OUTLINE = <<~APPLESCRIPT
+  on findOutline()
+    tell application "System Events"
+      tell process "Final Cut Pro"
+        set queue to {window "Final Cut Pro"}
+        repeat 400 times
+          if (count of queue) is 0 then exit repeat
+          set current to item 1 of queue
+          set queue to rest of queue
+          try
+            if (role of current as string) is "AXOutline" then return current
+            repeat with k in (every UI element of current)
+              set end of queue to k
+            end repeat
+          end try
+        end repeat
+      end tell
+    end tell
+    return missing value
+  end findOutline
+
+  on rowLabel(theOutline, i)
+    tell application "System Events"
+      tell process "Final Cut Pro"
+        set q2 to {row i of theOutline}
+        repeat 30 times
+          if (count of q2) is 0 then exit repeat
+          set cur to item 1 of q2
+          set q2 to rest of q2
+          if (role of cur as string) is "AXTextField" then return (value of cur as string)
+          try
+            repeat with k in (every UI element of cur)
+              set end of q2 to k
+            end repeat
+          end try
+        end repeat
+      end tell
+    end tell
+    return "?"
+  end rowLabel
+APPLESCRIPT
+
+# Blind save-panel recipe (panels are remote views — not AX-readable): the
+# filename field has focus when the panel opens; cmd+shift+G navigates.
+def drive_save_panel(name:, dir:)
+  QaHarness.osascript(<<~APPLESCRIPT)
+    tell application "System Events"
+      tell process "Final Cut Pro"
+        set frontmost to true
+        delay 0.5
+        keystroke "a" using {command down}
+        delay 0.3
+        keystroke "#{name}"
+        delay 0.5
+        keystroke "g" using {command down, shift down}
+        delay 1.0
+        keystroke "#{dir}"
+        delay 0.5
+        key code 36
+        delay 1.5
+        key code 36
+      end tell
+    end tell
+  APPLESCRIPT
+end
+
+def close_qa_library(name)
+  out, = QaHarness.run_osascript(<<~APPLESCRIPT)
+    #{FIND_OUTLINE}
+    set theOutline to findOutline()
+    if theOutline is missing value then return "NO OUTLINE"
+    tell application "System Events"
+      tell process "Final Cut Pro"
+        set frontmost to true
+        delay 0.5
+        set n to count of rows of theOutline
+        repeat with i from 1 to n
+          if (my rowLabel(theOutline, i)) is "#{name}" then
+            set value of attribute "AXSelected" of (row i of theOutline) to true
+            delay 1.0
+            try
+              click menu item "Close Library “#{name}”" of menu "File" of menu bar 1
+              return "CLOSED"
+            on error errMsg
+              return "MENU ERROR: " & errMsg
+            end try
+          end if
+        end repeat
+        return "NOT OPEN"
+      end tell
+    end tell
+  APPLESCRIPT
+  out
+end
+
+def selected_sidebar_row
+  out, = QaHarness.run_osascript(<<~APPLESCRIPT)
+    #{FIND_OUTLINE}
+    set theOutline to findOutline()
+    if theOutline is missing value then return "NO OUTLINE"
+    tell application "System Events"
+      tell process "Final Cut Pro"
+        set n to count of rows of theOutline
+        repeat with i from 1 to n
+          if (value of attribute "AXSelected" of (row i of theOutline)) then
+            return my rowLabel(theOutline, i)
+          end if
+        end repeat
+      end tell
+    end tell
+    return "NONE"
+  APPLESCRIPT
+  out
+end
+
+def alert_texts
+  out, = QaHarness.run_osascript(<<~APPLESCRIPT)
+    tell application "System Events"
+      tell process "Final Cut Pro"
+        set report to {}
+        repeat with w in windows
+          if (subrole of w as string) is "AXDialog" and (name of w as string) is not "Final Cut Pro" then
+            try
+              set end of report to (name of w as string) & ": " & ((value of every static text of w) as string)
+            end try
+          end if
+        end repeat
+      end tell
+    end tell
+    set text item delimiters to " | "
+    return report as string
+  APPLESCRIPT
+  out
+end
+
+# ---------- run ----------
+
+event_name = first_event_name(xml_path)
+bundle_path = File.join(FCP_WORK_DIR, "#{QA_LIBRARY}.fcpbundle")
+reexport_path = File.join(FCP_WORK_DIR, "#{REEXPORT}.fcpxmld")
+FileUtils.mkdir_p(FCP_WORK_DIR)
+
+QaHarness.ensure_app_ready(process: 'Final Cut Pro', app_name: 'Final Cut Pro', ready_probe: <<~APPLESCRIPT)
+  tell application "System Events" to tell process "Final Cut Pro"
+    return exists menu "File" of menu bar 1
+  end tell
+APPLESCRIPT
+
+# clean up any previous run (close in FCP before deleting on disk)
+previous = close_qa_library(QA_LIBRARY)
+puts "Previous QA library: #{previous}"
+sleep 2 if previous == 'CLOSED' # let FCP release the bundle before it's deleted
+FileUtils.rm_rf([bundle_path, reexport_path])
+
+puts "Importing #{File.basename(xml_path)} into new library #{QA_LIBRARY}..."
+system('open', '-a', 'Final Cut Pro', xml_path) || abort('open failed')
+
+dialog_up = QaHarness.wait_until(tries: 30) do
+  QaHarness.osascript_true?(<<~APPLESCRIPT)
+    tell application "System Events" to tell process "Final Cut Pro"
+      return exists window "Open Library"
+    end tell
+  APPLESCRIPT
+end
+abort "FCP never showed the 'Open Library' import dialog" unless dialog_up
+
+QaHarness.osascript(<<~APPLESCRIPT)
+  tell application "System Events"
+    tell process "Final Cut Pro"
+      set frontmost to true
+      delay 0.5
+      click button "New…" of window "Open Library"
+    end tell
+  end tell
+APPLESCRIPT
+sleep 1.5
+drive_save_panel(name: QA_LIBRARY, dir: FCP_WORK_DIR)
+
+event_dir = File.join(bundle_path, event_name)
+unless QaHarness.wait_until(tries: 60) { File.directory?(event_dir) }
+  alerts = alert_texts
+  abort "Import didn't land (no #{event_dir}).#{alerts.empty? ? '' : " FCP alerts: #{alerts}"}"
+end
+puts "  ✓ event '#{event_name}' imported into #{File.basename(bundle_path)}"
+sleep 3
+
+alerts = alert_texts
+abort "FCP raised an alert during import: #{alerts}" unless alerts.empty?
+
+# FCP auto-selects the imported event
+selection = selected_sidebar_row
+unless selection == event_name
+  abort "Expected sidebar selection '#{event_name}' after import, found '#{selection}' — not exporting blind"
+end
+
+puts 'Re-exporting the imported event as XML...'
+QaHarness.osascript(<<~APPLESCRIPT)
+  tell application "System Events"
+    tell process "Final Cut Pro"
+      set frontmost to true
+      delay 0.5
+      click menu item "Export XML…" of menu "File" of menu bar 1
+    end tell
+  end tell
+APPLESCRIPT
+sleep 2
+drive_save_panel(name: REEXPORT, dir: FCP_WORK_DIR)
+
+info_fcpxml   = File.join(reexport_path, 'Info.fcpxml')
+bare_reexport = File.join(FCP_WORK_DIR, "#{REEXPORT}.fcpxml")
+landed = QaHarness.wait_until(tries: 30) { File.exist?(info_fcpxml) || File.exist?(bare_reexport) }
+abort 'Re-export never appeared on disk' unless landed
+reexport_file = File.exist?(info_fcpxml) ? reexport_path : bare_reexport
+
+actual = parse_fcp_reexport(reexport_file)
+puts "Closing QA library: #{close_qa_library(QA_LIBRARY)}"
+QaHarness.finish!(actual, xml_path: xml_path, expected_path: expected_path,
+                  label: "Final Cut Pro round-trip of #{File.basename(xml_path)}")

--- a/qa/scripts/verify_premiere.rb
+++ b/qa/scripts/verify_premiere.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# Premiere leg of the editor round-trip QA harness: launches Premiere with a
+# startup ExtendScript (the only unattended script mechanism Premiere offers)
+# that imports the ButterCut FCP7 XML into a scratch project, walks the
+# sequence's tracks, and writes a tick-accurate JSON report; this runner then
+# verifies it frame-accurately against the fixture's expected_<scenario>.json.
+#
+# ExtendScript is supported through ~Sept 2026; the replacement is a UXP panel
+# (no unattended loader exists yet — see qa/editor-roundtrip.md, Premiere notes).
+#
+# Usage (from the repo root; Premiere must NOT already be running):
+#   ruby qa/scripts/verify_premiere.rb [xml_path] [expected_json_path]
+#
+# The runner launches its own Premiere instance and force-quits it when done
+# (the script closes the scratch project first, so nothing is left dirty). If
+# Premiere is already running it aborts rather than risk someone's open work.
+
+require 'fileutils'
+require 'json'
+require_relative 'qa_helpers'
+
+TICKS_PER_SECOND = 254_016_000_000
+TEMPLATE     = File.join(__dir__, 'premiere', 'buttercut_qa_dump.jsx.template')
+JSX_PATH     = '/tmp/buttercut_qa_premiere_dump.jsx'
+REPORT_PATH  = '/tmp/buttercut_qa_premiere_report.json'
+PROJECT_PATH = '/tmp/buttercut_qa_premiere_scratch.prproj'
+
+def kill_premiere = system('pkill', '-9', '-f', 'Adobe Premiere', out: File::NULL, err: File::NULL)
+
+xml_path, expected_path = QaHarness.verify_args('premiere')
+
+premiere_bin = QaHarness.premiere_binary
+abort 'No Adobe Premiere binary found under /Applications' unless premiere_bin
+
+if system('pgrep -fq "Adobe Premiere"')
+  abort 'Adobe Premiere is already running — quit it first (the QA runner must launch its own instance ' \
+        'because Premiere only executes scripts at launch).'
+end
+
+jsx = File.read(TEMPLATE)
+      .gsub('__XML_PATH__', xml_path)
+      .gsub('__REPORT_PATH__', REPORT_PATH)
+      .gsub('__PROJECT_PATH__', PROJECT_PATH)
+File.write(JSX_PATH, jsx)
+FileUtils.rm_f([REPORT_PATH, "#{REPORT_PATH}.tmp", PROJECT_PATH])
+
+puts "Launching #{File.basename(premiere_bin)} with startup script (this takes a minute)..."
+pid = Process.spawn(premiere_bin, '/C', "es.processFile #{JSX_PATH}", %i[out err] => '/dev/null')
+Process.detach(pid)
+
+unless QaHarness.wait_until(tries: 150, interval: 2) { File.exist?(REPORT_PATH) }
+  kill_premiere
+  abort "No report at #{REPORT_PATH} after 5 minutes — the /C es.processFile launch flag may have " \
+        'stopped working in this Premiere version, or a first-run dialog blocked startup. ' \
+        'See the Premiere notes in qa/editor-roundtrip.md for the fallback.'
+end
+
+# the jsx writes the report atomically (tmp + rename), so it's complete once it exists
+report = JSON.parse(File.read(REPORT_PATH))
+
+kill_premiere
+FileUtils.rm_f(PROJECT_PATH)
+
+abort "Premiere script failed at stage '#{report['stage']}': #{report['error']}" unless report['ok']
+
+sequence = report.fetch('sequence')
+ticks_per_frame = Integer(sequence.fetch('timebase_ticks_per_frame'))
+# Exact even for NTSC: 254,016,000,000 ticks/s over 8,475,667,200 ticks/frame
+# reduces to 30000/1001.
+fps = QaHarness.fps_value(Rational(TICKS_PER_SECOND, ticks_per_frame))
+
+def ticks_to_frames(ticks, ticks_per_frame)
+  t = Integer(ticks)
+  raise "#{t} ticks is not frame-aligned (#{ticks_per_frame} ticks/frame)" unless (t % ticks_per_frame).zero?
+
+  t / ticks_per_frame
+end
+
+video_items = report.fetch('video_tracks').flat_map { |t| t['items'] }
+clips = video_items.map do |item|
+  basename = File.basename(item['media_path'] || item['name'].to_s)
+  type = Library.media_type_of(basename) || 'video' # lib's registry, with its lenient-read video fallback
+  image = type == 'image'
+  clip = {
+    'source' => basename,
+    'type' => type,
+    'record_in' => ticks_to_frames(item['start_ticks'], ticks_per_frame),
+    'record_out' => ticks_to_frames(item['end_ticks'], ticks_per_frame)
+  }
+  unless image
+    clip['source_in']  = ticks_to_frames(item['in_ticks'], ticks_per_frame)
+    clip['source_out'] = ticks_to_frames(item['out_ticks'], ticks_per_frame)
+  end
+  clip # mute isn't exposed to ExtendScript — compare_timeline reports it as skipped
+end
+
+actual = {
+  'editor' => "Adobe Premiere #{report['app_version']}",
+  'timeline' => {
+    'frame_rate' => fps,
+    'width' => sequence['width'],
+    'height' => sequence['height'],
+    'total_frames' => clips.map { |c| c['record_out'] }.max
+  },
+  'clips' => clips
+}
+
+QaHarness.finish!(actual, xml_path: xml_path, expected_path: expected_path,
+                  label: "Premiere import of #{File.basename(xml_path)}")

--- a/qa/scripts/verify_resolve.rb
+++ b/qa/scripts/verify_resolve.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+# DaVinci Resolve leg of the editor round-trip QA harness: imports a
+# ButterCut-exported timeline into a scratch Resolve project and verifies,
+# frame-accurately, that Resolve built the timeline the cut described.
+#
+# Works on the free edition (where external scripting is unavailable) by
+# driving Resolve's own Workspace > Scripts menu: the in-app Lua script
+# (qa/scripts/resolve/ButterCut QA Dump.lua) does the import and dumps what
+# Resolve actually built; this runner installs that script, triggers the menu
+# item via System Events, normalizes the dump, and compares it against the
+# fixture's expected_<scenario>.json.
+#
+# Usage (from the repo root; Resolve may be closed — it will be launched):
+#   ruby qa/scripts/verify_resolve.rb [xml_path] [expected_json_path]
+#
+# Defaults to the qa-editor-roundtrip fixture's resolve export. Exits 0 on
+# pass, 1 on fail. Requires Accessibility permission for the terminal/agent
+# process (System Events drives the menu click).
+
+require 'fileutils'
+require 'json'
+require_relative 'qa_helpers'
+
+SCRIPT_SRC  = File.join(__dir__, 'resolve', 'ButterCut QA Dump.lua')
+SCRIPT_DST  = File.expand_path('~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Utility/ButterCut QA Dump.lua')
+JOB_PATH    = '/tmp/buttercut_qa_resolve_job.lua'
+REPORT_PATH = '/tmp/buttercut_qa_resolve_report.json'
+
+xml_path, expected_path = QaHarness.verify_args('resolve')
+
+unless File.exist?(SCRIPT_DST) && File.read(SCRIPT_DST) == File.read(SCRIPT_SRC)
+  FileUtils.mkdir_p(File.dirname(SCRIPT_DST))
+  FileUtils.cp(SCRIPT_SRC, SCRIPT_DST)
+  puts "Installed in-app script -> #{SCRIPT_DST}"
+end
+
+File.write(JOB_PATH, <<~LUA)
+  return {
+    xml_path = #{xml_path.inspect},
+    report_path = #{REPORT_PATH.inspect},
+    timeline_name = #{"buttercut-qa-#{File.basename(xml_path, '.*')}".inspect},
+  }
+LUA
+FileUtils.rm_f([REPORT_PATH, "#{REPORT_PATH}.tmp"])
+
+QaHarness.ensure_app_ready(process: 'Resolve', app_name: 'DaVinci Resolve', ready_probe: <<~APPLESCRIPT)
+  tell application "System Events" to tell process "Resolve"
+    return exists menu item "Scripts" of menu "Workspace" of menu bar 1
+  end tell
+APPLESCRIPT
+
+puts 'Triggering Workspace > Scripts > ButterCut QA Dump...'
+_out, clicked = QaHarness.run_osascript(<<~APPLESCRIPT)
+  tell application "System Events"
+    tell process "Resolve"
+      set frontmost to true
+      delay 0.5
+      click menu item "ButterCut QA Dump" of menu of menu item "Scripts" of menu "Workspace" of menu bar 1
+    end tell
+  end tell
+APPLESCRIPT
+abort 'menu click failed — is Accessibility permission granted?' unless clicked
+
+unless QaHarness.wait_until(tries: 60, interval: 2) { File.exist?(REPORT_PATH) }
+  abort "No report at #{REPORT_PATH} after 2 minutes — check Resolve's console (Workspace > Console)"
+end
+
+report = JSON.parse(File.read(REPORT_PATH))
+abort "Resolve script failed: #{report['error']}" unless report['ok']
+
+timeline = report.fetch('timeline')
+start_frame = timeline['start_frame'].to_i
+video_items = report.fetch('video_tracks').flat_map { |t| t['items'] }
+
+actual = {
+  'editor' => "#{report['product']} #{report['resolve_version']}",
+  'timeline' => {
+    'frame_rate' => timeline['frame_rate'],
+    'width' => timeline['width'],
+    'height' => timeline['height'],
+    'total_frames' => timeline['end_frame'].to_i - start_frame
+  },
+  'clips' => video_items.map do |item|
+    still = item['media_type'].to_s == 'Still'
+    clip = {
+      'source' => File.basename(item['media_path'] || item['name'].to_s),
+      'type' => still ? 'image' : 'video',
+      'record_in' => item['start'].to_i - start_frame,
+      'record_out' => item['end'].to_i - start_frame
+    }
+    unless still
+      # left_offset (frames between media start and the clip's in-point) is
+      # file-relative even when the media carries an embedded start timecode;
+      # source_start_frame is kept as the fallback for older Resolve APIs.
+      source_in = item['left_offset'] || item['source_start_frame']
+      clip['source_in']  = source_in
+      clip['source_out'] = source_in + (item['source_end_frame'].to_i - item['source_start_frame'].to_i)
+    end
+    clip
+    # mute is not observable through Resolve's API — compare_timeline reports it as skipped
+  end
+}
+
+QaHarness.finish!(actual, xml_path: xml_path, expected_path: expected_path,
+                  label: "DaVinci Resolve import of #{File.basename(xml_path)}")

--- a/qa/scripts/verify_resolve.rb
+++ b/qa/scripts/verify_resolve.rb
@@ -94,8 +94,18 @@ actual = {
       # file-relative even when the media carries an embedded start timecode;
       # source_start_frame is kept as the fallback for older Resolve APIs.
       source_in = item['left_offset'] || item['source_start_frame']
+      # GetSourceStartFrame/GetSourceEndFrame are converted through the media's
+      # embedded start timecode, and each endpoint independently picks up a ±1
+      # rounding (observed on qa_filmF, tc 21:44:10:09: spans of 192 for a
+      # 192-frame clip but 121 for a 120-frame one). left_offset and the record
+      # range never go through that conversion, so the out-point derives from
+      # them when the raw span agrees to within the jitter; a bigger
+      # disagreement (a real retime/conform) is passed through for the
+      # comparator to fail.
+      raw_span    = item['source_end_frame'].to_i - item['source_start_frame'].to_i
+      record_span = clip['record_out'] - clip['record_in']
       clip['source_in']  = source_in
-      clip['source_out'] = source_in + (item['source_end_frame'].to_i - item['source_start_frame'].to_i)
+      clip['source_out'] = source_in + ((raw_span - record_span).abs <= 1 ? record_span : raw_span)
     end
     clip
     # mute is not observable through Resolve's API — compare_timeline reports it as skipped

--- a/skills/.gitignore
+++ b/skills/.gitignore
@@ -36,3 +36,7 @@
 !buttercut/**
 !bc/
 !bc/**
+
+# Developer-only (companion to qa/ — never triggered in video-editor sessions).
+!integration-tests/
+!integration-tests/**

--- a/skills/integration-tests/SKILL.md
+++ b/skills/integration-tests/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: integration-tests
+description: Run the full editor round-trip QA — Tier 1 (deterministic import/verify matrix via qa/scripts/run_all.rb) followed by the Tier-2 visual pass, driving Final Cut Pro, DaVinci Resolve, and Premiere and checking viewer screenshots against expected_visuals.md. Developer-only. Use when the developer asks to "run the integration tests", "run the roundtrip QA", "run the editor QA", "run tier 2", or "visually verify the exports".
+---
+
+# Skill: Editor round-trip QA (Tier 1 + Tier 2)
+
+Runs both tiers of `qa/editor-roundtrip.md` end to end. Tier 1 is the
+deterministic PASS/FAIL matrix; Tier 2 is the visual pass — you (the agent)
+park each editor's playhead at known timeline positions, screenshot the
+viewer, and check the burned-in ticker/colors/waveforms against
+`libraries/qa-editor-roundtrip/expected_visuals.md`. Read that runbook first
+if anything here is surprising; this skill only adds the driving recipes.
+
+Prerequisites:
+
+- Developer checkout (`.buttercut_mode` present) — never run in a video-editor session.
+- Accessibility **and** Screen Recording permission for this agent's shell.
+- **Premiere closed** before starting (both tiers launch their own instance).
+- Editors steal focus while this runs — warn the developer not to type over it.
+
+Ask the developer whether to run the fast tier or `--full` (default to `--full`
+before merges — that's the merge-confidence gate).
+
+## Step 1 — Tier 1 (deterministic)
+
+```bash
+ruby qa/scripts/run_all.rb --full     # or without --full for the fast tier
+```
+
+Report the PASS/FAIL matrix. If a leg fails, stop and investigate before
+Tier 2 — the runbook's troubleshooting section covers the known aborts. A
+Resolve `source_out` failure of more than ±1 is a real disagreement (the leg
+already absorbs the ±1 embedded-timecode jitter documented in the runbook).
+
+## Step 2 — Tier 2 (visual)
+
+### What to check at each position
+
+Open `libraries/qa-editor-roundtrip/expected_visuals.md`. For every clip row
+of every scenario you're checking, park at three timeline frames — `record_in`
+(first frame), a middle frame, and `record_out - 1` (last frame; `record_out`
+itself already shows the *next* clip) — and verify in the viewer screenshot:
+
+- **Background color + giant letter** match the row.
+- **SRC ticker frame**: at timeline frame `t`, the ticker must read
+  `F(row_in + (t - record_in))` — e.g. parking at the last frame of a clip
+  trimmed `F360 → F480` must show `F479`. The ticker format is
+  `<letter> SRC hh:mm:ss.ffffff F<n>`; compare the `F<n>` number, it's exact.
+- The still (`qa_title_card.png` rows) shows the yellow TITLE CARD, no ticker.
+
+Then one **full-window screenshot per scenario** showing the timeline itself:
+
+- The muted clip's audio is drawn **flat** in Resolve and Premiere (mute is
+  invisible to their APIs, so this screenshot is the only mute check there;
+  FCP's mute is already verified structurally by Tier 1's re-export).
+- Other clips show their beep pattern (1/s = one short, 2/s = double, long).
+- The still appears as a video-only clip with **no audio** under it.
+
+### Screenshots
+
+`screencapture -x -R x,y,w,h out.png` takes coordinates in **points**. To find
+them: take a full screenshot (`screencapture -x full.png`), Read it, locate
+the viewer, then convert with `points = image_px × (screen_width_points /
+image_width_px)` (Read's rendering is downscaled; on this 2×-retina display
+the factor has been ≈0.8 for a 2000px rendering). Crop tight to the viewer so
+the ticker text is legible; re-crop rather than squint.
+
+### Per-editor driving
+
+Both Tier-1 legs keep only the **last** scenario imported (each run deletes
+the previous scratch project/library), so for Resolve and FCP work one
+scenario at a time: re-run that scenario's Tier-1 leg to import it, then do
+its visual positions. Premiere imports everything in one launch instead.
+
+**DaVinci Resolve**
+
+1. `ruby qa/scripts/verify_resolve.rb <export> <expected>` — imports the
+   scenario into a fresh `buttercut-qa-*` project (skip for the scenario that
+   is already current after Tier 1).
+2. Make sure Resolve is on the Edit page (screenshot; Shift+4 switches to it).
+3. Park: `ruby skills/integration-tests/resolve_park.rb <frame>` —
+   prints a report with Resolve's own `tc_readback`; compare its digits only
+   (drop-frame timelines read back with `;` where `:` was set). A digit
+   mismatch is a failed park, not a failed export.
+4. Screenshot the timeline viewer per position; full window for waveforms.
+
+**Final Cut Pro**
+
+1. `ruby qa/scripts/verify_fcp.rb <export> <expected>` — re-imports (it closes
+   the QA library when done), then reopen it:
+   `open libraries/qa-editor-roundtrip/fcp/buttercut-qa-import.fcpbundle`.
+2. Open the imported project: find its row in the browser on a screenshot,
+   then double-click it with
+   `osascript -l JavaScript skills/integration-tests/mouse.js <x> <y> 2`
+   (System Events `click at` is only an AXPress — it won't open the project).
+3. Park: `ruby skills/integration-tests/fcp_park.rb <frame> <fps>`
+   (fps from the scenario: 30, 29.97, or 23.976).
+4. Bonus check: FCP draws corner "L" badges in the viewer on a clip's first
+   and last frame, and sprocket-hole borders at media limits — free
+   confirmation that a boundary park really is the boundary.
+
+**Premiere**
+
+1. `ruby skills/integration-tests/premiere_open_all.rb` — launches
+   Premiere once with every scenario imported into one saved scratch project,
+   all sequences as timeline tabs, and **leaves it running**.
+2. Select a scenario's tab (single `mouse.js` click on the tab), then park by
+   clicking the Program monitor's timecode field (`mouse.js`), typing the
+   digits and Return:
+   `osascript -e 'tell application "System Events" to tell process "Adobe Premiere Pro" to keystroke "<digits>" & return'`
+   Digits are NDF `m ss ff` at the nominal rate, same convention as
+   `fcp_park.rb` prints (e.g. frame 315 @ 30 fps → `1015`).
+3. Screenshot per position; full window for waveforms.
+4. Quit when done — dialog-free because the project was saved:
+   `osascript -e 'tell application id "com.adobe.PremierePro" to quit'`.
+
+## Step 3 — Report
+
+Give the developer one summary: the Tier-1 matrix verbatim, then a Tier-2 table —
+scenario × editor × position, each with the expected vs observed ticker frame
+and the waveform/mute verdict — and a clear overall PASS/FAIL. Keep
+screenshots in the session scratchpad; nothing from this skill belongs in the
+repo or the fixture library.
+
+## Known quirks
+
+- Parking timecode math everywhere in this skill is NDF at the nominal
+  integer rate — valid because the QA timelines start at 0 and are under a
+  minute. Don't reuse the parkers on long drop-frame timelines.
+- If a keystroke lands in the wrong app, something stole focus mid-run;
+  re-run that position (every step here is idempotent).
+- If the Workspace > Scripts menu is missing "ButterCut QA Park", open the
+  menu once by hand (it re-scans) — the driver installs the script
+  automatically.
+- To uninstall the in-app park script:
+  `rm "~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Utility/ButterCut QA Park.lua"`.

--- a/skills/integration-tests/fcp_park.rb
+++ b/skills/integration-tests/fcp_park.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Parks the Final Cut Pro playhead at a timeline frame, for the Tier-2 visual
+# pass (skills/integration-tests/SKILL.md). FCP has no scripting API,
+# so this types the position: Cmd+2 (focus the timeline), Ctrl+P (Go To
+# Playhead Position), the timecode digits, Return.
+#
+# The digits are computed NDF at the nominal integer rate (30 for 29.97, 24
+# for 23.976) — exact for the QA timelines, which start at 0 and run well
+# under a minute.
+#
+# Usage (FCP must be running with the QA project open in the timeline):
+#   ruby skills/integration-tests/fcp_park.rb <timeline_frame> <fps>
+#   ruby skills/integration-tests/fcp_park.rb 315 30      # -> types 1015 (0:10:15)
+
+require_relative '../../qa/scripts/qa_helpers'
+
+frame = Integer(ARGV[0], exception: false)
+fps   = Float(ARGV[1] || '', exception: false)
+abort 'Usage: ruby fcp_park.rb <timeline_frame> <fps>' unless frame && fps
+
+nominal = fps.round
+ff = frame % nominal
+total_s = frame / nominal
+digits = format('%d%02d%02d', total_s / 60, total_s % 60, ff).sub(/\A0+(?=\d)/, '')
+
+QaHarness.osascript(<<~APPLESCRIPT)
+  tell application "System Events"
+    tell process "Final Cut Pro"
+      set frontmost to true
+      delay 0.5
+      keystroke "2" using {command down}
+      delay 0.3
+      keystroke "p" using {control down}
+      delay 0.3
+      keystroke "#{digits}"
+      delay 0.2
+      key code 36
+    end tell
+  end tell
+APPLESCRIPT
+
+puts "Parked FCP at frame #{frame} (typed #{digits} @ #{nominal} fps NDF)"

--- a/skills/integration-tests/mouse.js
+++ b/skills/integration-tests/mouse.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env osascript -l JavaScript
+// Real CGEvent mouse clicks at global screen coordinates (points, origin at
+// the top-left of the main display), for the Tier-2 visual pass
+// (skills/integration-tests/SKILL.md).
+//
+// System Events' `click at` only sends an AXPress, which FCP's browser rows
+// (and some other views) ignore for double-clicks — a real double-click needs
+// kCGMouseEventClickState set on the event, which is what this does.
+//
+// Usage:
+//   osascript -l JavaScript skills/integration-tests/mouse.js <x> <y> [clicks]
+//     clicks: 1 (default) or 2 for a double-click
+
+ObjC.import('CoreGraphics');
+
+function run(argv) {
+  const x = parseFloat(argv[0]);
+  const y = parseFloat(argv[1]);
+  const clicks = argv.length > 2 ? parseInt(argv[2], 10) : 1;
+  if (!isFinite(x) || !isFinite(y) || !(clicks >= 1)) {
+    return 'Usage: mouse.js <x> <y> [clicks]';
+  }
+  const pt = { x: x, y: y };
+
+  function post(type, clickState) {
+    const ev = $.CGEventCreateMouseEvent($(), type, pt, $.kCGMouseButtonLeft);
+    if (clickState > 0) $.CGEventSetIntegerValueField(ev, $.kCGMouseEventClickState, clickState);
+    $.CGEventPost($.kCGHIDEventTap, ev);
+  }
+
+  post($.kCGEventMouseMoved, 0);
+  delay(0.1);
+  for (let c = 1; c <= clicks; c++) {
+    post($.kCGEventLeftMouseDown, c);
+    post($.kCGEventLeftMouseUp, c);
+    delay(0.08);
+  }
+  return `clicked (${x}, ${y}) x${clicks}`;
+}

--- a/skills/integration-tests/premiere/buttercut_qa_open_all.jsx.template
+++ b/skills/integration-tests/premiere/buttercut_qa_open_all.jsx.template
@@ -1,0 +1,98 @@
+// ButterCut QA Open All (Premiere) — ExtendScript, executed at app launch via:
+//   ".../Adobe Premiere Pro 2026" /C es.processFile <this file>
+//
+// Tier-2 variant of qa/scripts/premiere/buttercut_qa_dump.jsx.template: builds
+// one scratch project, imports EVERY scenario XML into it, opens each imported
+// sequence as a timeline tab, saves, and leaves Premiere RUNNING so an agent
+// (or human) can park the playhead and eyeball the timelines against
+// expected_visuals.md. Because the project is saved here, quitting Premiere
+// afterwards is dialog-free.
+//
+// premiere_open_all.rb copies this template to /tmp with the placeholders
+// filled in, launches Premiere with it, and polls for the report file.
+
+var XML_PATHS = __XML_PATHS__;
+var REPORT_PATH = "__REPORT_PATH__";
+var PROJECT_PATH = "__PROJECT_PATH__";
+
+function esc(s) {
+  s = String(s);
+  var out = "";
+  for (var i = 0; i < s.length; i++) {
+    var c = s.charAt(i);
+    var code = s.charCodeAt(i);
+    if (c === '"') out += '\\"';
+    else if (c === "\\") out += "\\\\";
+    else if (c === "\n") out += "\\n";
+    else if (c === "\r") out += "\\r";
+    else if (c === "\t") out += "\\t";
+    else if (code < 32) out += "\\u" + ("000" + code.toString(16)).slice(-4);
+    else out += c;
+  }
+  return out;
+}
+
+function toJson(v) {
+  if (v === null || v === undefined) return "null";
+  var t = typeof v;
+  if (t === "number") return isFinite(v) ? String(v) : "null";
+  if (t === "boolean") return String(v);
+  if (t === "string") return '"' + esc(v) + '"';
+  if (v instanceof Array) {
+    var parts = [];
+    for (var i = 0; i < v.length; i++) parts.push(toJson(v[i]));
+    return "[" + parts.join(",") + "]";
+  }
+  var kv = [];
+  for (var k in v) if (v.hasOwnProperty(k)) kv.push('"' + esc(k) + '":' + toJson(v[k]));
+  return "{" + kv.join(",") + "}";
+}
+
+var report = { ok: false, stage: "start", script: "buttercut_qa_open_all.jsx" };
+
+// temp file + rename so the Ruby poller never reads a half-written report
+function save() {
+  var f = new File(REPORT_PATH + ".tmp");
+  f.encoding = "UTF-8";
+  f.open("w");
+  f.write(toJson(report));
+  f.close();
+  f.rename(new File(REPORT_PATH).name);
+}
+
+try {
+  report.app_version = app.version;
+
+  if (!app.project || !app.project.rootItem) {
+    report.stage = "newProject";
+    app.enableQE();
+    qe.newProject(PROJECT_PATH);
+  }
+  report.project_name = app.project.name;
+
+  report.stage = "import";
+  report.imported = [];
+  for (var i = 0; i < XML_PATHS.length; i++) {
+    var ok = app.project.importFiles([XML_PATHS[i]], 1, app.project.rootItem, 0);
+    report.imported.push({ xml: XML_PATHS[i], returned: ok ? true : false });
+  }
+
+  report.stage = "openSequences";
+  report.sequences = [];
+  for (var s = 0; s < app.project.sequences.numSequences; s++) {
+    var seq = app.project.sequences[s];
+    app.project.openSequence(seq.sequenceID);
+    report.sequences.push(seq.name);
+  }
+
+  report.stage = "save";
+  app.project.save();
+
+  report.ok = true;
+  report.stage = "done";
+} catch (err) {
+  report.error = String(err);
+}
+
+save();
+// Deliberately NO closeDocument/quit — the whole point is to stay open.

--- a/skills/integration-tests/premiere_open_all.rb
+++ b/skills/integration-tests/premiere_open_all.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Launches Premiere with every scenario's FCP7 XML imported into one scratch
+# project, all sequences open as timeline tabs, project saved — and leaves
+# Premiere RUNNING for the Tier-2 visual pass
+# (skills/integration-tests/SKILL.md).
+#
+# Premiere only executes scripts at launch, so like the Tier-1 leg this must
+# start its own instance and refuses to run when Premiere is already open.
+# Because the script saves the project, quitting Premiere afterwards is
+# dialog-free:
+#   osascript -e 'tell application id "com.adobe.PremierePro" to quit'
+#
+# Usage (from the repo root; exports must exist — run Tier 1 first):
+#   ruby skills/integration-tests/premiere_open_all.rb [xml ...]
+#
+# Defaults to every scenario export present under the fixture's cuts/.
+
+require 'fileutils'
+require 'json'
+require_relative '../../qa/scripts/qa_helpers'
+
+TEMPLATE     = File.join(__dir__, 'premiere', 'buttercut_qa_open_all.jsx.template')
+JSX_PATH     = '/tmp/buttercut_qa_premiere_open_all.jsx'
+REPORT_PATH  = '/tmp/buttercut_qa_premiere_open_all_report.json'
+PROJECT_PATH = '/tmp/buttercut_qa_premiere_tier2.prproj'
+
+xml_paths = if ARGV.any?
+              ARGV.map { |p| File.expand_path(p) }
+            else
+              QaHarness::SCENARIOS.keys.map { |s| QaHarness.export_path('premiere', s) }.select { |p| File.exist?(p) }
+            end
+abort 'No scenario exports found — run `ruby qa/scripts/run_all.rb --full` (or export manually) first' if xml_paths.empty?
+missing = xml_paths.reject { |p| File.exist?(p) }
+abort "Missing XML: #{missing.join(', ')}" if missing.any?
+
+premiere_bin = QaHarness.premiere_binary
+abort 'No Adobe Premiere binary found under /Applications' unless premiere_bin
+
+if system('pgrep -fq "Adobe Premiere"')
+  abort 'Adobe Premiere is already running — quit it first (Premiere only executes scripts at launch).'
+end
+
+jsx = File.read(TEMPLATE)
+      .gsub('__XML_PATHS__', JSON.generate(xml_paths))
+      .gsub('__REPORT_PATH__', REPORT_PATH)
+      .gsub('__PROJECT_PATH__', PROJECT_PATH)
+File.write(JSX_PATH, jsx)
+FileUtils.rm_f([REPORT_PATH, "#{REPORT_PATH}.tmp", PROJECT_PATH])
+
+puts "Launching #{File.basename(premiere_bin)} with #{xml_paths.length} scenario XML(s) (takes a minute)..."
+pid = Process.spawn(premiere_bin, '/C', "es.processFile #{JSX_PATH}", %i[out err] => '/dev/null')
+Process.detach(pid)
+
+unless QaHarness.wait_until(tries: 150, interval: 2) { File.exist?(REPORT_PATH) }
+  abort "No report at #{REPORT_PATH} after 5 minutes — see the Premiere notes in qa/editor-roundtrip.md. " \
+        'Premiere was left running; quit it by hand.'
+end
+
+report = JSON.parse(File.read(REPORT_PATH))
+abort "Premiere script failed at stage '#{report['stage']}': #{report['error']} (Premiere left running)" unless report['ok']
+
+puts "✓ Premiere is open with sequences: #{report['sequences'].join(', ')}"
+puts '  Park the playhead by clicking the Program monitor timecode field, typing digits, Enter.'
+puts '  Quit when done (project already saved): osascript -e \'tell application id "com.adobe.PremierePro" to quit\''

--- a/skills/integration-tests/resolve/ButterCut QA Park.lua
+++ b/skills/integration-tests/resolve/ButterCut QA Park.lua
@@ -1,0 +1,127 @@
+-- ButterCut QA Park
+-- Parks the playhead of the current Resolve timeline at a requested timeline
+-- frame, for the Tier-2 visual pass of the editor round-trip QA harness
+-- (qa/editor-roundtrip.md). Runs INSIDE Resolve (Workspace > Scripts >
+-- ButterCut QA Park) so it works on the free edition.
+--
+-- Contract:
+--   reads  /tmp/buttercut_qa_park_job.lua -- written by resolve_park.rb:
+--            return { frame = 315, report_path = "/abs/report.json",
+--                     timeline_name = "optional -- switch to it first" }
+--   writes report_path (JSON) -- always, even on failure (ok=false + error)
+--
+-- Timecode math is NDF at the nominal integer rate (30 for 29.97, 24 for
+-- 23.976). That's exact for the QA timelines because they start at
+-- 00:00:00:00 and run well under a minute — no drop-frame labels can occur
+-- before the first minute boundary. Don't reuse this on long DF timelines.
+
+local JOB_PATH = "/tmp/buttercut_qa_park_job.lua"
+local FALLBACK_REPORT = "/tmp/buttercut_qa_park_report.json"
+
+local function json_escape(s)
+  s = s:gsub("\\", "\\\\"):gsub('"', '\\"'):gsub("\n", "\\n"):gsub("\r", "\\r"):gsub("\t", "\\t")
+  return (s:gsub("%c", function(c) return string.format("\\u%04x", c:byte()) end))
+end
+
+local function to_json(v)
+  local t = type(v)
+  if v == nil then return "null" end
+  if t == "number" then
+    if v == math.floor(v) then return string.format("%d", v) end
+    return string.format("%.6f", v)
+  end
+  if t == "boolean" then return tostring(v) end
+  if t == "string" then return '"' .. json_escape(v) .. '"' end
+  if t == "table" then
+    local keys = {}
+    for k in pairs(v) do keys[#keys + 1] = k end
+    table.sort(keys)
+    local parts = {}
+    for _, k in ipairs(keys) do
+      parts[#parts + 1] = '"' .. json_escape(tostring(k)) .. '": ' .. to_json(v[k])
+    end
+    return "{" .. table.concat(parts, ", ") .. "}"
+  end
+  return '"' .. json_escape(tostring(v)) .. '"'
+end
+
+-- temp file + rename so the driver's existence poll never reads a half write
+local function write_report(path, report)
+  local tmp = path .. ".tmp"
+  local f = io.open(tmp, "w")
+  if not f then return false end
+  f:write(to_json(report), "\n")
+  f:close()
+  return os.rename(tmp, path) == true
+end
+
+local function safe(fn)
+  local ok, result = pcall(fn)
+  if ok then return result end
+  return nil
+end
+
+local report = { ok = false, script = "ButterCut QA Park" }
+local report_path = FALLBACK_REPORT
+
+local function fail(msg)
+  report.error = msg
+  write_report(report_path, report)
+  print("ButterCut QA Park FAILED: " .. msg)
+end
+
+local job_chunk = loadfile(JOB_PATH)
+if not job_chunk then return fail("no job file at " .. JOB_PATH) end
+local job = job_chunk()
+if type(job) ~= "table" or type(job.frame) ~= "number" then
+  return fail("job file malformed (need frame = <number>)")
+end
+report_path = job.report_path or FALLBACK_REPORT
+report.requested_frame = job.frame
+
+local rv = resolve or (bmd and bmd.scriptapp("Resolve"))
+if not rv then return fail("no resolve object (run from Workspace > Scripts inside DaVinci Resolve)") end
+
+local project = rv:GetProjectManager():GetCurrentProject()
+if not project then return fail("no current project") end
+
+if job.timeline_name then
+  local found = false
+  for i = 1, (safe(function() return project:GetTimelineCount() end) or 0) do
+    local tl = project:GetTimelineByIndex(i)
+    if tl and safe(function() return tl:GetName() end) == job.timeline_name then
+      project:SetCurrentTimeline(tl)
+      found = true
+      break
+    end
+  end
+  if not found then return fail("no timeline named " .. job.timeline_name) end
+end
+
+local timeline = project:GetCurrentTimeline()
+if not timeline then return fail("no current timeline") end
+report.timeline = safe(function() return timeline:GetName() end)
+
+local fps = tonumber(safe(function() return timeline:GetSetting("timelineFrameRate") end)) or 0
+if fps <= 0 then return fail("could not read timelineFrameRate") end
+local nominal = math.floor(fps + 0.5)
+local start_frame = safe(function() return timeline:GetStartFrame() end) or 0
+
+local abs = start_frame + job.frame
+local ff = abs % nominal
+local total_s = math.floor(abs / nominal)
+local tc = string.format("%02d:%02d:%02d:%02d",
+  math.floor(total_s / 3600), math.floor(total_s / 60) % 60, total_s % 60, ff)
+
+if not safe(function() return timeline:SetCurrentTimecode(tc) end) then
+  return fail("SetCurrentTimecode(" .. tc .. ") failed")
+end
+
+report.ok = true
+report.fps = fps
+report.nominal_fps = nominal
+report.start_frame = start_frame
+report.tc_set = tc
+report.tc_readback = safe(function() return timeline:GetCurrentTimecode() end)
+write_report(report_path, report)
+print("ButterCut QA Park: frame " .. job.frame .. " -> " .. tc)

--- a/skills/integration-tests/resolve_park.rb
+++ b/skills/integration-tests/resolve_park.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# Parks the current Resolve timeline's playhead at a timeline frame, for the
+# Tier-2 visual pass (skills/integration-tests/SKILL.md). Installs the
+# in-app park script and triggers it via the Workspace > Scripts menu — the
+# same mechanism as qa/scripts/verify_resolve.rb, so it works on the free
+# edition.
+#
+# Usage (from the repo root; Resolve must be running with the QA project open):
+#   ruby skills/integration-tests/resolve_park.rb <timeline_frame> [timeline_name]
+#
+# Prints the park report JSON (tc_set + Resolve's own tc_readback) on success.
+
+require 'fileutils'
+require 'json'
+require_relative '../../qa/scripts/qa_helpers'
+
+SCRIPT_SRC  = File.join(__dir__, 'resolve', 'ButterCut QA Park.lua')
+SCRIPT_DST  = File.expand_path('~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Utility/ButterCut QA Park.lua')
+JOB_PATH    = '/tmp/buttercut_qa_park_job.lua'
+REPORT_PATH = '/tmp/buttercut_qa_park_report.json'
+
+frame = Integer(ARGV[0], exception: false)
+abort 'Usage: ruby resolve_park.rb <timeline_frame> [timeline_name]' unless frame
+
+unless File.exist?(SCRIPT_DST) && File.read(SCRIPT_DST) == File.read(SCRIPT_SRC)
+  FileUtils.mkdir_p(File.dirname(SCRIPT_DST))
+  FileUtils.cp(SCRIPT_SRC, SCRIPT_DST)
+  puts "Installed in-app script -> #{SCRIPT_DST}"
+end
+
+File.write(JOB_PATH, <<~LUA)
+  return {
+    frame = #{frame},
+    report_path = #{REPORT_PATH.inspect},
+    #{ARGV[1] ? "timeline_name = #{ARGV[1].inspect}," : ''}
+  }
+LUA
+FileUtils.rm_f([REPORT_PATH, "#{REPORT_PATH}.tmp"])
+
+QaHarness.ensure_app_ready(process: 'Resolve', app_name: 'DaVinci Resolve', ready_probe: <<~APPLESCRIPT)
+  tell application "System Events" to tell process "Resolve"
+    return exists menu item "Scripts" of menu "Workspace" of menu bar 1
+  end tell
+APPLESCRIPT
+
+def click_park_menu_item
+  _out, clicked = QaHarness.run_osascript(<<~APPLESCRIPT)
+    tell application "System Events"
+      tell process "Resolve"
+        set frontmost to true
+        delay 0.5
+        click menu item "ButterCut QA Park" of menu of menu item "Scripts" of menu "Workspace" of menu bar 1
+      end tell
+    end tell
+  APPLESCRIPT
+  clicked
+end
+
+unless click_park_menu_item
+  # The Scripts menu only re-scans when opened, so a freshly installed script
+  # isn't listed yet — open Workspace once, dismiss it, and retry.
+  QaHarness.run_osascript(<<~APPLESCRIPT)
+    tell application "System Events"
+      tell process "Resolve"
+        set frontmost to true
+        delay 0.5
+        click menu bar item "Workspace" of menu bar 1
+        delay 1
+        key code 53
+      end tell
+    end tell
+  APPLESCRIPT
+  sleep 1
+  abort 'menu click failed — is Accessibility permission granted?' unless click_park_menu_item
+end
+
+unless QaHarness.wait_until(tries: 20, interval: 1) { File.exist?(REPORT_PATH) }
+  abort "No report at #{REPORT_PATH} after 20s — check Resolve's console (Workspace > Console)"
+end
+
+report = JSON.parse(File.read(REPORT_PATH))
+abort "Park failed: #{report['error']}" unless report['ok']
+
+puts JSON.pretty_generate(report)


### PR DESCRIPTION
## What

Automated integration tests for the promise RSpec can't check: that exported timelines **import into the real editors** and build the cut the YAML described — right clips, right order, right trims, frame-accurately.

From the repo root: `ruby qa/scripts/run_all.rb` → generates the fixture, exports all three formats through the shipped CLI, imports each into a scratch project/library inside the real app, and prints a PASS/FAIL matrix (~4 min warm). Runbook: `qa/editor-roundtrip.md`.

## How it verifies

- **Self-identifying fixture footage**: every frame burns in its clip letter, source timecode, and frame number over a per-clip color, with per-clip beep patterns so waveforms read on sight. Ground truth lives in the pixels — a wrong-clip/wrong-trim bug can't look correct.
- **Editors are the oracle, not golden files**: each leg extracts what the editor actually built and compares exact frame numbers against `expected_timeline.json`, which is computed with plain arithmetic (deliberately not lib/buttercut's own timecode math). Innocuous XML changes cause zero test churn.
- **Per-editor doors**: Resolve via an in-app Lua script (works on the free edition), Final Cut Pro via System Events UI driving + Export XML round-trip (also verifies mute), Premiere via launch-time ExtendScript (supported through ~Sept 2026; UXP successor documented in the runbook).

## Notes

- Developer-only: fixture library is gitignored and regenerated per run; nothing binary is committed; never runs in video-editor sessions (AGENTS.md line included).
- Proven green on FCP 12.3, DaVinci Resolve 21.0.2 (free), Premiere 26.2.2 — in both editions (Pro PR is the byte-identical copy).