### PR TITLE
Edition seams and beta-feature flags (pre-multicam groundwork)

### DIFF
--- a/lib/buttercut/library.rb
+++ b/lib/buttercut/library.rb
@@ -13,10 +13,23 @@ require 'yaml'
 
 require_relative 'media_tools'
 require_relative 'media_verifier'
+require_relative 'settings'
 require_relative 'version'
 
 class Library
   LIBRARIES_ROOT = File.expand_path('../../libraries', __dir__)
+
+  # Edition seam: extensions register extra CLI subcommands here (usage line +
+  # handler taking (library, args)). Core ships none.
+  EXTENSION_COMMANDS = {}
+
+  def self.register_command(name, usage:, &handler)
+    EXTENSION_COMMANDS[name.to_s] = { usage: usage, handler: handler }
+  end
+
+  # CLI file arguments, comma- and/or space-separated. A class method (not a
+  # CLI-block local) so registered extension commands parse file lists the same way.
+  def self.split_file_args(args) = args.flat_map { |a| a.split(',').map(&:strip).reject(&:empty?) }
 
   # Per-field on-disk layout. `namer` builds the filename from a clip key
   # (see `clip_key`); `keep` is an optional regex of filenames the
@@ -278,11 +291,14 @@ class Library
 
   # Remove entries from library.yaml and delete their artifact files
   # (transcripts, contact sheets, summaries — plus legacy visual transcripts).
-  # NEVER touches the source footage itself.
+  # NEVER touches the source footage itself. before_remove_media! runs first,
+  # so an edition can refuse the whole batch before anything is deleted.
   def remove_media!(media_filenames)
     removed = []
     mutate do |library|
-      Array(media_filenames).each do |filename|
+      filenames = Array(media_filenames)
+      before_remove_media!(library, filenames)
+      filenames.each do |filename|
         media = find_media!(library, filename)
         delete_artifacts(media)
         library['media'].delete(media)
@@ -449,6 +465,12 @@ class Library
   # so the convenience keys never reach the write path — mutations load and
   # persist via `load_library` directly.
   def media = merged_media(load_library)
+
+  # Edition seam: multicam groups (Pro layers them onto library.yaml; core has
+  # none). media_and_multicams serves both from one parse for per-request callers.
+  def multicams = []
+  def media_and_multicams = [media, multicams]
+
   def language = load_library['language']
   def transcript_refinement = load_library['transcript_refinement']
   def user_context = load_library['user_context'].to_s
@@ -548,6 +570,7 @@ class Library
       'media_count' => meds.size
     }
     MEDIA_TYPES.each_key { |type| snapshot["#{type}_count"] = counts.fetch(type, 0) }
+    snapshot.merge!(edition_summary(data))
     snapshot.merge(
       'complete_count' => meds.size - incomplete.size,
       'incomplete_count' => incomplete.size,
@@ -736,10 +759,20 @@ class Library
     library['media'].find { |m| self.class.filename_of(m) == media_filename } ||
       raise(ArgumentError, "media not found in library.yaml: #{media_filename}")
   end
+
+  # Edition seam: refuse a whole remove_media! batch before any artifact is
+  # deleted (Pro guards multicam angles). Inside the lock, so a refusal changes nothing.
+  def before_remove_media!(library, filenames) = nil
+
+  # Edition seam: extra #summary fields (Pro adds multicam counts). Core has none.
+  def edition_summary(data) = {}
 end
 
+# Pro layers multicam groups onto the library here; core ships no such file.
+ButterCut.load_extension('library')
+
 if __FILE__ == $PROGRAM_NAME
-  USAGE = <<~USAGE
+  BASE_USAGE = <<~USAGE
     Usage:
       ruby library.rb list                            — every library, newest first (library.yaml mtime)
       ruby library.rb recent [N]                      — N most recent libraries by deepest file mtime (default 10)
@@ -762,6 +795,12 @@ if __FILE__ == $PROGRAM_NAME
       <name> add_media <path>...                      — append media records (type inferred from extension; video: #{Library::MEDIA_TYPES['video'][:extensions].join('/')}; image: #{Library::MEDIA_TYPES['image'][:extensions].join('/')})
       <name> remove_media <files>                     — drop entries + delete their artifacts (source footage untouched)
       <name> relink <old_prefix> <new_prefix>         — rewrite media paths under old_prefix to new_prefix (segment-aware, all-or-nothing; propose from verify_media, user confirms)
+  USAGE
+
+  # Registered extension subcommands slot in here — blank in core.
+  EXTENSION_USAGE = Library::EXTENSION_COMMANDS.values.map { |command| "#{command[:usage]}\n" }.join
+
+  REST_USAGE = <<~USAGE
       <name> update_metadata <key> <value...>         — set footage_summary, user_context, language, editor, or transcript_refinement
       <name> complete <field> <files>                 — mark files done for one field
       <name> reset <field> [<field>...]               — wipe one or more phases
@@ -780,6 +819,8 @@ if __FILE__ == $PROGRAM_NAME
                        transcript_refinement: true, media_paths: ['/abs/a.mov', '/abs/b.jpg'])"
   USAGE
 
+  USAGE = BASE_USAGE + EXTENSION_USAGE + REST_USAGE
+
   # Agent records that it just checked for updates (see check_for_update!). Kept
   # ahead of the daily gate below so recording a check is never itself gated.
   if ARGV.first == 'update_checked'
@@ -797,6 +838,15 @@ if __FILE__ == $PROGRAM_NAME
   if ARGV.first == 'list'
     puts Library.list
     exit 0
+  end
+
+  # Beta-feature gate for skills: exit 0 = on, 1 = off. A plain settings read,
+  # so it never hits the daily update gate.
+  if ARGV.first == 'beta_feature'
+    feature = ARGV[1].to_s.strip
+    abort 'beta_feature requires <name>' if feature.empty?
+
+    exit Settings.load.beta_feature?(feature) ? 0 : 1
   end
 
   if ARGV.first == 'recent'
@@ -827,8 +877,6 @@ if __FILE__ == $PROGRAM_NAME
     warn "library: #{e.message}"
     exit 1
   end
-
-  split_files = ->(args) { args.flat_map { |a| a.split(',').map(&:strip).reject(&:empty?) } }
 
   begin
     Library.check_for_update!
@@ -861,7 +909,7 @@ if __FILE__ == $PROGRAM_NAME
     when 'remove_media'
       raise ArgumentError, 'remove_media requires <files>' if rest.empty?
 
-      library.remove_media!(split_files.call(rest))
+      library.remove_media!(Library.split_file_args(rest))
     when 'relink'
       # Volume names contain spaces ("Andrew SSD") — an unquoted call must fail
       # here, not downstream with a misleading "no media paths under /Volumes/Andrew".
@@ -894,7 +942,7 @@ if __FILE__ == $PROGRAM_NAME
       field, *files = rest
       raise ArgumentError, 'complete requires <field> <files>' if field.nil? || files.empty?
 
-      library.complete!(field, split_files.call(files))
+      library.complete!(field, Library.split_file_args(files))
     when 'reset'
       raise ArgumentError, 'reset requires <field> [<field>...]' if rest.empty?
 
@@ -909,9 +957,14 @@ if __FILE__ == $PROGRAM_NAME
     when 'remove_visual_transcripts'
       library.remove_visual_transcripts!
     else
-      warn "unknown action: #{action}"
-      warn USAGE
-      exit 1
+      command = Library::EXTENSION_COMMANDS[action]
+      if command
+        command[:handler].call(library, rest)
+      else
+        warn "unknown action: #{action}"
+        warn USAGE
+        exit 1
+      end
     end
   rescue StandardError => e
     warn "library: #{e.message}"

--- a/lib/buttercut/settings.rb
+++ b/lib/buttercut/settings.rb
@@ -40,4 +40,23 @@ class Settings
 
     value
   end
+
+  # Opt-in flags for features still in testing, as a name→bool map. Which
+  # features exist is the edition's business — Settings only stores and reports.
+  def beta_features
+    map = @data['beta_features']
+    map.is_a?(Hash) ? map : {}
+  end
+
+  # Is a beta feature on? A missing map, an unlisted feature, or any falsey value
+  # all read as off, so a fresh (or pre-feature) settings.yaml has every beta off.
+  def beta_feature?(name) = truthy?(beta_features[name.to_s])
+
+  private
+
+  def truthy?(value)
+    return value if [true, false].include?(value)
+
+    %w[true yes 1 on].include?(value.to_s.strip.downcase)
+  end
 end

--- a/lib/buttercut/version.rb
+++ b/lib/buttercut/version.rb
@@ -20,4 +20,12 @@ class ButterCut
 
     "#{base}_core"
   end
+
+  # Load this edition's optional extension for a shared file, if it ships one.
+  # Unlike engine_variant (which swaps a whole file), this layers Pro behavior
+  # onto a file both editions share — see library.rb.
+  def self.load_extension(base)
+    path = File.join(__dir__, "#{base}_pro.rb")
+    require path if pro? && File.exist?(path)
+  end
 end

--- a/spec/buttercut/library_spec.rb
+++ b/spec/buttercut/library_spec.rb
@@ -1,62 +1,8 @@
 require 'spec_helper'
-require 'tmpdir'
-require 'yaml'
 require_relative '../../lib/buttercut/library'
 
 RSpec.describe Library do
-  let(:libraries_root) { @libraries_root }
-  let(:library_name) { 'test-lib' }
-  let(:library_dir) { File.join(libraries_root, library_name) }
-  let(:library_yaml_path) { File.join(library_dir, 'library.yaml') }
-
-  around do |example|
-    Dir.mktmpdir('library-spec-') do |root|
-      @libraries_root = root
-      example.run
-    end
-  end
-
-  before do
-    stub_const('Library::LIBRARIES_ROOT', @libraries_root)
-    allow($stdout).to receive(:puts)
-  end
-
-  def write_library(media:, name: library_name, **metadata)
-    dir = File.join(libraries_root, name)
-    FileUtils.mkdir_p(File.join(dir, 'transcripts'))
-    FileUtils.mkdir_p(File.join(dir, 'contact_sheets'))
-    FileUtils.mkdir_p(File.join(dir, 'summaries'))
-    payload = metadata.transform_keys(&:to_s).merge('media' => media)
-    File.write(File.join(dir, 'library.yaml'), payload.to_yaml)
-    dir
-  end
-
-  # A video record: probed duration + the three video fields.
-  def video_entry(filename, **overrides)
-    {
-      'path' => "/tmp/#{filename}",
-      'duration' => '00:00:05',
-      'transcript' => '',
-      'contact_sheet' => '',
-      'summary' => ''
-    }.merge(overrides.transform_keys(&:to_s))
-  end
-
-  # An image record: no duration, no transcript/contact_sheet — just a summary.
-  def image_entry(filename, **overrides)
-    {
-      'path' => "/tmp/#{filename}",
-      'summary' => ''
-    }.merge(overrides.transform_keys(&:to_s))
-  end
-
-  def touch(*paths)
-    paths.each { |p| FileUtils.touch(p) }
-  end
-
-  def load_yaml
-    YAML.safe_load_file(library_yaml_path)
-  end
+  include_context 'library sandbox'
 
   describe '.exists?' do
     it 'returns true when both directory and library.yaml exist' do

--- a/spec/buttercut/settings_spec.rb
+++ b/spec/buttercut/settings_spec.rb
@@ -46,4 +46,21 @@ RSpec.describe Settings do
       with_settings("editor: fcpx\n") { |s| expect { s.whisper_model }.to raise_error(/whisper_model is not set/) }
     end
   end
+
+  describe 'beta features' do
+    it 'reads every flag as off when the key is absent' do
+      with_settings("whisper_model: small\n") do |s|
+        expect(s.beta_feature?('multicam')).to be(false)
+        expect(s.beta_features).to eq({})
+      end
+    end
+
+    it 'reads a flag as on only when explicitly truthy' do
+      with_settings("beta_features:\n  multicam: true\n  other: false\n") do |s|
+        expect(s.beta_feature?('multicam')).to be(true)
+        expect(s.beta_feature?('other')).to be(false)
+        expect(s.beta_feature?('unlisted')).to be(false)
+      end
+    end
+  end
 end

--- a/spec/support/export_sandbox.rb
+++ b/spec/support/export_sandbox.rb
@@ -14,12 +14,16 @@ module ExportSandbox
   def fixture_media(filename) = File.join(MEDIA_DIR, filename)
 
   # Yields [relative cut path, absolute output path] from inside the sandbox.
-  def within_export_sandbox(cut:, media:, library: 'export-sandbox')
+  # A `media:` entry is a path, or a Hash of library-entry keys when the spec
+  # needs more of one — `duration:`, say, which Export reads to bound a
+  # multicam span.
+  def within_export_sandbox(cut:, media:, library: 'export-sandbox', multicams: nil)
     Dir.mktmpdir do |dir|
       cuts_dir = File.join(dir, 'libraries', library, 'cuts')
       FileUtils.mkdir_p(cuts_dir)
-      File.write(File.join(dir, 'libraries', library, 'library.yaml'),
-                 { 'media' => media.map { |path| { 'path' => path } } }.to_yaml)
+      library_yaml = { 'media' => media.map { |entry| entry.is_a?(Hash) ? entry : { 'path' => entry } } }
+      library_yaml['multicams'] = multicams if multicams
+      File.write(File.join(dir, 'libraries', library, 'library.yaml'), library_yaml.to_yaml)
       File.write(File.join(cuts_dir, 'cut.yaml'), cut.to_yaml)
       Dir.chdir(dir) do
         yield File.join('libraries', library, 'cuts', 'cut.yaml'), File.join(dir, 'output.xml')

--- a/spec/support/library_sandbox.rb
+++ b/spec/support/library_sandbox.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'yaml'
+
+# A throwaway libraries root plus helpers to write library.yaml fixtures —
+# shared by the core and Pro Library specs.
+RSpec.shared_context 'library sandbox' do
+  let(:libraries_root) { @libraries_root }
+  let(:library_name) { 'test-lib' }
+  let(:library_dir) { File.join(libraries_root, library_name) }
+  let(:library_yaml_path) { File.join(library_dir, 'library.yaml') }
+
+  around do |example|
+    Dir.mktmpdir('library-spec-') do |root|
+      @libraries_root = root
+      example.run
+    end
+  end
+
+  before do
+    stub_const('Library::LIBRARIES_ROOT', @libraries_root)
+    allow($stdout).to receive(:puts)
+  end
+
+  def write_library(media:, name: library_name, **metadata)
+    dir = File.join(libraries_root, name)
+    FileUtils.mkdir_p(File.join(dir, 'transcripts'))
+    FileUtils.mkdir_p(File.join(dir, 'contact_sheets'))
+    FileUtils.mkdir_p(File.join(dir, 'summaries'))
+    payload = metadata.transform_keys(&:to_s).merge('media' => media)
+    File.write(File.join(dir, 'library.yaml'), payload.to_yaml)
+    dir
+  end
+
+  # A video record: probed duration + the three video fields.
+  def video_entry(filename, **overrides)
+    {
+      'path' => "/tmp/#{filename}",
+      'duration' => '00:00:05',
+      'transcript' => '',
+      'contact_sheet' => '',
+      'summary' => ''
+    }.merge(overrides.transform_keys(&:to_s))
+  end
+
+  # An image record: no duration, no transcript/contact_sheet — just a summary.
+  def image_entry(filename, **overrides)
+    {
+      'path' => "/tmp/#{filename}",
+      'summary' => ''
+    }.merge(overrides.transform_keys(&:to_s))
+  end
+
+  def touch(*paths)
+    paths.each { |p| FileUtils.touch(p) }
+  end
+
+  def load_yaml
+    YAML.safe_load_file(library_yaml_path)
+  end
+end

--- a/spec/support/probe_metadata.rb
+++ b/spec/support/probe_metadata.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# ffprobe-shaped metadata for generator specs without touching real media:
+# build_metadata fabricates the probe hash, stub_ffprobe serves a path→metadata
+# map to every generator instance. Specs needing extra stream fields (rotation,
+# timecode) define their own build_metadata, which shadows this one.
+module ProbeMetadata
+  def build_metadata(duration_seconds:, frame_rate: '25/1', width: 1280, height: 720, sample_rate: '48000')
+    {
+      'streams' => [
+        { 'codec_type' => 'video', 'width' => width, 'height' => height,
+          'r_frame_rate' => frame_rate, 'color_space' => 'bt709' },
+        { 'codec_type' => 'audio', 'sample_rate' => sample_rate }
+      ],
+      'format' => { 'duration' => duration_seconds.to_s, 'tags' => {} }
+    }
+  end
+
+  def stub_ffprobe(metadata_by_path)
+    allow_any_instance_of(ButterCut::EditorBase).to receive(:extract_metadata_from_ffprobe) do |_instance, path|
+      metadata_by_path.fetch(path)
+    end
+  end
+end
+
+RSpec.configure { |config| config.include ProbeMetadata }

--- a/templates/settings_template.yaml
+++ b/templates/settings_template.yaml
@@ -25,3 +25,9 @@ save_to_desktop_after_export: true
 # the project directory and survive a fresh clone or `update-buttercut` run.
 # Set to a different absolute path (or one starting with ~) to redirect.
 # backups_dir: ~/Documents/buttercut-video-editor-backups
+
+# Beta features — opt-in flags for features still in testing. Off unless set to
+# true here (a missing key or feature reads as off). Uncomment the block and
+# name the feature to try it.
+# beta_features:
+#   feature_name: true


### PR DESCRIPTION
Back-ports the edition groundwork from ButterCut Pro's multicam branch (buttercut-pro#63) so the shared files stay identical across editions. No feature code — everything here is a seam an edition can hook or a flag a user can set.

- **Library edition seams** — `ButterCut.load_extension` (no-op in core), registered CLI subcommands (`EXTENSION_COMMANDS` + usage slotting), `before_remove_media!` / `edition_summary` hooks, and `multicams` / `media_and_multicams` readers (empty in core; one YAML parse serves both).
- **beta_features settings flags** — name→bool map in `settings.yaml` with reader-only accessors (`beta_features`, `beta_feature?`), the `beta_feature` CLI gate skills check, and a documenting block in the settings template. (The Pro repo's writable-settings/preview-UI half doesn't apply here — core has no preview app.)
- **Shared spec scaffolding** — `library sandbox` shared context, `probe_metadata` ffprobe helper, export-sandbox media-entry attributes.

Test note: this checkout's suite has 74 pre-existing failures on `main` (missing local media tooling); this branch keeps the same 74 and adds 2 passing examples (400 → 402).

🤖 Generated with [Claude Code](https://claude.com/claude-code)