### PR TITLE
core: Fix clipitem enabled flags and gate Resolve stills specs on ancestry

### DIFF
--- a/lib/buttercut/fcp7_core.rb
+++ b/lib/buttercut/fcp7_core.rb
@@ -188,7 +188,7 @@ class ButterCut
 
       xml.clipitem(id: payload[:video_clip_id]) do
         xml.name asset[:basename]
-        xml.enabled xmeml_enabled(payload[:clip][:video_enabled])
+        xml.enabled xmeml_enabled(payload.dig(:clip, :clip_definition, :video_enabled))
         xml.duration payload[:timeline_duration]
         xml.start payload[:timeline_start]
         xml.end_ payload[:timeline_end]
@@ -268,7 +268,7 @@ class ButterCut
 
       xml.clipitem(id: payload[:audio_clip_id]) do
         xml.name asset[:basename]
-        xml.enabled xmeml_enabled(payload[:clip][:audio_enabled])
+        xml.enabled xmeml_enabled(payload.dig(:clip, :clip_definition, :audio_enabled))
         xml.duration payload[:timeline_duration]
         xml.start payload[:timeline_start]
         xml.end_ payload[:timeline_end]

--- a/spec/buttercut/fcp7_spec.rb
+++ b/spec/buttercut/fcp7_spec.rb
@@ -114,6 +114,35 @@ RSpec.describe ButterCut::FCP7 do
 
       expect(clipitem).not_to include('audiolevels')
     end
+
+    # video_enabled/audio_enabled let a stacked alternate take sit on the
+    # timeline without rendering — each flag disables only its own clipitem.
+    it 'disables only the video clipitem for a clip with video_enabled: false' do
+      xml = described_class.new([{ path: clip_a_path, video_enabled: false }]).to_xml
+      video = xml[/<clipitem id="clipitem-video-1">.*?<\/clipitem>/m]
+      audio = xml[/<clipitem id="clipitem-audio-1">.*?<\/clipitem>/m]
+
+      expect(video).to include('<enabled>FALSE</enabled>')
+      expect(audio).to include('<enabled>TRUE</enabled>')
+    end
+
+    it 'disables only the audio clipitem for a clip with audio_enabled: false' do
+      xml = described_class.new([{ path: clip_a_path, audio_enabled: false }]).to_xml
+      video = xml[/<clipitem id="clipitem-video-1">.*?<\/clipitem>/m]
+      audio = xml[/<clipitem id="clipitem-audio-1">.*?<\/clipitem>/m]
+
+      expect(video).to include('<enabled>TRUE</enabled>')
+      expect(audio).to include('<enabled>FALSE</enabled>')
+    end
+
+    it 'writes both clipitems enabled when neither flag is given' do
+      xml = described_class.new([{ path: clip_a_path }]).to_xml
+      video = xml[/<clipitem id="clipitem-video-1">.*?<\/clipitem>/m]
+      audio = xml[/<clipitem id="clipitem-audio-1">.*?<\/clipitem>/m]
+
+      expect(video).to include('<enabled>TRUE</enabled>')
+      expect(audio).to include('<enabled>TRUE</enabled>')
+    end
   end
 
   # NTSC fractional rates (29.97/23.976) are what most real camera footage

--- a/spec/buttercut/generator_stills_spec.rb
+++ b/spec/buttercut/generator_stills_spec.rb
@@ -182,9 +182,10 @@ RSpec.describe 'Generator still handling' do
     it_behaves_like 'an xmeml still generator'
   end
 
-  # Core only: Pro's Resolve rides the FCPX generator (FCPXML — see
-  # resolve_pro.rb), so it stops being an xmeml generator there.
-  if ButterCut.core?
+  # Gated on ancestry, not edition: Resolve stays an xmeml generator until an
+  # edition variant actually reroutes it (Pro's planned resolve_pro rides the
+  # FCPX generator instead), and keeps this coverage exactly that long.
+  if ButterCut::Resolve <= ButterCut::FCP7
     describe ButterCut::Resolve do
       it_behaves_like 'an xmeml still generator'
     end


### PR DESCRIPTION
## Summary
- Fix the clipitem enabled-flag seam: read `video_enabled`/`audio_enabled` from the clip definition — the caller's clip hash — matching how `mute` is read. The seam read `payload[:clip]` one level too high, so both flags were silently ignored and every clipitem exported enabled.
- Add specs for each flag and the enabled-by-default case. They fail against the old reads.
- Gate the Resolve stills shared examples on `Resolve <= FCP7` ancestry instead of the edition, so coverage stays on until an edition variant actually reroutes Resolve off the xmeml generator.

## Testing
- `bundle exec rspec`: 376 examples, 0 failures on this branch.
- Verified the new specs fail with the seam reverted.
- Ran the Pro editor round-trip suite (the integration harness lives in Pro) with this fix in place: all 12 legs pass — 4 scenarios x Final Cut Pro, DaVinci Resolve, and Premiere, including a new mixed-rate scenario exercising the per-clipitem `<rate>` declarations.