### PR TITLE
core: Read the timecode track when ffprobe won't format it

### DIFF
--- a/lib/buttercut/editor_base_core.rb
+++ b/lib/buttercut/editor_base_core.rb
@@ -161,9 +161,50 @@ class ButterCut
       nil
     end
 
+    # The QuickTime timecode track ('tmcd'), when the clip carries one. Its
+    # single sample is the start frame number, which is the same value ffprobe
+    # formats into the `timecode` tag — so this only matters when that tag is
+    # missing.
+    def timecode_track(video_path)
+      streams = extract_metadata(video_path)['streams'] or return nil
+
+      streams.find { |stream| stream['codec_tag_string'] == 'tmcd' }
+    end
+
+    # Start frame number read straight out of the timecode track, or nil if it
+    # can't be read.
+    #
+    # Some cameras — Final Cut Camera among them — write a timecode track whose
+    # drop-frame flag is invalid for the clip's frame rate (24 fps footage
+    # flagged DF). ffprobe refuses to format that into a timecode string, so the
+    # `timecode` tag is absent even though the track itself is intact: a 32-bit
+    # big-endian frame number. ffprobe still reports where that sample lives, so
+    # read the four bytes directly.
+    def timecode_track_frames(video_path)
+      stream = timecode_track(video_path) or return nil
+
+      command = "#{Shellwords.escape(MediaTools.ffprobe)} -v error " \
+                "-select_streams #{stream['index'].to_i} -show_packets -of json " \
+                "#{Shellwords.escape(video_path)} 2>/dev/null"
+      output = `#{command}`
+      return nil unless $?.exitstatus.zero?
+
+      packet = JSON.parse(output)['packets']&.first or return nil
+      position = packet['pos']&.to_i
+      size = packet['size']&.to_i
+      return nil if position.nil? || size.nil? || size < 4
+
+      bytes = File.binread(video_path, 4, position)
+      return nil unless bytes&.bytesize == 4
+
+      bytes.unpack1('N')
+    rescue JSON::ParserError, SystemCallError, IOError
+      nil
+    end
+
     def clip_timecode_fraction(video_path)
       timecode = clip_timecode_string(video_path)
-      return "0s" if timecode.nil? || timecode.strip.empty?
+      return timecode_track_fraction(video_path) if timecode.nil? || timecode.strip.empty?
 
       parts = timecode.strip.tr(';', ':').split(':').map(&:to_i)
       return "0s" unless parts.length == 4
@@ -186,13 +227,42 @@ class ButterCut
         ((hours * 3600 + minutes * 60 + seconds) * fps_nominal) + frames
       end
 
+      frames_to_fraction(total_frames, video_path)
+    end
+
+    # A whole number of start frames against the clip's real frame rate:
+    # 1697293 frames of 24/1 footage is 1697293/24s, the exact value Final Cut
+    # writes for the same clip.
+    def frames_to_fraction(total_frames, video_path)
       return "0s" if total_frames.negative?
+
+      rate_num, rate_denom = frame_rate(video_path).split('/').map(&:to_i)
+      return "0s" if rate_denom.zero? || rate_num.zero?
 
       start_num = total_frames * rate_denom
       start_denom = rate_num
 
       divisor = gcd(start_num, start_denom)
       "#{start_num / divisor}/#{start_denom / divisor}s"
+    end
+
+    # Start timecode for a clip whose timecode track ffprobe wouldn't format
+    # into a string. No track at all means the clip really does start at zero.
+    # A track we can't read must NOT collapse to zero: that anchors the asset
+    # away from its own media, and Final Cut then rejects every edit against it
+    # as "invalid edit with no respective media" — a broken export that looks
+    # fine until it reaches the editor. Fail here instead.
+    def timecode_track_fraction(video_path)
+      return "0s" if timecode_track(video_path).nil?
+
+      total_frames = timecode_track_frames(video_path)
+      if total_frames.nil?
+        raise "#{File.basename(video_path)} has a timecode track that could not be read. Exporting it " \
+              'would anchor the clip at 00:00:00:00 and Final Cut would reject every edit against it ' \
+              'as "invalid edit with no respective media".'
+      end
+
+      frames_to_fraction(total_frames, video_path)
     end
 
     # Drop-frame is a frame-NUMBERING scheme in the timecode digits, not a

--- a/spec/buttercut/fcpx_spec.rb
+++ b/spec/buttercut/fcpx_spec.rb
@@ -255,6 +255,67 @@ RSpec.describe ButterCut::FCPX do
         expect(xml).to match(/<asset-clip[^>]*start="298851\/5s"/)
       end
     end
+
+    # The 24 fps Final Cut Camera case: the clip carries a perfectly good
+    # timecode track, but its drop-frame flag is invalid at 24 fps, so ffprobe
+    # refuses to format the tag and reports no timecode at all. Falling back to
+    # "0s" there anchored the asset ~19.6 hours away from its own media, and
+    # Final Cut rejected every edit against it as "invalid edit with no
+    # respective media" (verified against Final Cut Pro's own XML export of the
+    # same clip, which anchors it at 1697293000/24000s).
+    context 'with a timecode track ffprobe cannot format into a string' do
+      let(:tmcd_path) { '/tmp/fcc_24_tmcd.mov' }
+      let(:tmcd_metadata) do
+        metadata = build_metadata(frame_rate: '24/1', duration_seconds: 170.059417)
+        metadata['streams'] << { 'codec_type' => 'data', 'codec_tag_string' => 'tmcd', 'index' => 2 }
+        metadata
+      end
+
+      before do
+        allow_any_instance_of(ButterCut::FCPX).to receive(:extract_metadata_from_ffprobe).and_return(tmcd_metadata)
+      end
+
+      it 'recovers the start frame from the timecode track' do
+        generator = ButterCut::FCPX.new([{ path: tmcd_path }])
+        allow(generator).to receive(:timecode_track_frames).and_return(1_697_293)
+
+        # 1697293 frames ÷ 24 — the exact anchor Final Cut writes for this clip.
+        expect(generator.clip_timecode_fraction(tmcd_path)).to eq('1697293/24s')
+      end
+
+      it 'anchors the asset and asset-clip at the recovered timecode' do
+        generator = ButterCut::FCPX.new([{ path: tmcd_path }])
+        allow(generator).to receive(:timecode_track_frames).and_return(1_697_293)
+        xml = generator.to_xml
+        asset_id = asset_id_for(generator, tmcd_path)
+
+        expect(xml).to match(/<asset id="#{Regexp.escape(asset_id)}"[^>]*start="1697293\/24s"/)
+        expect(xml).to match(/<asset-clip[^>]*start="1697293\/24s"/)
+      end
+
+      it 'refuses to export when the timecode track cannot be read' do
+        generator = ButterCut::FCPX.new([{ path: tmcd_path }])
+        allow(generator).to receive(:timecode_track_frames).and_return(nil)
+
+        expect { generator.clip_timecode_fraction(tmcd_path) }
+          .to raise_error(/timecode track that could not be read/)
+      end
+    end
+
+    context 'with no timecode of any kind' do
+      let(:no_tc_path) { '/tmp/no_timecode.mov' }
+
+      before do
+        allow_any_instance_of(ButterCut::FCPX).to receive(:extract_metadata_from_ffprobe)
+          .and_return(build_metadata(frame_rate: '24/1', duration_seconds: 10.0))
+      end
+
+      it 'starts at zero, because the clip genuinely has no timecode' do
+        generator = ButterCut::FCPX.new([{ path: no_tc_path }])
+
+        expect(generator.clip_timecode_fraction(no_tc_path)).to eq('0s')
+      end
+    end
   end
 
   describe '#generate_uuid' do


### PR DESCRIPTION
## The bug

Final Cut Camera writes 24 fps clips whose timecode track carries a drop-frame flag — invalid at that rate. ffprobe refuses to format such a timecode into a string, so the `timecode` tag is absent even though the track itself is intact.

`clip_timecode_fraction` treated that absence as *"this clip starts at 00:00:00:00"* and anchored the asset there. The media actually starts ~19.6 hours in, so every `asset-clip` referencing it landed outside its own media and Final Cut rejected the lot:

> Invalid edit with no respective media.

This hit **plain single-track cuts** as much as multicam ones — a five-clip cut off a single phone angle failed on all five clips. The export validated against the FCPXML DTD and looked fine right up until it reached the editor.

This is the 24 fps sibling of the 30 fps Final Cut Camera drop-frame case already handled in `drop_frame_timecode?`. There, ffprobe produced a timecode string and the digits needed correcting. Here it produces no string at all.

## The fix

Read the start frame straight out of the timecode track. ffprobe still reports where the sample lives, and it is a 32-bit big-endian frame number.

- `timecode_track` — finds the tmcd stream by `codec_tag_string` (not "first data stream" — DJI clips put proto telemetry there).
- `timecode_track_frames` — reads the packet's `pos`/`size`, then the four bytes.
- `frames_to_fraction` — the frames→fraction math, factored out so both paths share it.
- `timecode_track_fraction` — no track → `0s` (genuinely correct); readable → the real anchor; **track present but unreadable → raises**, rather than silently emitting a wrong anchor.

That last point is the important one: the old behaviour turned an unreadable timecode into a plausible-looking export that no editor would accept. A loud failure at export is strictly better.

## Verification

Checked against Final Cut Pro's own XML export of the same clip, which anchors it at `1697293000/24000s`:

| clip | before | after | FCP's own value |
| --- | --- | --- | --- |
| `IMG_0005.mov` (Final Cut Camera, 24 fps) | `0s` | `1697293/24s` | `1697293000/24000s` |
| `DJI_..._0299_D.MP4` (23.976, readable TC) | `117103987/1500s` | unchanged | — |

The DJI clip's tmcd sample independently agrees with its string-derived value, so both paths corroborate. A previously-failing multicam cut and a plain phone-only cut both now import into Final Cut Pro cleanly.

## Tests

4 new specs: frame recovery, XML anchoring, the raise on an unreadable track, and the genuine-no-timecode case. Full suite green — 387 examples, 0 failures.