### PR TITLE
Add missing spec for ScriptExtractor

### DIFF
--- a/spec/buttercut/script_extractor_spec.rb
+++ b/spec/buttercut/script_extractor_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'json'
+require_relative '../../lib/buttercut/script_extractor'
+
+RSpec.describe ScriptExtractor do
+  def with_transcript(segments)
+    Dir.mktmpdir('script-extractor-spec-') do |dir|
+      path = File.join(dir, 'transcript.json')
+      File.write(path, JSON.generate({ 'segments' => segments }))
+      yield path
+    end
+  end
+
+  describe '.extract' do
+    it 'writes one line per segment, stripped, to stdout' do
+      with_transcript([{ 'text' => '  Hello there.  ' }, { 'text' => 'General Kenobi.' }]) do |path|
+        expect { described_class.extract(path) }.to output("Hello there.\nGeneral Kenobi.\n").to_stdout
+      end
+    end
+
+    it 'drops segments whose text is blank or whitespace-only' do
+      with_transcript([{ 'text' => 'Real line.' }, { 'text' => '   ' }, { 'text' => '' }]) do |path|
+        expect { described_class.extract(path) }.to output("Real line.\n").to_stdout
+      end
+    end
+
+    it 'raises when the transcript has no segments key' do
+      Dir.mktmpdir('script-extractor-spec-') do |dir|
+        path = File.join(dir, 'transcript.json')
+        File.write(path, JSON.generate({ 'language' => 'en' }))
+        expect { described_class.extract(path) }.to raise_error(/no 'segments' key/)
+      end
+    end
+  end
+
+  describe '.new' do
+    it 'raises when transcript_path is nil or empty' do
+      expect { described_class.new(nil) }.to raise_error(ArgumentError, /required/)
+      expect { described_class.new('') }.to raise_error(ArgumentError, /required/)
+    end
+
+    it 'raises when the transcript file does not exist' do
+      expect { described_class.new('/nonexistent/transcript.json') }.to raise_error(ArgumentError, /not found/)
+    end
+  end
+end


### PR DESCRIPTION
## What
Adds `spec/buttercut/script_extractor_spec.rb` — the only file in `lib/buttercut/` that had zero test coverage.

## Why
`ScriptExtractor` is a small, self-contained utility (extracts clean dialogue lines from a transcript JSON) but had no spec, unlike every sibling file in `lib/buttercut/`.

## Coverage added
- `.extract` writes one stripped line per segment to stdout
- blank/whitespace-only segments are dropped
- raises when the transcript JSON has no `segments` key
- `.new` raises `ArgumentError` for a nil/empty path and for a nonexistent file

No production code changed — test-only addition.