### PR TITLE
core: Fix mixed-rate clip in-points in FCP7 XML exports

### DIFF
--- a/lib/buttercut/fcp7_core.rb
+++ b/lib/buttercut/fcp7_core.rb
@@ -162,8 +162,14 @@ class ButterCut
         )
       else
         asset_rate_num, asset_rate_denom = asset[:frame_rate].split('/').map(&:to_i)
-        source_in_frames = frames_for_fraction(clip[:source_in], asset[:frame_duration])
-        source_duration_frames = frames_for_fraction(clip[:source_duration], asset[:frame_duration])
+        # Clipitem <in>/<out> count on the SEQUENCE's frame grid, not the
+        # source's: Premiere and Resolve both decode them as source seconds ×
+        # sequence rate, whatever the clipitem/file rate declarations say
+        # (verified frame-by-frame in both editors with a 25 fps source in a
+        # 30 fps timeline). Identical numbers when the rates match; only the
+        # file-level <duration> and <timecode> stay in media-native frames.
+        source_in_frames = frames_for_fraction(clip[:source_in], timeline_frame_duration)
+        source_duration_frames = frames_for_fraction(clip[:source_duration], timeline_frame_duration)
 
         payload.merge!(
           audio_clip_id: "clipitem-audio-#{id_index}",
@@ -194,9 +200,10 @@ class ButterCut
         xml.end_ payload[:timeline_end]
         xml.in_ payload[:source_in]
         xml.out payload[:source_out]
-        # The clipitem's own rate: in/out are frame counts in the SOURCE's
-        # timebase. Without it an importer falls back to the sequence rate
-        # and misreads every trim on a rate-mismatched clip (Premiere does).
+        # The clipitem's own rate declares the source's native timebase (the
+        # conform metadata). It does NOT change how in/out are read — both
+        # Premiere and Resolve count them on the sequence grid regardless,
+        # which is why build_clip_payload writes them in sequence frames.
         emit_clipitem_rate(xml, payload)
         # Documented still marker: "Photoshop PSD files, jpeg files, tiff
         # files, or other still images imported into Final Cut have

--- a/spec/buttercut/fcp7_spec.rb
+++ b/spec/buttercut/fcp7_spec.rb
@@ -252,10 +252,7 @@ RSpec.describe ButterCut::FCP7 do
         expect(pal_file_rate.at_xpath('ntsc').text).to eq('FALSE')
       end
 
-      it 'declares each clipitem rate so in/out are read in the source timebase' do
-        # Without a clipitem-level <rate>, an importer inherits the sequence
-        # rate (29.97 here) and misreads the PAL clip's in/out — Premiere does
-        # exactly this, shifting every trim on a rate-mismatched clip.
+      it 'declares each clipitem rate as the source timebase (conform metadata)' do
         %w[clipitem-video-2 clipitem-audio-2].each do |id|
           rate = doc.at_xpath("//clipitem[@id='#{id}']/rate")
           expect(rate.at_xpath('timebase').text).to eq('25')
@@ -263,14 +260,19 @@ RSpec.describe ButterCut::FCP7 do
         end
       end
 
-      it 'trims in source frames but places on the timeline in sequence frames' do
-        # The 2.0s PAL clip is 50 source frames (25 fps) but occupies 60
-        # timeline frames (29.97): in/out count the file, start/end the sequence.
+      it 'writes in/out on the sequence frame grid, like start/end' do
+        # Premiere and Resolve decode clipitem in/out as source seconds ×
+        # SEQUENCE rate regardless of the declared clipitem/file rate —
+        # verified frame-by-frame in both editors (editor round-trip QA,
+        # mixed-rate-pal25). The 2.0s PAL clip therefore spans 60 grid units
+        # (29.97), not its 50 native frames; only the file-level <duration>
+        # and <timecode> stay in media frames.
         pal_clip = doc.at_xpath('//clipitem[@id="clipitem-video-2"]')
         expect(pal_clip.at_xpath('in').text).to eq('0')
-        expect(pal_clip.at_xpath('out').text).to eq('50')
+        expect(pal_clip.at_xpath('out').text).to eq('60')
         expect(pal_clip.at_xpath('start').text).to eq('120')
         expect(pal_clip.at_xpath('end').text).to eq('180')
+        expect(pal_clip.at_xpath('file/duration').text).to eq('50')
 
         expect(doc.at_xpath('/xmeml/sequence/duration').text).to eq('180')
       end


### PR DESCRIPTION
Write clipitem `<in>`/`<out>` on the sequence frame grid instead of in source-native frames. Premiere and DaVinci Resolve both decode those fields as source seconds × sequence rate regardless of the declared clipitem or file rate, so a rate-mismatched clip started early: a 25 fps source trimmed at 2.000s landed at 1.667s (frame 50 read at 30 fps) in both editors. Same-rate clips are unaffected — the two grids carry identical numbers when the rates match. Final Cut's FCPXML flavor was always correct.

Caught and verified frame-by-frame in both editors by the Pro editor round-trip integration tests (mixed-rate scenario); this is the identical commit validated there.