### PR TITLE
core: Upgrade WhisperX to 3.8.6 and pin the full ML stack

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -20,6 +20,6 @@ python.compile = false
 python.github_attestations = false
 
 # Notes on dependencies:
-# - whisperx 3.4.2 requires pyannote-audio <4.0.0
-# - pyannote-audio 4.x removed the 'use_auth_token' parameter
-# - We use pyannote-audio 3.4.0 for compatibility
+# - whisperx 3.8.x requires pyannote-audio >=4.0.0 (see requirements.txt)
+# - The tested combination is pinned in requirements.txt and the setup skill —
+#   keep those two files in sync when upgrading either package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to ButterCut will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Transcription is sturdier.** ButterCut now runs the current WhisperX release (3.8.6, with pyannote-audio 4.0.7). This fixes the transcription failures some users hit on the old pinned version, and improves word-level timing accuracy so cuts land on cleaner points.
+
 ## [0.9.0] - 2026-08-09
 
 **ButterCut Pro learns multicam**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@
 | Ruby | 3.3.6 | XML generation and scripts |
 | Python | 3.12.8 | WhisperX transcription |
 | FFmpeg | latest | Video/audio processing |
-| WhisperX | latest | Speech-to-text with word timing |
+| WhisperX | 3.8.6 (pinned, with pyannote-audio 4.0.7) | Speech-to-text with word timing |
 
 Version files (`.ruby-version`, `.python-version`) are included for compatibility with most version managers (rbenv, pyenv, asdf, mise, etc.).
 

--- a/lib/buttercut/transcribe_job.rb
+++ b/lib/buttercut/transcribe_job.rb
@@ -39,9 +39,13 @@ class TranscribeJob < Job
   private
 
   NO_SPEECH_MARKER = 'No active speech found in audio'
+  PYTHON_TRACEBACK_MARKER = 'Traceback (most recent call last)'
 
-  # Returns true if whisperx produced a real transcript, false if it rescued a
+  # Returns true if whisperx produced a transcript file, false if it rescued a
   # silent clip by writing an empty one. Raises on any other failure.
+  # whisperx 3.8+ handles silent clips itself: it prints NO_SPEECH_MARKER but
+  # exits 0 with a valid empty-segments JSON, so the rescue below only fires on
+  # older whisperx versions that exit non-zero.
   def run_whisperx
     # WhisperX decodes audio by running a bare `ffmpeg` from PATH (see
     # whisperx/audio.py load_audio), so the subprocess gets MediaTools'
@@ -68,7 +72,28 @@ class TranscribeJob < Job
       return false
     end
 
+    raise stale_install_message(output, status) if output.include?(PYTHON_TRACEBACK_MARKER)
+
     raise "whisperx failed for #{clip} (exit #{status.exitstatus})"
+  end
+
+  # A Python traceback means whisperx itself crashed rather than choking on the
+  # footage. Every known breakage of this kind is a stale venv — packages that
+  # drifted from the pinned set (torchaudio 2.9 removed AudioMetaData; torch
+  # 2.6 flipped torch.load to weights_only, breaking the VAD checkpoint) — and
+  # the fix is the same either way: resync the venv to requirements.txt. This
+  # matters most right after an update that changed the pins, since older
+  # update flows didn't sync the venv.
+  def stale_install_message(output, status)
+    tail = output.lines.last(15).join
+    <<~MSG
+      whisperx crashed with a Python error for #{clip} (exit #{status.exitstatus}). This usually means the WhisperX install is stale or broken, not that the footage is bad.
+      Fix: from the ButterCut directory, sync the WhisperX packages to ButterCut's pinned versions:
+        ~/.buttercut/venv/bin/pip install --only-binary :all: --no-binary antlr4-python3-runtime,docopt -r requirements.txt
+      then retry this clip. If that doesn't fix it, run the setup skill.
+      Last output from whisperx:
+      #{tail}
+    MSG
   end
 
   def rescue_silent_clip

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,16 +9,33 @@
 #   - ffmpeg (brew install ffmpeg)
 
 # WhisperX - video transcription with timestamp alignment
-whisperx==3.4.2
+whisperx==3.8.6
 
-# CRITICAL: pyannote-audio must be <4.0.0 for whisperx 3.4.2 compatibility
-# Version 4.x removed 'use_auth_token' parameter that whisperx still uses
-# If you see: TypeError: Inference.__init__() got an unexpected keyword argument 'use_auth_token'
-# Run: pip install "pyannote-audio<4.0.0"
-pyannote-audio==3.4.0
+# VAD/diarization stack. whisperx 3.8.x requires pyannote-audio >=4.0.0
+# (the reverse of the old constraint: whisperx 3.4.2 needed pyannote-audio <4
+# because 4.x removed 'use_auth_token'; whisperx fixed that upstream in 3.6+).
+pyannote-audio==4.0.7
 
-# Additional dependencies (installed by whisperx/pyannote but pinned for reproducibility)
-torch>=2.0.0
-torchaudio>=2.0.0
-transformers>=4.30.0
-faster-whisper>=0.9.0
+# ML stack — pinned exactly. whisperx/pyannote declare only open floors for
+# most of these, so unpinned installs resolve whatever is newest that day;
+# a drifting torch is exactly how whisperx 3.4.2 installs broke (torchaudio
+# 2.9 removed AudioMetaData; torch 2.6 flipped torch.load weights_only).
+# This block is the combination ButterCut is tested against — when bumping
+# whisperx, re-test and re-pin the whole block together. The long tail of
+# transitive deps (requests, click, …) deliberately stays unpinned.
+torch==2.8.0
+torchaudio==2.8.0
+torchvision==0.23.0
+torchcodec==0.7.0
+faster-whisper==1.2.1
+ctranslate2==4.8.1
+transformers==4.57.6
+huggingface-hub==0.36.2
+lightning==2.6.5
+numpy==2.5.2
+pandas==3.0.5
+
+# Note: whisperx 3.8.x pulls in torchcodec, whose native FFmpeg bindings may
+# fail to load at startup (a libavutil / LC_RPATH warning). That's harmless —
+# whisperx decodes audio through the ffmpeg *binary*, so transcription works;
+# don't chase the warning.

--- a/skills/setup/simple-setup.md
+++ b/skills/setup/simple-setup.md
@@ -199,11 +199,13 @@ fi
 
 source ~/.buttercut/venv/bin/activate
 pip install --upgrade pip
-pip install 'whisperx==3.4.2' 'pyannote-audio==3.4.0'
+pip install -r requirements.txt
 deactivate
 ```
 
-(The versions are pinned to the combination ButterCut is tested against — `pyannote-audio` 4.x breaks whisperx 3.4.2, so don't install newer versions even if pip suggests them.)
+Run the `pip install` from the buttercut directory so `requirements.txt` resolves.
+
+(requirements.txt pins the exact combination ButterCut is tested against — don't install different versions even if pip suggests them.)
 
 ## Step 7: WhisperX Wrapper Script
 
@@ -287,3 +289,4 @@ running ButterCut in:
 - **Wrong Ruby/Python**: Run `mise trust && mise install` from buttercut directory
 - **WhisperX not found**: Ensure `~/.buttercut` is in PATH, open new terminal
 - **WhisperX import errors**: The wrapper script handles venv activation automatically; ensure you're using `~/.buttercut/whisperx` not calling whisperx directly
+- **`torchcodec` / `libavutil` warning when WhisperX starts**: Harmless — torchcodec's native FFmpeg bindings may fail to load, but WhisperX decodes audio through the ffmpeg binary, so transcription still works. Ignore it.

--- a/skills/update-buttercut/SKILL.md
+++ b/skills/update-buttercut/SKILL.md
@@ -34,6 +34,12 @@ GIT_TERMINAL_PROMPT=0 git pull origin main
 bundle install
 ```
 
+Also sync the WhisperX install to the repo's pinned versions — updates sometimes move them, and `git pull` alone never touches the venv:
+```bash
+~/.buttercut/venv/bin/pip install -r requirements.txt
+```
+This is fast and a no-op when the pins haven't changed. If `~/.buttercut/venv` doesn't exist, the install predates the standard venv layout — skip this command (that Mac's transcription setup lives wherever `.buttercut_env` points). If it fails because the network dropped, continue the update but tell the user transcription may misbehave until it's re-run.
+
 **5. Tell the user what they got — in their language:**
 ```bash
 git diff <sha-from-step-1>..HEAD -- CHANGELOG.md

--- a/spec/buttercut/transcribe_job_spec.rb
+++ b/spec/buttercut/transcribe_job_spec.rb
@@ -25,4 +25,33 @@ RSpec.describe TranscribeJob do
     expect(captured_env['PATH'].split(':').first).to eq(MediaTools::DEPENDENCIES_DIR)
     expect(captured_env['PATH']).to include(ENV.fetch('PATH'))
   end
+
+  def stub_whisperx_failure(output)
+    allow(MediaTools).to receive(:ffmpeg) # preflight only — keep the spec hermetic
+    allow(Open3).to receive(:capture2e).and_return(
+      [output, instance_double(Process::Status, success?: false, exitstatus: 1)]
+    )
+  end
+
+  # A Python traceback means whisperx itself is broken (a stale venv), not the
+  # clip — the error must point at the requirements.txt resync so any session
+  # can self-heal, even one updated by an older skill that didn't sync the venv.
+  it 'points at the venv resync when whisperx dies with a Python traceback' do
+    stub_whisperx_failure(<<~OUTPUT)
+      Traceback (most recent call last):
+        File "whisperx/asr.py", line 16, in <module>
+      AttributeError: module 'torchaudio' has no attribute 'AudioMetaData'
+    OUTPUT
+
+    expect { job.perform }.to raise_error do |error|
+      expect(error.message).to match(/pip install .*-r requirements\.txt/)
+      expect(error.message).to include('AudioMetaData') # the traceback tail rides along for diagnosis
+    end
+  end
+
+  it 'raises the plain failure message when whisperx fails without a traceback' do
+    stub_whisperx_failure("some ffmpeg decode noise\n")
+
+    expect { job.perform }.to raise_error('whisperx failed for clip.mov (exit 1)')
+  end
 end


### PR DESCRIPTION
Back-port of the WhisperX upgrade shipped to ButterCut Pro, adapted to this repo's Homebrew-based setup flow.

## What changed

- **WhisperX 3.4.2 → 3.8.6, pyannote-audio 3.4.0 → 4.0.7** in `requirements.txt`, the setup skill, and docs. (The old pyannote `<4` constraint is now inverted — whisperx 3.8.x *requires* ≥4.)
- **The ML stack is now pinned exactly** (torch, torchaudio, torchvision, torchcodec, faster-whisper, ctranslate2, transformers, huggingface-hub, lightning, numpy, pandas). whisperx/pyannote declare only open floors for most of these, so unpinned installs resolve whatever is newest that day. The transitive long tail deliberately stays unpinned.
- **Setup installs `-r requirements.txt`** instead of naming packages inline — one source of truth.
- **`update-buttercut` now syncs the WhisperX venv to `requirements.txt` after pulling** — previously updates only ran `bundle install`, so a stale venv stayed stale forever.
- **`TranscribeJob` self-heals stale venvs:** when whisperx dies with a Python traceback (the stale-install signature, not bad footage), the error carries the exact pip resync command plus the traceback tail. This matters because the skill-based venv sync only takes effect from the second update onward — the transition update runs under the old skill text.

## Why

Transcription breaks on recently-installed setups, two independent ways: pyannote 3.4.0 never capped torch/torchaudio, so fresh venvs resolve torchaudio ≥2.9 (removed `AudioMetaData` → whisperx crashes at import) or torch ≥2.6 (`weights_only` default flip → whisperx's bundled VAD checkpoint fails to unpickle). Reproduced locally: every clip failed on a fresh 3.4.2 install; a working baseline required forcing torch 2.5.1.

## Verification (done on the Pro side; these files are identical or equivalently adapted)

- ~14 min of real footage (6 clips, 4 cameras) transcribed with both versions: word-for-word identical text, matched word starts within ~30 ms median. Where timings differ, 3.8.6 is more accurate — 3.4.2 stretched words across silence gaps into multi-second spans.
- Clean venv install from the pinned file: resolves exactly, `pip check` clean.
- Simulated 3.4.2-era venv upgraded in place via the new sync command: clean resolve, transcribes correctly after.
- End-to-end: fresh 3-clip library through `process_footage.rb` — transcripts 3/3, contact sheets 3/3.
- Silent clips: whisperx 3.8+ exits 0 with a valid empty-segments JSON; the no-speech rescue path remains for older versions.

## Reviewer notes

- **torchcodec warning is expected and harmless:** the new whisperx dep may log a `libavutil`/LC_RPATH warning at startup; whisperx decodes through the ffmpeg *binary*, so transcription is unaffected. Documented in requirements.txt and setup troubleshooting.
- The RSpec suite in my checkout has 73 pre-existing environment failures (no ffmpeg on the non-interactive PATH — `MediaTools::MissingBinary`) on clean main; this change adds none. The new TranscribeJob specs stub the ffmpeg preflight so they're hermetic.