### PR TITLE
Fix Sony RTMD timecode: anchor exports to the timecode each editor reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 - **Final Cut Camera (iPhone) exports now import into Final Cut Pro cleanly.** The app records true 30/60fps media with drop-frame timecode; the exporter skipped the drop-frame correction for those files, so Final Cut rejected every clip ("Invalid edit with no respective media"). Thanks to @acreagetcg for the report and diagnosis.
+- **Sony camera exports now import into Final Cut Pro cleanly.** Sony's XAVC cameras write their start timecode into a metadata stream that Final Cut can't read, so the exporter anchored every clip to a camera clock the editor never saw — and Final Cut rejected the whole timeline ("Invalid edit with no respective media"). Exports now use a clip's timecode only when the editor can see it too, and start from zero when it can't.
 
 ## [0.8.0] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 - **Final Cut Camera (iPhone) exports now import into Final Cut Pro cleanly.** The app records true 30/60fps media with drop-frame timecode; the exporter skipped the drop-frame correction for those files, so Final Cut rejected every clip ("Invalid edit with no respective media"). Thanks to @acreagetcg for the report and diagnosis.
-- **Sony camera exports now import into Final Cut Pro cleanly.** Sony's XAVC cameras write their start timecode into a metadata stream that Final Cut can't read, so the exporter anchored every clip to a camera clock the editor never saw — and Final Cut rejected the whole timeline ("Invalid edit with no respective media"). Exports now use a clip's timecode only when the editor can see it too, and start from zero when it can't.
+- **Sony camera exports now import into Final Cut Pro and DaVinci Resolve cleanly.** Sony's XAVC cameras write their start timecode into a metadata stream Final Cut can't read but Resolve can, so no single anchor suited both: anchoring every clip to the camera clock made Final Cut reject the whole timeline ("Invalid edit with no respective media"), and starting from zero left Resolve unable to match the footage in the media pool, importing every clip offline. Each export now anchors to the timecode that editor actually reads.
 
 ## [0.8.0] - 2026-06-26
 

--- a/lib/buttercut/editor_base_core.rb
+++ b/lib/buttercut/editor_base_core.rb
@@ -143,37 +143,46 @@ class ButterCut
       (rate_num.to_f / rate_denom).round
     end
 
+    # A clip's start timecode as an "hh:mm:ss:ff" string — but only when a real
+    # QuickTime timecode track ('tmcd') stands behind it.
+    #
+    # The gate matters because ffprobe and Final Cut don't read the same
+    # metadata. Sony XAVC cameras carry their start timecode as a tag on an
+    # `rtmd` real-time-metadata stream and ship no timecode track at all;
+    # ffprobe reports that tag happily, but AVFoundation — which is how Final
+    # Cut sees media — doesn't expose the stream (`avmediainfo` on the same
+    # file: "Track count: 2", video and audio). Anchoring the asset to a camera
+    # clock the editor can't read put every edit 18 hours past media it thinks
+    # starts at zero, and Final Cut rejected all of them as "invalid edit with
+    # no respective media". A timecode is usable as an anchor only if the editor
+    # can see it too; anything else exports anchored at zero.
+    #
+    # With a track present the value can sit in three places — ffprobe copies a
+    # tmcd track's timecode onto the track, onto the video stream, and into the
+    # format tags alike — so read it off the track itself, then fall back to the
+    # format tags (Panasonic Semi-Pro clips bury theirs in an embedded XML blob).
     def clip_timecode_string(video_path)
-      metadata = extract_metadata(video_path)
+      track = timecode_track(video_path) or return nil
 
-      if metadata['streams']
-        metadata['streams'].each do |stream|
-          tags = stream['tags']
-          next unless tags && tags['timecode'] && !tags['timecode'].empty?
+      tag = track.dig('tags', 'timecode')
+      return tag unless tag.nil? || tag.empty?
 
-          return tags['timecode']
-        end
-      end
+      format_tags = extract_metadata(video_path).dig('format', 'tags') or return nil
 
-      format_tags = metadata.dig('format', 'tags')
-      if format_tags
-        tc = format_tags['timecode']
-        return tc unless tc.nil? || tc.empty?
+      tc = format_tags['timecode']
+      return tc unless tc.nil? || tc.empty?
 
-        panasonic_xml = format_tags['com.panasonic.Semi-Pro.metadata.xml']
-        if panasonic_xml
-          match = panasonic_xml.match(/<StartTimecode>([^<]+)<\/StartTimecode>/)
-          return match[1].strip if match
-        end
-      end
-
-      nil
+      panasonic_xml = format_tags['com.panasonic.Semi-Pro.metadata.xml']
+      match = panasonic_xml&.match(/<StartTimecode>([^<]+)<\/StartTimecode>/)
+      match && match[1].strip
     end
 
-    # The QuickTime timecode track ('tmcd'), when the clip carries one. Its
-    # single sample is the start frame number, which is the same value ffprobe
-    # formats into the `timecode` tag — so this only matters when that tag is
-    # missing.
+    # The QuickTime timecode track ('tmcd'), when the clip carries one. This is
+    # the gate on every source timecode: it's the only carrier AVFoundation
+    # exposes, so no track means the clip exports anchored at zero however much
+    # timecode ffprobe found elsewhere. Its single sample is the start frame
+    # number — the same value ffprobe formats into the `timecode` tag, which
+    # only matters directly when that tag is missing.
     def timecode_track(video_path)
       streams = extract_metadata(video_path)['streams'] or return nil
 

--- a/lib/buttercut/editor_base_core.rb
+++ b/lib/buttercut/editor_base_core.rb
@@ -143,46 +143,51 @@ class ButterCut
       (rate_num.to_f / rate_denom).round
     end
 
-    # A clip's start timecode as an "hh:mm:ss:ff" string — but only when a real
-    # QuickTime timecode track ('tmcd') stands behind it.
-    #
-    # The gate matters because ffprobe and Final Cut don't read the same
-    # metadata. Sony XAVC cameras carry their start timecode as a tag on an
-    # `rtmd` real-time-metadata stream and ship no timecode track at all;
-    # ffprobe reports that tag happily, but AVFoundation — which is how Final
-    # Cut sees media — doesn't expose the stream (`avmediainfo` on the same
-    # file: "Track count: 2", video and audio). Anchoring the asset to a camera
-    # clock the editor can't read put every edit 18 hours past media it thinks
-    # starts at zero, and Final Cut rejected all of them as "invalid edit with
-    # no respective media". A timecode is usable as an anchor only if the editor
-    # can see it too; anything else exports anchored at zero.
-    #
-    # With a track present the value can sit in three places — ffprobe copies a
-    # tmcd track's timecode onto the track, onto the video stream, and into the
-    # format tags alike — so read it off the track itself, then fall back to the
-    # format tags (Panasonic Semi-Pro clips bury theirs in an embedded XML blob).
+    # A clip's start timecode as "hh:mm:ss:ff", or nil when it carries none this
+    # editor reads — a per-editor question, since ffprobe sees more than they do.
     def clip_timecode_string(video_path)
-      track = timecode_track(video_path) or return nil
-
-      tag = track.dig('tags', 'timecode')
-      return tag unless tag.nil? || tag.empty?
-
-      format_tags = extract_metadata(video_path).dig('format', 'tags') or return nil
-
-      tc = format_tags['timecode']
-      return tc unless tc.nil? || tc.empty?
-
-      panasonic_xml = format_tags['com.panasonic.Semi-Pro.metadata.xml']
-      match = panasonic_xml&.match(/<StartTimecode>([^<]+)<\/StartTimecode>/)
-      match && match[1].strip
+      tracked_timecode_string(video_path) || untracked_timecode_string(video_path)
     end
 
-    # The QuickTime timecode track ('tmcd'), when the clip carries one. This is
-    # the gate on every source timecode: it's the only carrier AVFoundation
-    # exposes, so no track means the clip exports anchored at zero however much
-    # timecode ffprobe found elsewhere. Its single sample is the start frame
-    # number — the same value ffprobe formats into the `timecode` tag, which
-    # only matters directly when that tag is missing.
+    # Timecode standing on a real 'tmcd' track — the one carrier every editor
+    # reads. ffprobe copies it to track, video stream and format tags alike.
+    def tracked_timecode_string(video_path)
+      track = timecode_track(video_path) or return nil
+
+      present(track.dig('tags', 'timecode')) || format_timecode_string(video_path)
+    end
+
+    # Timecode carried anywhere but a 'tmcd' track. Nil on purpose: only an
+    # editor that actually reads these carriers may anchor to them.
+    def untracked_timecode_string(_video_path) = nil
+
+    # The first `timecode` tag hanging off any stream — where Sony XAVC puts
+    # its, on the `rtmd` data stream.
+    def stream_timecode_string(video_path)
+      streams = extract_metadata(video_path)['streams'] or return nil
+
+      streams.filter_map { |stream| present(stream.dig('tags', 'timecode')) }.first
+    end
+
+    # Timecode in the container's format tags, plain or buried in the embedded
+    # XML blob Panasonic Semi-Pro clips use.
+    def format_timecode_string(video_path)
+      tags = extract_metadata(video_path).dig('format', 'tags') or return nil
+
+      present(tags['timecode']) || present(panasonic_start_timecode(tags))
+    end
+
+    def panasonic_start_timecode(format_tags)
+      xml = format_tags['com.panasonic.Semi-Pro.metadata.xml'] or return nil
+
+      xml[%r{<StartTimecode>([^<]+)</StartTimecode>}, 1]
+    end
+
+    # Nil for blank, the trimmed string otherwise.
+    def present(value) = (stripped = value.to_s.strip).empty? ? nil : stripped
+
+    # The QuickTime timecode track ('tmcd'), when the clip carries one — the
+    # only carrier AVFoundation, and so Final Cut, exposes.
     def timecode_track(video_path)
       streams = extract_metadata(video_path)['streams'] or return nil
 

--- a/lib/buttercut/resolve_core.rb
+++ b/lib/buttercut/resolve_core.rb
@@ -1,9 +1,13 @@
 require_relative 'fcpx'
 
 class ButterCut
-  # DaVinci Resolve timeline export, riding the FCPX generator as a pure
-  # pass-through — a named subclass gives Resolve behavior a home if it ever
-  # diverges.
+  # DaVinci Resolve timeline export. The XML is the FCPX generator's, unchanged
+  # — Resolve reads FCPXML 1.12 — but the source-timecode anchor diverges.
   class Resolve < FCPX
+    # Resolve reads timecode off the file with or without a track, and links an
+    # import by matching pool timecode — a zero anchor lands every clip offline.
+    def untracked_timecode_string(video_path)
+      stream_timecode_string(video_path) || format_timecode_string(video_path)
+    end
   end
 end

--- a/spec/buttercut/fcp7_spec.rb
+++ b/spec/buttercut/fcp7_spec.rb
@@ -20,8 +20,16 @@ RSpec.describe ButterCut::FCP7 do
       'sample_rate' => sample_rate
     }
 
+    # A camera reporting a timecode carries a real 'tmcd' track behind it —
+    # the track the exporter gates on. See the note in fcpx_spec.rb.
+    streams = [video_stream, audio_stream]
+    if timecode
+      streams << { 'codec_type' => 'data', 'codec_tag_string' => 'tmcd', 'index' => 2,
+                   'tags' => { 'timecode' => timecode } }
+    end
+
     {
-      'streams' => [video_stream, audio_stream],
+      'streams' => streams,
       'format' => {
         'duration' => duration_seconds.to_s,
         'tags' => timecode ? { 'timecode' => timecode } : {}

--- a/spec/buttercut/fcpx_spec.rb
+++ b/spec/buttercut/fcpx_spec.rb
@@ -20,8 +20,16 @@ RSpec.describe ButterCut::FCPX do
 
     audio_streams ||= [{ 'codec_type' => 'audio', 'sample_rate' => sample_rate }]
 
+    # A camera reporting timecode has a real 'tmcd' track behind it, and ffprobe
+    # copies the value onto track, video stream and format tags alike.
+    streams = [video_stream, *audio_streams]
+    if timecode
+      streams << { 'codec_type' => 'data', 'codec_tag_string' => 'tmcd', 'index' => streams.size,
+                   'tags' => { 'timecode' => timecode } }
+    end
+
     {
-      'streams' => [video_stream, *audio_streams],
+      'streams' => streams,
       'format' => {
         'duration' => duration_seconds.to_s,
         'tags' => timecode ? { 'timecode' => timecode } : {}
@@ -297,6 +305,57 @@ RSpec.describe ButterCut::FCPX do
 
         expect { generator.clip_timecode_fraction(tmcd_path) }
           .to raise_error(/timecode track that could not be read/)
+      end
+    end
+
+    # Sony XAVC hangs start timecode off an `rtmd` stream with no timecode track.
+    # AVFoundation hides that stream, so Final Cut sees media starting at zero.
+    context 'with timecode on a Sony rtmd metadata stream and no timecode track' do
+      let(:rtmd_path) { '/tmp/sony_C0055.MP4' }
+      let(:rtmd_metadata) do
+        metadata = build_metadata(frame_rate: '50/1', duration_seconds: 20.64, width: 1920, height: 1080)
+        metadata['streams'] << { 'codec_type' => 'data', 'codec_tag_string' => 'rtmd', 'index' => 2,
+                                 'tags' => { 'timecode' => '18:07:16:04' } }
+        metadata
+      end
+
+      before do
+        allow_any_instance_of(ButterCut::FCPX).to receive(:extract_metadata_from_ffprobe).and_return(rtmd_metadata)
+      end
+
+      it 'ignores a timecode the editor cannot see' do
+        generator = ButterCut::FCPX.new([{ path: rtmd_path }])
+
+        expect(generator.clip_timecode_string(rtmd_path)).to be_nil
+        expect(generator.clip_timecode_fraction(rtmd_path)).to eq('0s')
+      end
+
+      it 'anchors the asset and asset-clip at zero so the edits land inside the media' do
+        generator = ButterCut::FCPX.new([{ path: rtmd_path }])
+        xml = generator.to_xml
+        asset_id = asset_id_for(generator, rtmd_path)
+
+        expect(xml).to match(/<asset id="#{Regexp.escape(asset_id)}"[^>]*start="0s"/)
+        expect(xml).to match(/<asset-clip[^>]*start="0s"/)
+        expect(xml).not_to include('1630902/25s')
+      end
+    end
+
+    # The other over-broad carrier: a format-tag timecode with no tmcd track
+    # behind it (Panasonic Semi-Pro clips reach this via their embedded XML).
+    context 'with a format-level timecode and no timecode track' do
+      let(:format_tc_path) { '/tmp/format_only_tc.mov' }
+
+      before do
+        metadata = build_metadata(frame_rate: '25/1', duration_seconds: 10.0)
+        metadata['format']['tags'] = { 'timecode' => '01:00:00:00' }
+        allow_any_instance_of(ButterCut::FCPX).to receive(:extract_metadata_from_ffprobe).and_return(metadata)
+      end
+
+      it 'exports anchored at zero' do
+        generator = ButterCut::FCPX.new([{ path: format_tc_path }])
+
+        expect(generator.clip_timecode_fraction(format_tc_path)).to eq('0s')
       end
     end
 

--- a/spec/buttercut/generator_stills_spec.rb
+++ b/spec/buttercut/generator_stills_spec.rb
@@ -22,8 +22,15 @@ RSpec.describe 'Generator still handling' do
       'color_space' => 'bt709', 'color_primaries' => 'bt709', 'color_transfer' => 'bt709'
     }
     video_stream['tags'] = { 'timecode' => timecode } if timecode
+    # A camera reporting a timecode carries a real 'tmcd' track behind it —
+    # the track the exporter gates on. See the note in fcpx_spec.rb.
+    streams = [video_stream, { 'codec_type' => 'audio', 'sample_rate' => sample_rate }]
+    if timecode
+      streams << { 'codec_type' => 'data', 'codec_tag_string' => 'tmcd', 'index' => 2,
+                   'tags' => { 'timecode' => timecode } }
+    end
     {
-      'streams' => [video_stream, { 'codec_type' => 'audio', 'sample_rate' => sample_rate }],
+      'streams' => streams,
       'format' => { 'duration' => duration.to_s, 'tags' => timecode ? { 'timecode' => timecode } : {} }
     }
   end

--- a/spec/buttercut/resolve_spec.rb
+++ b/spec/buttercut/resolve_spec.rb
@@ -2,10 +2,8 @@
 
 require 'spec_helper'
 
-# Resolve rides the FCPX generator (resolve_core.rb) as a pure pass-through.
-# The bare-decibel volume amounts Resolve's importer requires ("-96", never
-# "-96db") come from the shared generator, so these examples guard the
-# contract Resolve imports depend on.
+# Resolve rides the FCPX generator (resolve_core.rb), diverging only where it
+# conforms an import differently. These examples guard the contracts it needs.
 RSpec.describe ButterCut::Resolve do
   let(:video_path) { '/tmp/resolve_spec.mov' }
 
@@ -44,5 +42,48 @@ RSpec.describe ButterCut::Resolve do
     expect(xml).to match(/<asset-clip name="resolve_spec\.mov"[^>]*audioRole="dialogue"/)
     expect(xml).to include('<adjust-volume amount="-13.1"/>')
     expect(xml).not_to include('db"')
+  end
+
+  # Sony XAVC hangs start timecode off an `rtmd` stream with no timecode track.
+  # Final Cut can't read it and needs zero; Resolve reads it and needs the match.
+  context 'with timecode on a Sony rtmd metadata stream and no timecode track' do
+    let(:rtmd_path) { '/tmp/sony_C0055.MP4' }
+
+    let(:metadata) do
+      {
+        'streams' => [
+          { 'codec_type' => 'video', 'codec_name' => 'h264',
+            'width' => 1920, 'height' => 1080, 'r_frame_rate' => '50/1',
+            'color_space' => 'bt709', 'color_primaries' => 'bt709', 'color_transfer' => 'bt709' },
+          { 'codec_type' => 'audio', 'sample_rate' => '48000' },
+          { 'codec_type' => 'data', 'codec_tag_string' => 'rtmd', 'index' => 2,
+            'tags' => { 'timecode' => '18:07:16:04' } }
+        ],
+        'format' => { 'duration' => '20.64', 'tags' => {} }
+      }
+    end
+
+    it 'anchors to the timecode Resolve can read' do
+      generator = described_class.new([{ path: rtmd_path }])
+
+      expect(generator.clip_timecode_string(rtmd_path)).to eq('18:07:16:04')
+      # 18:07:16:04 at 50 fps — 3_261_804 frames ÷ 50, reduced.
+      expect(generator.clip_timecode_fraction(rtmd_path)).to eq('1630902/25s')
+    end
+
+    it 'anchors the asset and asset-clip so the pool clip links' do
+      generator = described_class.new([{ path: rtmd_path }])
+      xml = generator.to_xml
+
+      expect(xml).to match(%r{<asset id="[^"]+"[^>]*start="1630902/25s"})
+      expect(xml).to match(%r{<asset-clip[^>]*start="1630902/25s"})
+    end
+
+    it 'leaves Final Cut anchored at zero for the same clip' do
+      generator = ButterCut::FCPX.new([{ path: rtmd_path }])
+
+      expect(generator.clip_timecode_string(rtmd_path)).to be_nil
+      expect(generator.clip_timecode_fraction(rtmd_path)).to eq('0s')
+    end
   end
 end


### PR DESCRIPTION
Ports the Sony RTMD timecode fix to open-source ButterCut (PRs #67/#68 in the Pro repo).

## Problem
Sony XAVC cameras carry their start timecode as a tag on an `rtmd` real-time-metadata stream and ship no QuickTime `tmcd` track. ffprobe reports that tag, but AVFoundation (how Final Cut reads media) doesn't expose the stream — so anchoring every clip to the camera clock made Final Cut reject the whole timeline ("invalid edit with no respective media"), while anchoring at zero left Resolve unable to match footage in the media pool, importing every clip offline.

## Fix
- Gate the timecode lookup on a real `tmcd` track: read the tag off that track, then fall back to format tags (covers Panasonic Semi-Pro clips, which bury theirs in an embedded XML blob). No track means the clip anchors at zero.
- Anchor each export to the timecode that editor actually reads: Final Cut only sees `tmcd` tracks; Resolve also reads the RTMD stream, so its FCPXML export keeps the camera-clock anchor.

## Testing
- Full suite: 408 examples, 0 failures.

Note: the first commit's Pro-only spec updates (`fcp7_pro_spec.rb`, `fcpx_pro_spec.rb`) are excluded from this port.