### PR TITLE
WIP core: make the system-Ruby failure fix itself, not just document itself

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,8 @@ bundle exec rspec
 ### Running scripts
 The project pins Ruby via `.mise.toml`; once mise is activated in the user shell (the default setup), plain `ruby` and `python` should resolve to it through mise shims. However, if the shell has been changed/shell didn't activate/user has a custom setting, read `.buttercut_env`. If this doesn't exist, attempt to find the dependencies in standard locations and then replace this file. You can look for information about setting up this file in simple-setup.md.
 
+**If a script dies with `syntax error, unexpected '='`** — usually a wall of them from `library.rb` — that is macOS system Ruby 2.6 trying to parse ButterCut's Ruby 3 syntax. It is **not** a corrupt checkout, and re-cloning won't help. It means mise never reached this shell: non-interactive shells (how agentic clients run commands) read `~/.zshenv`, not `~/.zshrc`. Read `.buttercut_env` and use the absolute invocation it records, then tell the user their shell setup needs the mise shims line in `~/.zshenv` (see simple-setup.md).
+
 ## Claude Skills
 
 **Before creating any skill, check your mode** (`cat .buttercut_mode 2>/dev/null || echo "video editor/Youtube creator"`, labeled "Loading ButterCut" as above). If the file is absent, the person asking is a non-technical video editor — help them describe what they want, then build the skill for them. Keep skills brief, use plain language, active voice.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,13 @@ bundle exec rspec
 ### Running scripts
 The project pins Ruby via `.mise.toml`; once mise is activated in the user shell (the default setup), plain `ruby` and `python` should resolve to it through mise shims. However, if the shell has been changed/shell didn't activate/user has a custom setting, read `.buttercut_env`. If this doesn't exist, attempt to find the dependencies in standard locations and then replace this file. You can look for information about setting up this file in simple-setup.md.
 
-**If a script dies with `syntax error, unexpected '='`** — usually a wall of them from `library.rb` — that is macOS system Ruby 2.6 trying to parse ButterCut's Ruby 3 syntax. It is **not** a corrupt checkout, and re-cloning won't help. It means mise never reached this shell: non-interactive shells (how agentic clients run commands) read `~/.zshenv`, not `~/.zshrc`. Read `.buttercut_env` and use the absolute invocation it records, then tell the user their shell setup needs the mise shims line in `~/.zshenv` (see simple-setup.md).
+Every script the skills invoke starts by requiring `lib/buttercut/boot.rb`, which checks the Ruby version and, if the shell handed it macOS system Ruby (2.6), finds the real interpreter and re-runs itself under that. So this normally sorts itself out with no output. Two rules keep it working, both enforced by `spec/buttercut/boot_spec.rb`: **`boot.rb` and every directly-invoked script must stay parseable by Ruby 2.6** (no endless `def x = y` in those files — the ones they require can use anything), and **`require_relative 'boot'` comes before any other project require**. Ruby parses a whole file before running line 1, so a check inside a file that itself uses 3.x syntax never gets to run.
+
+**If a script still dies with `syntax error, unexpected '='`** — usually a wall of them — that is Ruby 2.6 parsing Ruby 3 syntax, in a file that lost one of the two rules above. It is **not** a corrupt checkout, and re-cloning won't help. Fix the file, and run `bundle exec rspec spec/buttercut/boot_spec.rb` to confirm.
+
+**If a script aborts with `buttercut: needs Ruby 3.0+`**, the gate ran and couldn't find any Ruby 3 to hand off to. The message lists what it tried and why each failed — read that first, since the cause is often specific (an untrusted `.mise.toml` needs `mise trust`, for instance). Also worth knowing: this can misfire on a machine that *is* set up correctly. `/etc/zprofile` runs `path_helper`, which rebuilds `PATH` with the system directories first — and it runs *after* `~/.zshenv`, so mise's shims get demoted behind `/usr/bin` in any login shell. The durable fix is the shims line in `~/.zprofile` (see simple-setup.md); `.buttercut_env` records a working absolute invocation to use in the meantime.
+
+When shelling out to Ruby from Ruby, use `RbConfig.ruby`, never a bare `'ruby'` — the latter re-resolves through `PATH` and can land the child process back on 2.6.
 
 ## Claude Skills
 

--- a/lib/buttercut/backup_libraries.rb
+++ b/lib/buttercut/backup_libraries.rb
@@ -7,6 +7,8 @@
 # accelerated on Apple Silicon, Finder handles double-click extract. Falls
 # back to system zip otherwise.
 
+require_relative 'boot'
+
 require 'fileutils'
 require 'optparse'
 require 'time'

--- a/lib/buttercut/boot.rb
+++ b/lib/buttercut/boot.rb
@@ -1,0 +1,197 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Ruby-version gate for every script the skills invoke directly.
+#
+# THIS FILE MUST STAY PARSEABLE BY macOS SYSTEM RUBY (2.6). No endless method
+# definitions (`def x = y`), no pattern matching, no argument forwarding (`...`),
+# nothing else 3.x-only. Same rule applies to the entry-point files that require
+# it — see spec/buttercut/boot_spec.rb, which enforces both halves.
+#
+# Why the rule exists: Ruby parses an entire file before running line 1, so a
+# version check written inside a file that itself uses 3.x syntax never gets to
+# run. You get ~60 lines of `syntax error, unexpected '='` instead, which reads
+# like a corrupt checkout. The check only works from a file the old parser can
+# still read, which is what this one is.
+#
+# Why it re-execs instead of just complaining: on macOS this misfires even when
+# the machine is set up correctly. `/etc/zprofile` runs `path_helper`, which
+# rebuilds PATH with the system directories first — and it runs AFTER
+# `~/.zshenv`, so mise's shims get demoted behind `/usr/bin` in any login shell.
+# `ruby` is then 2.6 no matter what the setup skill wrote. Rather than hand that
+# problem to the caller, find the real interpreter and hand off to it.
+
+class ButterCut
+  module Boot
+    MINIMUM_RUBY = '3.0'
+
+    # Set on the child before exec so a mis-resolving interpreter can't put us
+    # in a re-exec loop: second time through we abort with a message instead.
+    REEXEC_FLAG = 'BUTTERCUT_REEXEC'
+
+    REPO_ROOT = File.expand_path('../..', __dir__)
+
+    def self.ruby_ok?
+      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(MINIMUM_RUBY)
+    end
+
+    # Where mise puts the interpreters it installs. Globbed as a last resort
+    # because these paths reach a Ruby directly: no mise binary, no config
+    # resolution, and no trust prompt. `mise exec` refuses to run at all in a
+    # checkout that hasn't been `mise trust`ed, which is exactly the kind of
+    # half-configured machine that lands here in the first place.
+    MISE_INSTALLS = '~/.local/share/mise/installs/ruby/*/bin/ruby'
+
+    # Candidate ways to reach a Ruby 3, best first. The `ruby = ...` line in
+    # .buttercut_env is what the setup skill recorded for this machine, so it
+    # wins. `mise exec` comes next because it honours the version pinned in
+    # .mise.toml. The bare interpreters are the backstop.
+    def self.candidates
+      recorded = recorded_ruby
+      list = []
+      list << recorded if recorded
+      list << [File.expand_path('~/.local/bin/mise'), 'exec', '--', 'ruby']
+      list << ['mise', 'exec', '--', 'ruby']
+      list + installed_rubies
+    end
+
+    # Newest first, so a machine carrying several installs gets the best one.
+    # The `3.3`/`3`/`latest` aliases mise keeps alongside real versions are
+    # symlinks to the same interpreters, so duplicates here are harmless.
+    def self.installed_rubies
+      paths = Dir.glob(File.expand_path(MISE_INSTALLS))
+      paths.sort_by { |path| version_key(path) }.reverse.map { |path| [path] }
+    end
+
+    # `.../installs/ruby/3.3.6/bin/ruby` sorts above `.../ruby/3.3/bin/ruby`,
+    # and the non-numeric aliases (`latest`) sort last rather than raising.
+    def self.version_key(path)
+      dirname = path[%r{/ruby/([^/]+)/bin/ruby\z}, 1].to_s
+      return Gem::Version.new('0') unless dirname =~ /\A\d+(\.\d+)*\z/
+
+      Gem::Version.new(dirname)
+    end
+
+    def self.recorded_ruby
+      path = File.join(REPO_ROOT, '.buttercut_env')
+      return nil unless File.file?(path)
+
+      line = File.readlines(path).find { |l| l =~ /\A\s*ruby\s*=/ }
+      return nil if line.nil?
+
+      argv = line.split('=', 2).last.to_s.strip.split(/\s+/)
+      argv.empty? ? nil : argv
+    end
+
+    # Ask a candidate where its interpreter actually lives, and how old it is.
+    #
+    # The recorded invocation is usually `mise exec -- ruby`, which picks its
+    # version from the .mise.toml nearest the WORKING DIRECTORY — run it from
+    # somewhere outside the checkout and it happily hands back the same 2.6 we
+    # are trying to escape. So the probe runs with cwd pinned to the repo root.
+    # Pinning the probe rather than the real exec is deliberate: we want an
+    # absolute interpreter path, which is cwd-independent, so the script itself
+    # still runs in the caller's directory and relative path arguments survive.
+    def self.probe(argv)
+      # Required here, not at the top: this file loads on every single CLI
+      # invocation, and open3 is only needed on the path where something is
+      # already wrong.
+      require 'open3'
+
+      out, err, status = Open3.capture3(*argv, '-e', 'print RbConfig.ruby, " ", RUBY_VERSION',
+                                       chdir: REPO_ROOT)
+      unless status.success?
+        note_failure(argv, err)
+        return nil
+      end
+
+      path, version = out.split(' ', 2)
+      return nil if path.nil? || version.nil? || path.empty?
+      return nil unless File.executable?(path)
+      return nil if Gem::Version.new(version.strip) < Gem::Version.new(MINIMUM_RUBY)
+
+      path
+    rescue StandardError => e
+      # Candidate isn't installed, isn't executable, or died. Try the next one.
+      note_failure(argv, e.message)
+      nil
+    end
+
+    # Keep why each candidate was rejected. A candidate can fail for a reason
+    # the caller can act on — an untrusted .mise.toml is the common one — and
+    # "no Ruby found" on its own sends people hunting in the wrong place.
+    def self.failures
+      @failures ||= []
+    end
+
+    def self.note_failure(argv, message)
+      text = message.to_s.strip
+      failures << [argv.join(' '), text] unless text.empty?
+    end
+
+    def self.resolve
+      candidates.each do |argv|
+        found = probe(argv)
+        return found if found
+      end
+      nil
+    end
+
+    def self.reexec!
+      target = resolve
+      abort(failure_message) if target.nil?
+
+      ENV[REEXEC_FLAG] = '1'
+      exec(target, $PROGRAM_NAME, *ARGV)
+    end
+
+    def self.failure_message
+      <<~MESSAGE
+        buttercut: needs Ruby #{MINIMUM_RUBY}+, but this shell is running #{RUBY_VERSION} (#{RbConfig.ruby})
+        and no Ruby #{MINIMUM_RUBY}+ could be found to hand off to.
+
+        This is a PATH/setup problem, not a bad checkout — re-cloning will not help.
+        #{tried_section}
+        To fix it, run the setup skill, or add mise's shims to ~/.zprofile:
+
+          eval "$(mise activate --shims zsh)"
+
+        ~/.zprofile is the file that matters on macOS: /etc/zprofile runs
+        path_helper, which demotes anything ~/.zshenv prepended behind /usr/bin.
+      MESSAGE
+    end
+
+    def self.tried_section
+      return '' if failures.empty?
+
+      lines = failures.map { |command, message| "  #{command}\n#{indent(salient_lines(message))}" }
+      "\nTried:\n#{lines.join("\n")}\n"
+    end
+
+    # Tools are chatty on the way down. mise in particular leads with `[WARN]`
+    # noise and puts the line that actually tells you what to do ("... are not
+    # trusted. Trust them with `mise trust`") further along, so skipping
+    # warnings is what makes this section worth printing.
+    def self.salient_lines(message, limit = 2)
+      all = message.to_s.lines.map(&:strip).reject(&:empty?)
+      meaty = all.reject { |line| line =~ /\A(\[?WARN|mise WARN)/i }
+      (meaty.empty? ? all : meaty).first(limit)
+    end
+
+    def self.indent(lines)
+      lines.map { |line| "    #{line}" }.join("\n")
+    end
+
+    def self.call
+      return if ruby_ok?
+
+      if ENV[REEXEC_FLAG]
+        abort(failure_message)
+      else
+        reexec!
+      end
+    end
+  end
+end
+
+ButterCut::Boot.call

--- a/lib/buttercut/contact_sheet.rb
+++ b/lib/buttercut/contact_sheet.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require_relative 'boot'
+
 require 'English'
 require 'json'
 require 'optparse'

--- a/lib/buttercut/export.rb
+++ b/lib/buttercut/export.rb
@@ -4,6 +4,8 @@
 # Edition shim plus the shared CLI entrypoint. Loads the single-track (core) or
 # multi-track (pro) exporter via ButterCut.engine_variant — see
 # lib/buttercut/version.rb.
+require_relative 'boot'
+
 require 'optparse'
 require_relative 'version'
 require_relative ButterCut.engine_variant('export')

--- a/lib/buttercut/full_transcript.rb
+++ b/lib/buttercut/full_transcript.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require_relative 'boot'
+
 require 'date'
 require 'json'
 require 'yaml'

--- a/lib/buttercut/library.rb
+++ b/lib/buttercut/library.rb
@@ -4,6 +4,8 @@
 # `Library` handle for reading and writing library.yaml. See README.md in
 # this directory for the Ruby and shell API reference and usage rules.
 
+require_relative 'boot'
+
 require 'date'
 require 'English'
 require 'fileutils'
@@ -64,7 +66,9 @@ class Library
     'transcript_refinement' => nil
   }.freeze
 
-  def self.find(library_name) = new(library_name)
+  def self.find(library_name)
+    new(library_name)
+  end
 
   def self.exists?(library_name)
     return false if library_name.to_s.strip.empty?
@@ -172,7 +176,9 @@ class Library
   # The basename used everywhere to refer to a clip. Derived from the full
   # `path` and never stored in library.yaml — one owner so reads, lookups, and
   # the `media` reader all agree on what a clip is called.
-  def self.filename_of(media) = File.basename(media['path'].to_s)
+  def self.filename_of(media)
+    File.basename(media['path'].to_s)
+  end
 
   # The key artifact filenames are built from. Videos keep the original
   # convention (extension stripped, matching every existing artifact on disk).
@@ -250,7 +256,9 @@ class Library
     raise ArgumentError, "library.yaml not found in #{@library_dir}" unless File.exist?(@library_yaml_path)
   end
 
-  def dir = @library_dir
+  def dir
+    @library_dir
+  end
 
   # Canonical on-disk path for one clip's artifact in a given field — the single
   # owner of the per-field filename convention (e.g. summary → `summaries/
@@ -448,12 +456,28 @@ class Library
   # extensions already in the yaml read as video). The merge returns copies,
   # so the convenience keys never reach the write path — mutations load and
   # persist via `load_library` directly.
-  def media = merged_media(load_library)
-  def language = load_library['language']
-  def transcript_refinement = load_library['transcript_refinement']
-  def user_context = load_library['user_context'].to_s
-  def footage_summary = load_library['footage_summary'].to_s
-  def editor = load_library['editor']
+  def media
+    merged_media(load_library)
+  end
+
+  def language
+    load_library['language']
+  end
+
+  def transcript_refinement
+    load_library['transcript_refinement']
+  end
+
+  def user_context
+    load_library['user_context'].to_s
+  end
+
+  def footage_summary
+    load_library['footage_summary'].to_s
+  end
+  def editor
+    load_library['editor']
+  end
 
   # Update any subset of the editable metadata fields. Omitted (nil) fields are
   # left alone; pass `''` to clear a string field. `transcript_refinement` takes
@@ -493,7 +517,9 @@ class Library
     meds.all? { |m| artifacts_ready?(m) }
   end
 
-  def incomplete_media = incomplete_from(media)
+  def incomplete_media
+    incomplete_from(media)
+  end
 
   # Clips still missing one specific artifact, as records the JobRunner can turn
   # straight into jobs. Unlike `incomplete_media` (missing ANY applicable
@@ -513,7 +539,9 @@ class Library
   # Every clip as a job-ready record, in the same shape as `pending` but
   # unfiltered. FootageProcessor's --force path uses this to rebuild artifacts
   # that already exist; keeping it here means the record shape has one owner.
-  def clip_records = media.map { |m| clip_record(m) }
+  def clip_records
+    media.map { |m| clip_record(m) }
+  end
 
   # Per-clip artifact status for the live "follow along" view: every clip with
   # a boolean per applicable field. Read-only, so it's safe to poll from a
@@ -561,14 +589,22 @@ class Library
     FIELDS.fetch(field.to_s) { raise ArgumentError, "unknown field: #{field.inspect}" }
   end
 
-  def present?(value) = !(value.nil? || value.to_s.strip.empty?)
+  def present?(value)
+    !(value.nil? || value.to_s.strip.empty?)
+  end
 
-  def pluralize(count, word) = "#{word}#{'s' unless count == 1}"
+  def pluralize(count, word)
+    "#{word}#{'s' unless count == 1}"
+  end
 
   # Segment-boundary match: `/a/b` matches `/a/b` and `/a/b/…`, never `/a/bc`.
-  def under_prefix?(path, prefix) = path == prefix || path.to_s.start_with?("#{prefix}/")
+  def under_prefix?(path, prefix)
+    path == prefix || path.to_s.start_with?("#{prefix}/")
+  end
 
-  def rewrite_prefix(path, old, new) = path == old ? new : new + path[old.length..]
+  def rewrite_prefix(path, old, new)
+    path == old ? new : new + path[old.length..]
+  end
 
   def merged_media(data)
     data['media'].map do |m|
@@ -808,7 +844,10 @@ if __FILE__ == $PROGRAM_NAME
   if ARGV.first == 'migrate' && ARGV.size == 1
     migrate_script = File.expand_path('../../scripts/migrate_all.rb', __dir__)
     repo_root = Library::REPO_ROOT
-    exec('ruby', migrate_script, chdir: repo_root)
+    # RbConfig.ruby, not 'ruby': the interpreter we're running under is known to
+    # be new enough (boot.rb saw to that), while a bare 'ruby' would go back
+    # through PATH and can land on system 2.6 all over again.
+    exec(RbConfig.ruby, migrate_script, chdir: repo_root)
   end
 
   library_name, action, *rest = ARGV

--- a/lib/buttercut/process_footage.rb
+++ b/lib/buttercut/process_footage.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require_relative 'boot'
+
 require 'optparse'
 require_relative 'footage_processor'
 require_relative 'run_log'

--- a/lib/buttercut/script_extractor.rb
+++ b/lib/buttercut/script_extractor.rb
@@ -12,6 +12,8 @@
 #   ruby script_extractor.rb <audio_transcript.json>            # → stdout
 #   ruby script_extractor.rb <audio_transcript.json> > out.txt  # → file
 
+require_relative 'boot'
+
 require 'json'
 
 class ScriptExtractor

--- a/lib/buttercut/transcribe_job.rb
+++ b/lib/buttercut/transcribe_job.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require_relative 'boot'
+
 require 'English'
 require 'fileutils'
 require 'json'
@@ -17,7 +19,9 @@ require_relative 'media_tools'
 # deliberately NOT here. That step is judgment, not mechanics, so it stays a
 # Claude step that runs after these jobs finish — see analyze-video/SKILL.md.
 class TranscribeJob < Job
-  def self.field = 'transcript'
+  def self.field
+    'transcript'
+  end
 
   PREPARE_SCRIPT = File.expand_path('prepare_audio_script.rb', __dir__)
 
@@ -86,7 +90,9 @@ class TranscribeJob < Job
     json = File.join(@output_dir, "#{File.basename(@video_path, '.*')}.json")
     raise "whisperx produced no transcript at #{json}" unless File.exist?(json)
 
-    ok = system('ruby', PREPARE_SCRIPT, json, @video_path)
+    # RbConfig.ruby rather than a bare 'ruby' — see the note in library.rb's
+    # migrate dispatch. PATH may still lead to system 2.6.
+    ok = system(RbConfig.ruby, PREPARE_SCRIPT, json, @video_path)
     raise "prepare_audio_script failed for #{clip}" unless ok
   end
 end

--- a/scripts/migrate_all.rb
+++ b/scripts/migrate_all.rb
@@ -25,7 +25,10 @@ failed = []
 MIGRATIONS.each do |script|
   name = File.basename(script)
   puts "=== #{name} ==="
-  system('ruby', script, '--all')
+  # RbConfig.ruby keeps every migration on the interpreter this script is
+  # already running under. A bare 'ruby' re-resolves through PATH, which on a
+  # half-configured Mac means system 2.6 and a wall of syntax errors.
+  system(RbConfig.ruby, script, '--all')
   failed << name unless $?.success?
   puts
 end

--- a/skills/setup/simple-setup.md
+++ b/skills/setup/simple-setup.md
@@ -90,13 +90,22 @@ mise --version
 brew upgrade mise   # run if version is older than 2025.12.4
 ```
 
-Activate mise in shell profile. This happens in **two** files on purpose:
-interactive shells (a human at a prompt) read `~/.zshrc`, but non-interactive
-shells — how agentic clients like Claude Code and Codex shell out to run
-commands — read only `~/.zshenv`. If mise is activated only in `~/.zshrc`, then
-in an agent session `ruby`/`python` fall through to the macOS system versions
-and ButterCut's Ruby 3 scripts fail to parse under system Ruby 2.6. So we also
-put mise's PATH shims in `~/.zshenv`, which every zsh reads.
+Activate mise in shell profile. This happens in **three** files on purpose, and
+all three are load-order decisions:
+
+- `~/.zshrc` — interactive shells (a human at a prompt).
+- `~/.zshenv` — the one file *every* zsh reads, including the non-interactive
+  ones agentic clients like Claude Code and Codex use to shell out.
+- `~/.zprofile` — login shells. This one is not redundant. macOS ships an
+  `/etc/zprofile` that runs `path_helper`, which **rebuilds `PATH` with the
+  system directories first**, and it runs *after* `~/.zshenv`. So anything
+  `~/.zshenv` prepended gets demoted behind `/usr/bin` — `ruby` becomes system
+  Ruby 2.6 again in any login shell, on a machine that otherwise looks
+  correctly configured. `~/.zprofile` is read after `/etc/zprofile`, so it is
+  the one that sticks.
+
+Without all three, `ruby`/`python` fall through to the macOS system versions and
+ButterCut's Ruby 3 scripts fail to parse under system Ruby 2.6.
 
 ```bash
 # Detect shell and add mise activation
@@ -105,6 +114,8 @@ if [[ "$SHELL" == *"zsh"* ]]; then
   grep -q 'mise activate' ~/.zshrc 2>/dev/null || echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
   # Non-interactive (agentic clients): shims in ~/.zshenv, the one file every zsh reads
   grep -q 'mise activate --shims' ~/.zshenv 2>/dev/null || echo 'eval "$(mise activate --shims zsh)"' >> ~/.zshenv
+  # Login shells: re-prepend AFTER /etc/zprofile's path_helper has reordered PATH
+  grep -q 'mise activate --shims' ~/.zprofile 2>/dev/null || echo 'eval "$(mise activate --shims zsh)"' >> ~/.zprofile
   eval "$(mise activate zsh)"
 elif [[ "$SHELL" == *"bash"* ]]; then
   grep -q 'mise activate' ~/.bash_profile 2>/dev/null || echo 'eval "$(mise activate bash)"' >> ~/.bash_profile
@@ -129,20 +140,28 @@ mise install
 
 Mise downloads precompiled Ruby and Python binaries (configured in `.mise.toml`), so this typically finishes in under a minute. If a precompiled binary isn't available for the pinned version, mise falls back to building from source, which can take 5-10 minutes.
 
-Verify versions in a **fresh non-interactive shell** — the same way agentic
-clients invoke tools — so the check catches a PATH that only works at an
-interactive prompt (the failure mode Step 3's `~/.zshenv` activation prevents).
-Verifying in the current already-activated shell would report success while real
-agent commands stayed broken.
+Verify versions in **fresh shells of both kinds**, not in the current
+already-activated one — that would report success while real agent commands
+stayed broken. Two checks, because the two failure modes are different:
+`-c` is the non-interactive shell an agentic client uses (covered by
+`~/.zshenv`), and `-l -c` is a login shell, where `/etc/zprofile`'s
+`path_helper` demotes the shims unless `~/.zprofile` puts them back. A machine
+can pass the first and fail the second.
 
 ```bash
-"$SHELL" -c 'ruby --version'    # Should show 3.3.6
-"$SHELL" -c 'python3 --version' # Should show 3.12.8
+"$SHELL" -c 'ruby --version'       # Should show 3.3.6
+"$SHELL" -c 'python3 --version'    # Should show 3.12.8
+"$SHELL" -l -c 'ruby --version'    # Should ALSO show 3.3.6, not 2.6.x
+"$SHELL" -l -c 'python3 --version' # Should ALSO show 3.12.8
 ```
 
-If either prints a system version (Ruby 2.6.x, Python 2.7.x) or "command not
-found", mise activation didn't reach non-interactive shells — recheck that the
-`--shims` line landed in `~/.zshenv`.
+If a login shell still reports 2.6, check that the `~/.zprofile` line from Step 3
+landed, and that nothing later in `~/.zprofile` or `~/.zshrc` re-runs
+`path_helper`.
+
+If any of them prints a system version (Ruby 2.6.x, Python 2.7.x) or "command
+not found", mise activation didn't reach that kind of shell — recheck that the
+`--shims` line landed in **both** `~/.zshenv` and `~/.zprofile`.
 
 ## Step 5: FFmpeg (full build with drawtext)
 

--- a/spec/buttercut/boot_spec.rb
+++ b/spec/buttercut/boot_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+# spec_helper loads lib/buttercut.rb, which pulls in the exporters but not the
+# CLI entry points, so the gate's own constants need requiring here.
+require_relative '../../lib/buttercut/boot'
+
+# The Ruby-version gate only works if the file carrying it can be parsed by the
+# old interpreter that trips the problem. That makes "entry points stay
+# 2.6-parseable, and require boot.rb first" a real invariant, easy to break by
+# writing a perfectly ordinary endless method in the wrong file. These specs are
+# the tripwire.
+RSpec.describe 'boot gate' do
+  REPO_ROOT = File.expand_path('../..', __dir__)
+  SYSTEM_RUBY = '/usr/bin/ruby'
+
+  # Derived from the docs rather than hardcoded: a file is an entry point
+  # exactly when we tell people (or agents) to run it with `ruby <path>`. Add a
+  # documented invocation and it is covered here automatically.
+  def self.documented_entry_points
+    sources = Dir[File.join(REPO_ROOT, 'skills', '**', '*.md')] +
+              [File.join(REPO_ROOT, 'AGENTS.md')]
+    # Explicit encoding: the docs are full of em-dashes, and a shell with no
+    # LANG set would otherwise read them as US-ASCII and blow up on scan.
+    sources.flat_map { |file| File.read(file, encoding: 'UTF-8').scan(%r{\bruby (lib/buttercut/[a-z_0-9]+\.rb)}) }
+           .flatten
+           .uniq
+           .sort
+  end
+
+  ENTRY_POINTS = documented_entry_points
+
+  it 'finds the documented entry points' do
+    # Guards the derivation itself: a bad regex would silently make every
+    # example below vacuous.
+    expect(ENTRY_POINTS).to include('lib/buttercut/library.rb')
+    expect(ENTRY_POINTS.size).to be >= 8
+  end
+
+  describe 'each documented entry point' do
+    ENTRY_POINTS.each do |relative_path|
+      context relative_path do
+        let(:full_path) { File.join(REPO_ROOT, relative_path) }
+        let(:source) { File.read(full_path, encoding: 'UTF-8') }
+
+        it 'exists' do
+          expect(File).to exist(full_path)
+        end
+
+        it 'requires boot before anything else in the project' do
+          first_local_require = source[/^require_relative .*$/]
+          expect(first_local_require).to eq("require_relative 'boot'")
+        end
+
+        # The actual property we care about: old Ruby can read the file far
+        # enough to run the gate. Skipped rather than failed off-macOS so the
+        # suite stays portable.
+        it 'parses under system Ruby 2.6' do
+          skip "#{SYSTEM_RUBY} not present" unless File.executable?(SYSTEM_RUBY)
+
+          _out, err, status = Open3.capture3(SYSTEM_RUBY, '-c', full_path, chdir: REPO_ROOT)
+          expect(status).to be_success, "#{relative_path} is not parseable by system Ruby:\n#{err}"
+        end
+      end
+    end
+  end
+
+  describe 'boot.rb itself' do
+    let(:full_path) { File.join(REPO_ROOT, 'lib/buttercut/boot.rb') }
+
+    # rspec runs under `bundle exec`, which exports RUBYOPT=-rbundler/setup.
+    # Handing that to system Ruby makes 2.6 try to load the 3.3 bundler and die
+    # before the gate gets a turn. Skills invoke these scripts as plain `ruby
+    # <path>` with no bundler in sight, so clearing it is also the honest
+    # reproduction of how they actually run.
+    def unbundled(extra = {})
+      cleared = ENV.keys.grep(/\A(RUBYOPT|RUBYLIB|BUNDLE_|GEM_)/).each_with_object({}) do |key, env|
+        env[key] = nil
+      end
+      cleared.merge(extra)
+    end
+
+    it 'parses under system Ruby 2.6' do
+      skip "#{SYSTEM_RUBY} not present" unless File.executable?(SYSTEM_RUBY)
+
+      _out, err, status = Open3.capture3(SYSTEM_RUBY, '-c', full_path, chdir: REPO_ROOT)
+      expect(status).to be_success, "boot.rb must stay 2.6-parseable:\n#{err}"
+    end
+
+    it 'hands a too-old interpreter off to a current one' do
+      skip "#{SYSTEM_RUBY} not present" unless File.executable?(SYSTEM_RUBY)
+
+      script = File.join(REPO_ROOT, 'spec', 'fixtures', 'boot_probe.rb')
+      out, err, status = Open3.capture3(unbundled, SYSTEM_RUBY, script, 'alpha', 'beta', chdir: REPO_ROOT)
+
+      expect(status).to be_success, "re-exec failed:\n#{err}"
+      version, args = out.strip.split(' ', 2)
+      expect(Gem::Version.new(version)).to be >= Gem::Version.new(ButterCut::Boot::MINIMUM_RUBY)
+      expect(args).to eq('alpha beta')
+    end
+
+    it 'does not re-exec a second time' do
+      # Belt and braces on the loop guard: with the flag already set, an old
+      # interpreter must fail loudly instead of spawning itself forever.
+      skip "#{SYSTEM_RUBY} not present" unless File.executable?(SYSTEM_RUBY)
+
+      script = File.join(REPO_ROOT, 'spec', 'fixtures', 'boot_probe.rb')
+      env = unbundled(ButterCut::Boot::REEXEC_FLAG => '1')
+      _out, err, status = Open3.capture3(env, SYSTEM_RUBY, script, chdir: REPO_ROOT)
+
+      expect(status).not_to be_success
+      expect(err).to include('needs Ruby')
+      expect(err).to include('not a bad checkout')
+    end
+  end
+end

--- a/spec/buttercut/library_spec.rb
+++ b/spec/buttercut/library_spec.rb
@@ -1203,7 +1203,7 @@ RSpec.describe Library do
       FileUtils.mkdir_p(lib_dir)
       File.write(File.join(lib_dir, 'library.yaml'), { 'media' => [] }.to_yaml)
 
-      out = `ruby #{Shellwords.escape(cli)} cli-relink-arity-spec relink /Volumes/Andrew SSD /Volumes/Other 2>&1`
+      out = `#{Shellwords.escape(RbConfig.ruby)} #{Shellwords.escape(cli)} cli-relink-arity-spec relink /Volumes/Andrew SSD /Volumes/Other 2>&1`
 
       expect($CHILD_STATUS.exitstatus).to eq(1)
       expect(out).to include('quote prefixes containing spaces')
@@ -1217,7 +1217,7 @@ RSpec.describe Library do
     # byte-identical across the core and pro editions.
     it 'prints ButterCut::EDITION and exits 0' do
       cli = File.expand_path('../../lib/buttercut/library.rb', __dir__)
-      out = `ruby #{Shellwords.escape(cli)} edition`
+      out = `#{Shellwords.escape(RbConfig.ruby)} #{Shellwords.escape(cli)} edition`
       expect($CHILD_STATUS.exitstatus).to eq(0)
       expect(out.strip).to eq(ButterCut::EDITION.to_s)
     end

--- a/spec/fixtures/boot_probe.rb
+++ b/spec/fixtures/boot_probe.rb
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Fixture for boot_spec: a minimal entry point. Launched with system Ruby it
+# should come back running a current one, with its arguments intact. Kept
+# 2.6-parseable for the same reason the real entry points are.
+
+require_relative '../../lib/buttercut/boot'
+
+print RUBY_VERSION, ' ', ARGV.join(' ')

--- a/spec/migrations_spec.rb
+++ b/spec/migrations_spec.rb
@@ -787,10 +787,13 @@ RSpec.describe 'Migration scripts' do
   describe 'migrate_all' do
     let(:script_path) { File.expand_path('../scripts/migrate_all.rb', __dir__) }
     let(:repo_root) { File.expand_path('..', __dir__) }
+    # Not a bare `ruby`: PATH can lead to macOS system Ruby 2.6, which cannot
+    # parse this codebase. RbConfig.ruby is the interpreter running the suite.
+    let(:ruby) { Shellwords.escape(RbConfig.ruby) }
 
     it 'runs all numbered migration scripts in order' do
       Dir.chdir(repo_root) do
-        output = `ruby #{script_path} 2>&1`
+        output = `#{ruby} #{script_path} 2>&1`
         expect($?.success?).to be(true), "migrate_all.rb failed:\n#{output}"
         expect(output).to include('001_migrate_0.2_to_0.3.rb')
         expect(output).to include('002_migrate_add_transcript_refinement.rb')
@@ -802,7 +805,7 @@ RSpec.describe 'Migration scripts' do
 
     it 'runs scripts in numeric order' do
       Dir.chdir(repo_root) do
-        output = `ruby #{script_path} 2>&1`
+        output = `#{ruby} #{script_path} 2>&1`
         positions = %w[001 002 003 004 005].map { |n| output.index(n) }
         expect(positions).to eq(positions.sort)
       end
@@ -820,7 +823,7 @@ RSpec.describe 'Migration scripts' do
         FileUtils.cp(File.join(repo_root, 'scripts', 'migrate_all.rb'), File.join(tmpdir, 'scripts'))
 
         Dir.chdir(tmpdir) do
-          output = `ruby scripts/migrate_all.rb 2>&1`
+          output = `#{ruby} scripts/migrate_all.rb 2>&1`
           expect($?.success?).to be(true), "migrate_all.rb failed with no libraries:\n#{output}"
         end
       end


### PR DESCRIPTION
> **Work in progress** — paused mid-review, not ready to merge. See "Remaining" below.

## Problem

When the shell hands ButterCut macOS system Ruby (2.6), `library.rb` emits ~64 lines of:

```
lib/buttercut/library.rb:67: syntax error, unexpected '='
  def self.find(library_name) = new(library_name)
```

That reads like a corrupt checkout, so the natural next move is to re-clone — which does not help, because the cause is PATH (endless method defs need Ruby 3.0+).

This branch started as a doc note for that symptom. Review turned up two problems with stopping there:

1. **The documented cause was wrong.** The note said "mise never reached this shell." On a correctly set-up Mac mise *does* reach the shell — `/etc/zprofile` runs `path_helper`, which rebuilds `PATH` with the system directories first, and it runs *after* `~/.zshenv`. The shims get demoted behind `/usr/bin` in any login shell. Measured: shims at PATH position 1 in a non-interactive shell, position 13 (behind `/usr/bin` at 5) in a login shell. So an agent following the note would recheck `~/.zshenv`, find the line already there, and be stuck.
2. **A doc fix is probabilistic.** It only works if the agent has `AGENTS.md` loaded and connects symptom to cause. A deterministic fix exists.

## Fix, in three layers

**Root cause** — the setup skill writes the shims line to `~/.zprofile` as well (read *after* `/etc/zprofile`, so it sticks). Its verification step now runs `-l -c` as well as `-c`; the old check only exercised the shell type that already worked, so a broken machine passed it.

**Deterministic backstop** — `lib/buttercut/boot.rb` checks `RUBY_VERSION` and, when it's too old, resolves a real Ruby 3 and re-execs. The failure disappears rather than becoming legible, for every agent including ones that never read `AGENTS.md`.

The guard cannot live inside `library.rb`: Ruby parses a whole file before running line 1, so a check in a file that itself uses 3.x syntax never runs. Hence the invariant, enforced by `spec/buttercut/boot_spec.rb`:

- entry points stay 2.6-parseable (so `library.rb`'s 15 and `transcribe_job.rb`'s 1 endless defs are de-sugared) — the files they *require* can use anything;
- `require_relative 'boot'` comes before any other project require.

The spec derives the entry-point list from the documented `ruby lib/buttercut/*.rb` invocations in `skills/` and `AGENTS.md`, so a newly documented script is covered automatically. Resolution order is `.buttercut_env` → `mise exec` → mise's installed interpreters (the last tier needs no mise binary, no config resolution, and no `mise trust`, which is exactly the half-configured case that lands here). When nothing works it aborts with the candidates it tried and why — an untrusted `.mise.toml` is common, and "no Ruby found" alone sends people hunting in the wrong place.

**The doc note, with the cause corrected** — for the residual cases.

Plus: bare `'ruby'` shell-outs replaced with `RbConfig.ruby` (`library.rb` migrate dispatch, `transcribe_job`, `migrate_all`, two spec files) so child processes can't drop back to 2.6.

## Verification

- The exact failing command, launched with `/usr/bin/ruby`: 64 error lines before, prints usage after.
- Suite: 383 examples / 77 failures before → 411 / 73 after. Failure sets diffed — 4 fixed, 0 newly broken, 28 added. The remaining 73 are pre-existing and unrelated (no `ffprobe` in this checkout).

## Remaining

- [ ] Port to buttercut-pro. `simple-setup.md` there has none of the `~/.zshenv` content from 1ca10e6, so the note's "see simple-setup.md" currently points at a section that doesn't exist in Pro. Pro also has a `cut_sheet.rb` entry point (4 endless defs) needing the same treatment.
- [ ] Rename the branch, or land as two commits — `docs-ruby-version-breadcrumb` no longer describes this.
- [ ] Decide whether `boot.rb` should scrub `RUBYOPT` before re-exec. Under `bundle exec`, an inherited `RUBYOPT=-rbundler/setup` makes 2.6 load the Ruby 3 bundler and die before the gate runs. The specs work around it; skills invoke plain `ruby` so they never hit it.
