### PR TITLE
Move Resolve exports to FCPXML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - **Exports now catch unplugged or renamed footage before an XML ships**, with new tools to help the agent reconnect moved footage.
 
+#### Changed
+- **DaVinci Resolve exports now ship as FCPXML**, the same format Final Cut uses. It's a modern format with better support for future ButterCut features (multicam, connected clips, etc.).
+
 #### Fixed
 - **Final Cut Camera (iPhone) exports now import into Final Cut Pro cleanly.** The app records true 30/60fps media with drop-frame timecode; the exporter skipped the drop-frame correction for those files, so Final Cut rejected every clip ("Invalid edit with no respective media"). Thanks to @acreagetcg for the report and diagnosis.
 

--- a/lib/buttercut.rb
+++ b/lib/buttercut.rb
@@ -2,18 +2,22 @@ require_relative 'buttercut/distribution'
 require_relative 'buttercut/fcpx'
 require_relative 'buttercut/fcp7'
 require_relative 'buttercut/resolve'
+require_relative 'buttercut/resolve_legacy'
 require_relative 'buttercut/premiere'
 
 # ButterCut - Video editor XML generator
 #
 # Factory class that creates editor-specific generators based on the editor parameter.
 # Currently supports:
-#   - :fcpx - Final Cut Pro X (FCPXML 1.8 format)
-#   - :resolve - DaVinci Resolve (plain FCP7 / xmeml v5 interchange format)
+#   - :fcpx - Final Cut Pro X (FCPXML 1.12 format)
+#   - :resolve - DaVinci Resolve (FCPXML 1.12, riding the FCPX generator —
+#     see resolve_core.rb)
+#   - :resolve_legacy - DaVinci Resolve, FCP7 XML fallback — temporary, see
+#     resolve_legacy_core.rb
 #   - :premiere - FCP7 XML with explicit rotation for Adobe Premiere Pro
 #
-# FCP7 itself is the shared xmeml-v5 format base that Resolve and Premiere subclass;
-# it is not a public editor symbol.
+# FCP7 itself is the xmeml-v5 format base that Premiere and ResolveLegacy
+# subclass; it is not a public editor symbol.
 #
 # Example usage:
 #   clips = [
@@ -23,7 +27,7 @@ require_relative 'buttercut/premiere'
 #   generator = ButterCut.new(clips, editor: :fcpx)
 #   generator.save('output.fcpxml')
 class ButterCut
-  SUPPORTED_EDITORS = [:fcpx, :resolve, :premiere].freeze
+  SUPPORTED_EDITORS = [:fcpx, :resolve, :resolve_legacy, :premiere].freeze
 
   # `timeline:` is an optional explicit output format ({frame_rate:, width:,
   # height:}, any subset) — written by the cut skill into the cut YAML and
@@ -40,6 +44,8 @@ class ButterCut
       ButterCut::FCPX.new(clips, timeline: timeline)
     when :resolve
       ButterCut::Resolve.new(clips, timeline: timeline)
+    when :resolve_legacy
+      ButterCut::ResolveLegacy.new(clips, timeline: timeline)
     when :premiere
       ButterCut::Premiere.new(clips, timeline: timeline)
     else

--- a/lib/buttercut/editor_base_core.rb
+++ b/lib/buttercut/editor_base_core.rb
@@ -16,7 +16,9 @@ class ButterCut
 
     DEFAULT_START_TIME = "0s"
     DEFAULT_INITIAL_OFFSET = "0s"
-    DEFAULT_VOLUME_ADJUSTMENT = "-13.100000000000001db"
+    # The standard mix level every unmuted clip gets in FCPXML exports. A bare
+    # decibel number — see the volume note on FCPX::MUTE_VOLUME_ADJUSTMENT.
+    DEFAULT_VOLUME_ADJUSTMENT = "-13.1"
 
     attr_reader :clips, :initial_offset, :volume_adjustment
 

--- a/lib/buttercut/export.rb
+++ b/lib/buttercut/export.rb
@@ -13,7 +13,7 @@ if __FILE__ == $PROGRAM_NAME
 
   parser = OptionParser.new do |opts|
     opts.banner = "Usage: #{$0} [options] <roughcut.yaml> <output.xml>"
-    opts.on('-e', '--editor EDITOR', 'fcpx (default), premiere, or resolve') { |v| options[:editor] = v }
+    opts.on('-e', '--editor EDITOR', 'fcpx (default), premiere, resolve, or resolve_legacy (temporary FCP7 fallback)') { |v| options[:editor] = v }
     opts.on('-h', '--help', 'Show usage') { puts opts; exit }
   end
   parser.parse!

--- a/lib/buttercut/export_core.rb
+++ b/lib/buttercut/export_core.rb
@@ -10,7 +10,8 @@ require_relative 'media_verifier'
 class Export
   EDITOR_LABELS = {
     fcpx: 'Final Cut Pro X',
-    resolve: 'DaVinci Resolve (FCP7 XML)',
+    resolve: 'DaVinci Resolve (FCPXML)',
+    resolve_legacy: 'DaVinci Resolve (legacy FCP7 XML fallback)',
     premiere: 'Adobe Premiere Pro (FCP7 XML + rotation)'
   }.freeze
 
@@ -73,9 +74,8 @@ class Export
   # EditorBase#asset_sources: a variant whose clips fan out overrides it.
   def clip_source_paths(clip) = [clip[:path]]
 
-  # The editors whose output is FCPXML and so DTD-validated — an edition
-  # seam: a variant routing another editor through FCPX widens it.
-  def fcpxml_editor? = @editor == :fcpx
+  # The editors whose output is FCPXML and so DTD-validated.
+  def fcpxml_editor? = %i[fcpx resolve].include?(@editor)
 
   def index_media_paths(library)
     library['media'].each_with_object({}) do |media, map|
@@ -136,7 +136,7 @@ class Export
     editor = input.downcase.to_sym
     return editor if EDITOR_LABELS.key?(editor)
 
-    raise ArgumentError, "Unknown editor '#{input}'. Use 'fcpx', 'premiere', or 'resolve'"
+    raise ArgumentError, "Unknown editor '#{input}'. Use 'fcpx', 'premiere', 'resolve', or 'resolve_legacy'"
   end
 
   def write_xml(clips, editor, timeline)

--- a/lib/buttercut/fcp7.rb
+++ b/lib/buttercut/fcp7.rb
@@ -1,5 +1,5 @@
 # Edition shim. Loads the single-track (core) or multi-track (pro) FCP7/xmeml
-# generator (the shared base for Premiere and Resolve). See
-# ButterCut.engine_variant in lib/buttercut/version.rb.
+# generator (the base Premiere subclasses). See ButterCut.engine_variant in
+# lib/buttercut/version.rb.
 require_relative 'version'
 require_relative ButterCut.engine_variant('fcp7')

--- a/lib/buttercut/fcpx_core.rb
+++ b/lib/buttercut/fcpx_core.rb
@@ -6,9 +6,9 @@ class ButterCut
   # readable by DaVinci Resolve 19.1.1+ as well as Final Cut.
   class FCPX < EditorBase
     FORMAT_ID = "r1".freeze
-    # adjust-volume amount that silences a clip outright (a muted clip).
-    # -96 dB is below the audible floor — effectively off.
-    MUTE_VOLUME_ADJUSTMENT = "-96db".freeze
+    # Resolve's FCPXML importer only parses bare '-96', silently drops '-96dB'
+    # Final Cut docs say we should include dB in string, but parses fine without
+    MUTE_VOLUME_ADJUSTMENT = "-96".freeze
 
     def to_xml
       raise ArgumentError, "No clips provided" if clips.empty?

--- a/lib/buttercut/resolve.rb
+++ b/lib/buttercut/resolve.rb
@@ -1,6 +1,4 @@
-# Edition shim. Core Resolve rides the FCP7 (xmeml) generator; Pro rides the
-# FCPX generator instead — FCPXML is the only interchange format that lands a
-# real multicam clip in Resolve. See ButterCut.engine_variant in
-# lib/buttercut/version.rb.
+# Edition shim for the DaVinci Resolve generator. See ButterCut.engine_variant
+# in lib/buttercut/version.rb.
 require_relative 'version'
 require_relative ButterCut.engine_variant('resolve')

--- a/lib/buttercut/resolve_core.rb
+++ b/lib/buttercut/resolve_core.rb
@@ -1,9 +1,9 @@
-require_relative 'fcp7'
+require_relative 'fcpx'
 
 class ButterCut
-  # DaVinci Resolve timeline export. Resolve auto-corrects rotation from the
-  # source file on import, so plain FCP7 xmeml works as-is — a named
-  # pass-through subclass gives Resolve behavior a home if it ever diverges.
-  class Resolve < FCP7
+  # DaVinci Resolve timeline export, riding the FCPX generator as a pure
+  # pass-through — a named subclass gives Resolve behavior a home if it ever
+  # diverges.
+  class Resolve < FCPX
   end
 end

--- a/lib/buttercut/resolve_legacy.rb
+++ b/lib/buttercut/resolve_legacy.rb
@@ -1,0 +1,4 @@
+# Edition shim for the temporary DaVinci Resolve FCP7-fallback generator. See
+# ButterCut.engine_variant in lib/buttercut/version.rb.
+require_relative 'version'
+require_relative ButterCut.engine_variant('resolve_legacy')

--- a/lib/buttercut/resolve_legacy_core.rb
+++ b/lib/buttercut/resolve_legacy_core.rb
@@ -1,0 +1,12 @@
+require_relative 'fcp7'
+
+class ButterCut
+  # Temporary fallback for DaVinci Resolve: the FCP7 xmeml export Resolve
+  # exports used before the FCPXML migration (see resolve_core.rb). Kept
+  # around for a couple weeks after that migration ships so an editor whose
+  # Resolve install chokes on FCPXML import can still get a working export —
+  # remove this file (and the `resolve_legacy` editor value) once FCPXML has
+  # been in the field without incident.
+  class ResolveLegacy < FCP7
+  end
+end

--- a/skills/cut/SKILL.md
+++ b/skills/cut/SKILL.md
@@ -82,8 +82,16 @@ ruby lib/buttercut/export.rb --editor fcpx libraries/[library-name]/cuts/[slug]_
 ruby lib/buttercut/export.rb --editor premiere libraries/[library-name]/cuts/[slug]_[timestamp].yaml libraries/[library-name]/cuts/[slug]_[timestamp].xml
 
 # DaVinci Resolve
-ruby lib/buttercut/export.rb --editor resolve libraries/[library-name]/cuts/[slug]_[timestamp].yaml libraries/[library-name]/cuts/[slug]_[timestamp].xml
+ruby lib/buttercut/export.rb --editor resolve libraries/[library-name]/cuts/[slug]_[timestamp].yaml libraries/[library-name]/cuts/[slug]_[timestamp]_resolve.fcpxml
 ```
+
+**DaVinci Resolve fallback (temporary).** `resolve` above is the default and what every new cut should use. If the editor tells you a previous Resolve export failed to import, offer to re-export with `--editor resolve_legacy` instead — it writes the older FCP7 XML format Resolve exports used before FCPXML, as a compatibility fallback:
+
+```bash
+ruby lib/buttercut/export.rb --editor resolve_legacy libraries/[library-name]/cuts/[slug]_[timestamp].yaml libraries/[library-name]/cuts/[slug]_[timestamp]_resolve.xml
+```
+
+Don't offer this proactively or use it by default — only reach for it after the editor reports an import problem with the FCPXML export.
 
 ## 7. Copy File to Desktop (if enabled)
 Check `libraries/settings.yaml` for `save_to_desktop_after_export`:
@@ -107,7 +115,7 @@ Include the one-line import instruction for the editor used:
 
 - **Final Cut Pro X:** Open the cut in Final Cut Pro with File → Import → XML
 - **Adobe Premiere Pro:** Open the cut in Premiere with File → Import, then select the XML file
-- **DaVinci Resolve:** Open the cut in Resolve with File → Import → Timeline, then select the XML file
+- **DaVinci Resolve:** Open the cut in Resolve with File → Import → Timeline, then select the exported `.fcpxml` file (`.xml` if you used the `resolve_legacy` fallback)
 
 ## 10. Open in Editor (if enabled)
 Check `libraries/settings.yaml` for `open_in_editor_after_export`:

--- a/spec/buttercut/export_spec.rb
+++ b/spec/buttercut/export_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Export do
         perform(cut_path, out)
         volume = parse(out).at_xpath('//spine/asset-clip/adjust-volume')
 
-        expect(volume['amount']).to eq('-96db')
+        expect(volume['amount']).to eq('-96')
       end
     end
 
@@ -210,13 +210,22 @@ RSpec.describe Export do
       { 'clips' => [{ 'source_file' => 'MVI_0309_720p.mov', 'in_point' => 0, 'out_point' => 2 }] }
     end
 
-    it 'writes xmeml version 5 for resolve' do
+    it 'writes FCPXML 1.12 for resolve' do
       within_export_sandbox(cut: cut, media: [clip_a]) do |cut_path, out|
         perform(cut_path, out, editor: 'resolve')
         doc = parse(out)
 
-        expect(doc.at_xpath('/xmeml')['version']).to eq('5')
-        expect(doc.xpath('//clipitem').length).to eq(2) # video + linked audio
+        expect(doc.at_xpath('/fcpxml')['version']).to eq('1.12')
+        expect(doc.xpath('//spine/asset-clip').length).to eq(1)
+      end
+    end
+
+    it 'writes xmeml for resolve_legacy, the temporary FCP7 fallback' do
+      within_export_sandbox(cut: cut, media: [clip_a]) do |cut_path, out|
+        perform(cut_path, out, editor: 'resolve_legacy')
+        xml = File.read(out)
+
+        expect(xml).to include('<xmeml version="5">')
       end
     end
 

--- a/spec/buttercut/fcpx_spec.rb
+++ b/spec/buttercut/fcpx_spec.rb
@@ -422,15 +422,15 @@ RSpec.describe ButterCut::FCPX do
 
       expect(xml).to include('audioRate="48000"')
       expect(xml).to include('audioRate="48k"')
-      expect(xml).to include('<adjust-volume amount="-13.100000000000001db"/>')
+      expect(xml).to include('<adjust-volume amount="-13.1"/>')
     end
 
     it 'silences a muted clip outright instead of playing it' do
       generator = ButterCut::FCPX.new([{ path: video_file_path, mute: true }])
       xml = generator.to_xml
 
-      expect(xml).to include('<adjust-volume amount="-96db"/>')
-      expect(xml).not_to include('<adjust-volume amount="-13.100000000000001db"/>')
+      expect(xml).to include('<adjust-volume amount="-96"/>')
+      expect(xml).not_to include('<adjust-volume amount="-13.1"/>')
     end
 
     it 'handles multiple video files' do

--- a/spec/buttercut/generator_stills_spec.rb
+++ b/spec/buttercut/generator_stills_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Generator still handling' do
     end
   end
 
-  describe ButterCut::FCPX do
+  shared_examples 'an fcpxml still generator' do
     it 'emits one rate-undefined format per unique still dimension, with no frameDuration' do
       xml = described_class.new(image_only_clips, timeline: timeline_block).to_xml
       # 1920x1080 and 1080x1080 → two distinct still formats.
@@ -135,6 +135,14 @@ RSpec.describe 'Generator still handling' do
     end
   end
 
+  describe ButterCut::FCPX do
+    it_behaves_like 'an fcpxml still generator'
+  end
+
+  describe ButterCut::Resolve do
+    it_behaves_like 'an fcpxml still generator'
+  end
+
   shared_examples 'an xmeml still generator' do
     it 'marks the still clipitem with <stillframe>TRUE</stillframe>' do
       xml = described_class.new(image_only_clips, timeline: timeline_block).to_xml
@@ -180,15 +188,6 @@ RSpec.describe 'Generator still handling' do
 
   describe ButterCut::FCP7 do
     it_behaves_like 'an xmeml still generator'
-  end
-
-  # Gated on ancestry, not edition: Resolve stays an xmeml generator until an
-  # edition variant actually reroutes it (Pro's planned resolve_pro rides the
-  # FCPX generator instead), and keeps this coverage exactly that long.
-  if ButterCut::Resolve <= ButterCut::FCP7
-    describe ButterCut::Resolve do
-      it_behaves_like 'an xmeml still generator'
-    end
   end
 
   describe ButterCut::Premiere do

--- a/spec/buttercut/premiere_spec.rb
+++ b/spec/buttercut/premiere_spec.rb
@@ -9,7 +9,7 @@ require 'spec_helper'
 # so the shared FCP7 output (raw landscape dimensions, no rotation) imports SIDEWAYS.
 #
 # These specs are the failing-first contract for the fix: the Premiere generator must
-# emit the rotation into the XML, and the Resolve (FCP7) path must stay untouched.
+# emit the rotation into the XML.
 RSpec.describe ButterCut::Premiere do
   let(:rotated_clip_path)   { '/tmp/premiere_rotated.mov' }
   let(:upright_clip_path)   { '/tmp/premiere_upright.mov' }
@@ -178,19 +178,6 @@ RSpec.describe ButterCut::Premiere do
 
       expect(format).to include('<width>2160</width>')
       expect(format).to include('<height>3840</height>')
-    end
-  end
-
-  # Regression guard: the Resolve path must NOT change — it already imports correctly
-  # because Resolve reads the source rotation flag itself. If a future change starts
-  # injecting rotation into the shared FCP7 output, this fails and warns us we have
-  # double-rotated Resolve.
-  describe 'Resolve output is left unchanged' do
-    it 'emits no rotation filter for the same rotated clip' do
-      xml = ButterCut::Resolve.new([{ path: rotated_clip_path }]).to_xml
-
-      expect(xml).not_to include('<parameterid>rotation</parameterid>')
-      expect(xml).not_to include('<name>Basic Motion</name>')
     end
   end
 end

--- a/spec/buttercut/resolve_legacy_spec.rb
+++ b/spec/buttercut/resolve_legacy_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# ResolveLegacy is the temporary FCP7-xmeml fallback for editors who hit
+# import trouble with the FCPXML-based ButterCut::Resolve (see
+# resolve_legacy_core.rb) — a pure pass-through, same as Resolve was before
+# the FCPXML migration.
+RSpec.describe ButterCut::ResolveLegacy do
+  let(:video_path) { '/tmp/resolve_legacy_spec.mov' }
+
+  let(:metadata) do
+    {
+      'streams' => [
+        { 'codec_type' => 'video', 'codec_name' => 'h264',
+          'width' => 1920, 'height' => 1080, 'r_frame_rate' => '24/1',
+          'color_space' => 'bt709', 'color_primaries' => 'bt709', 'color_transfer' => 'bt709' },
+        { 'codec_type' => 'audio', 'sample_rate' => '48000' }
+      ],
+      'format' => { 'duration' => '4.0', 'tags' => {} }
+    }
+  end
+
+  before do
+    allow_any_instance_of(ButterCut::EditorBase)
+      .to receive(:extract_metadata_from_ffprobe).and_return(metadata)
+  end
+
+  it 'subclasses the FCP7 generator' do
+    expect(described_class).to be < ButterCut::FCP7
+  end
+
+  it 'writes xmeml version 5' do
+    xml = described_class.new([{ path: video_path, start_at: 0.0, duration: 2.0 }]).to_xml
+
+    expect(xml).to include('<xmeml version="5">')
+  end
+
+  it 'mutes a clip with a level-0 Audio Levels filter' do
+    xml = described_class.new([{ path: video_path, start_at: 0.0, duration: 2.0, mute: true }]).to_xml
+
+    expect(xml).to include('<effectid>audiolevels</effectid>')
+    expect(xml).to match(%r{<parameterid>level</parameterid>\s*<name>Level</name>.*?<value>0</value>}m)
+  end
+end

--- a/spec/buttercut/resolve_spec.rb
+++ b/spec/buttercut/resolve_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Resolve rides the FCPX generator (resolve_core.rb) as a pure pass-through.
+# The bare-decibel volume amounts Resolve's importer requires ("-96", never
+# "-96db") come from the shared generator, so these examples guard the
+# contract Resolve imports depend on.
+RSpec.describe ButterCut::Resolve do
+  let(:video_path) { '/tmp/resolve_spec.mov' }
+
+  let(:metadata) do
+    {
+      'streams' => [
+        { 'codec_type' => 'video', 'codec_name' => 'h264',
+          'width' => 1920, 'height' => 1080, 'r_frame_rate' => '24/1',
+          'color_space' => 'bt709', 'color_primaries' => 'bt709', 'color_transfer' => 'bt709' },
+        { 'codec_type' => 'audio', 'sample_rate' => '48000' }
+      ],
+      'format' => { 'duration' => '4.0', 'tags' => {} }
+    }
+  end
+
+  before do
+    allow_any_instance_of(ButterCut::EditorBase)
+      .to receive(:extract_metadata_from_ffprobe).and_return(metadata)
+  end
+
+  it 'subclasses the FCPX generator' do
+    expect(described_class).to be < ButterCut::FCPX
+  end
+
+  it 'mutes a clip with a bare -96 adjust-volume, keeping its audio on the timeline' do
+    xml = described_class.new([{ path: video_path, start_at: 0.0, duration: 2.0, mute: true }]).to_xml
+
+    expect(xml).to match(/<asset-clip name="resolve_spec\.mov"[^>]*audioRole="dialogue"/)
+    expect(xml).to include('<adjust-volume amount="-96"/>')
+    expect(xml).not_to include('db"')
+  end
+
+  it 'gives unmuted clips the bare standard mix level' do
+    xml = described_class.new([{ path: video_path, start_at: 0.0, duration: 2.0 }]).to_xml
+
+    expect(xml).to match(/<asset-clip name="resolve_spec\.mov"[^>]*audioRole="dialogue"/)
+    expect(xml).to include('<adjust-volume amount="-13.1"/>')
+    expect(xml).not_to include('db"')
+  end
+end

--- a/spec/fixtures/full_media_all_clips.fcpxml
+++ b/spec/fixtures/full_media_all_clips.fcpxml
@@ -18,13 +18,13 @@
         <sequence duration="9009/800s" format="r1" tcStart="0s" audioRate="48k">
           <spine>
             <asset-clip name="MVI_0309_720p.mov" ref="__ASSET_ID_MVI_0309__" start="0s" offset="0s" duration="101101/24000s" audioRole="dialogue">
-              <adjust-volume amount="-13.100000000000001db"/>
+              <adjust-volume amount="-13.1"/>
             </asset-clip>
             <asset-clip name="MVI_0323_720p.mov" ref="__ASSET_ID_MVI_0323__" start="0s" offset="101101/24000s" duration="29029/4800s" audioRole="dialogue">
-              <adjust-volume amount="-13.100000000000001db"/>
+              <adjust-volume amount="-13.1"/>
             </asset-clip>
             <asset-clip name="P1044376_timecode_fixture.mov" ref="__ASSET_ID_GH5__" start="626629003/8000s" offset="41041/4000s" duration="1001/1000s" audioRole="dialogue">
-              <adjust-volume amount="-13.100000000000001db"/>
+              <adjust-volume amount="-13.1"/>
             </asset-clip>
           </spine>
         </sequence>

--- a/spec/fixtures/full_media_last_second.fcpxml
+++ b/spec/fixtures/full_media_last_second.fcpxml
@@ -18,13 +18,13 @@
         <sequence duration="3003/1000s" format="r1" tcStart="0s" audioRate="48k">
           <spine>
             <asset-clip name="MVI_0309_720p.mov" ref="__ASSET_ID_MVI_0309__" start="77077/24000s" offset="0s" duration="1001/1000s" audioRole="dialogue">
-              <adjust-volume amount="-13.100000000000001db"/>
+              <adjust-volume amount="-13.1"/>
             </asset-clip>
             <asset-clip name="MVI_0323_720p.mov" ref="__ASSET_ID_MVI_0323__" start="121121/24000s" offset="1001/1000s" duration="1001/1000s" audioRole="dialogue">
-              <adjust-volume amount="-13.100000000000001db"/>
+              <adjust-volume amount="-13.1"/>
             </asset-clip>
             <asset-clip name="P1044376_timecode_fixture.mov" ref="__ASSET_ID_GH5__" start="626629003/8000s" offset="1001/500s" duration="1001/1000s" audioRole="dialogue">
-              <adjust-volume amount="-13.100000000000001db"/>
+              <adjust-volume amount="-13.1"/>
             </asset-clip>
           </spine>
         </sequence>


### PR DESCRIPTION
## Summary
- Move Resolve exports to FCPXML: `resolve_core.rb` now subclasses the FCPX generator, so Resolve timelines ship as FCPXML 1.12 instead of FCP7 XML (xmeml).
- Write FCPXML `adjust-volume` amounts as bare decibel numbers (`-96`, `-13.1` — no `db` suffix). Resolve's importer only parses the bare form and silently drops the suffixed one, while Final Cut accepts both. Muted clips import silent at -96 dB with their audio still on the timeline to raise later; unmuted clips import at the -13.1 dB mix level Final Cut exports always used, so a cut sounds the same in either editor.
- Create `resolve_legacy`, a temporary FCP7 XML fallback editor for anyone whose Resolve install chokes on FCPXML import. The cut skill offers it only after an import failure — remove it once FCPXML has been in the field without incident.
- Update the Export plumbing: relabel Resolve as FCPXML, widen DTD validation to cover it, and write `_resolve.fcpxml` from the cut skill.
- Update the specs: remove the ancestry gates and the Premiere double-rotation guard (Resolve no longer rides xmeml), create `resolve_spec.rb` guarding the bare-decibel contract and `resolve_legacy_spec.rb` covering the fallback.

## Testing
- `bundle exec rspec` — 383 examples, 0 failures.
- Cherry-picked from ButterCut Pro, where the full three-editor round-trip matrix passed (Tier 1 frame-exact on all four Resolve scenarios, Tier 2 visual pass, volume verified live in Final Cut and Resolve).