### PR TITLE
core: Fix FCPXML export orientation for rotated-portrait footage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fixed an issue with some vertical footage not embedding correctly.
 - **Transcription is sturdier.** ButterCut now runs the current WhisperX release (3.8.6, with pyannote-audio 4.0.7). This fixes the transcription failures some users hit on the old pinned version, and improves word-level timing accuracy so cuts land on cleaner points.
 
 ## [0.9.0] - 2026-08-09

--- a/lib/buttercut/editor_base_core.rb
+++ b/lib/buttercut/editor_base_core.rb
@@ -115,6 +115,16 @@ class ButterCut
       self.class.extract_rotation(video_stream(video_path))
     end
 
+    def quarter_turn?(video_path)
+      [90, 270].include?(video_rotation(video_path))
+    end
+
+    def display_dimensions(asset)
+      return [asset[:height], asset[:width]] if [90, 270].include?(asset[:rotation].to_i)
+
+      [asset[:width], asset[:height]]
+    end
+
     def video_duration(video_path)
       metadata = extract_metadata(video_path)
       metadata['format']['duration'].to_f
@@ -369,12 +379,19 @@ class ButterCut
       @timeline[:height] || source_format_height
     end
 
+    # The sequence follows the first video clip's *display* orientation, so a
+    # quarter-turn source gives a portrait timeline; an explicit `timeline:`
+    # block still wins.
     def source_format_width
-      first_video_path ? video_width(first_video_path) : 1920
+      return 1920 unless first_video_path
+
+      quarter_turn?(first_video_path) ? video_height(first_video_path) : video_width(first_video_path)
     end
 
     def source_format_height
-      first_video_path ? video_height(first_video_path) : 1080
+      return 1080 unless first_video_path
+
+      quarter_turn?(first_video_path) ? video_width(first_video_path) : video_height(first_video_path)
     end
 
     def format_frame_rate

--- a/lib/buttercut/fcpx_core.rb
+++ b/lib/buttercut/fcpx_core.rb
@@ -191,15 +191,21 @@ class ButterCut
       end
     end
 
+    # The key and id use DISPLAY dimensions — a quarter-turn source swaps its
+    # stored frame. Final Cut and Resolve rotate the pixels upright from the
+    # source flag themselves, but they trust the declared format, so upright
+    # and rotated sources of the same stored frame stay distinct formats.
     def video_format_key(asset)
-      [asset[:width], asset[:height], asset[:frame_duration], asset[:color_space]]
+      width, height = display_dimensions(asset)
+      [width, height, asset[:frame_duration], asset[:color_space]]
     end
 
     # Deterministic, human-readable id: "r_fmt_3840x2160_1000_30000_9-1-9".
     def video_format_id(asset)
+      width, height = display_dimensions(asset)
       rate = asset[:frame_duration].delete_suffix('s').tr('/', '_')
       color = asset[:color_space][/[\d-]+/]
-      "r_fmt_#{asset[:width]}x#{asset[:height]}_#{rate}_#{color}"
+      "r_fmt_#{width}x#{height}_#{rate}_#{color}"
     end
 
     # One rate-undefined format resource per unique still dimensions, keyed

--- a/lib/buttercut/premiere_core.rb
+++ b/lib/buttercut/premiere_core.rb
@@ -6,22 +6,7 @@ class ButterCut
   # rotation flags and maps frame sizes 1:1 — so rotation and scale-to-fit
   # are baked into the timeline as a Basic Motion filter.
   class Premiere < FCP7
-    # The sequence follows the first video clip's *display* orientation, so a
-    # quarter-turn source gives a portrait timeline; an explicit `timeline:`
-    # block still wins.
-    def source_format_width
-      first_video_path && quarter_turn?(first_video_path) ? video_height(first_video_path) : super
-    end
-
-    def source_format_height
-      first_video_path && quarter_turn?(first_video_path) ? video_width(first_video_path) : super
-    end
-
     private
-
-    def quarter_turn?(video_path)
-      [90, 270].include?(video_rotation(video_path))
-    end
 
     # One Basic Motion effect carries both corrections; an upright clip at
     # sequence size gets no filter at all.

--- a/spec/buttercut/fcpx_spec.rb
+++ b/spec/buttercut/fcpx_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe ButterCut::FCPX do
   let(:gh5_video_path) { File.expand_path('../fixtures/media/P1044376_timecode_fixture.mov', __dir__) }
 
   def build_metadata(frame_rate:, duration_seconds:, width: 1280, height: 720, sample_rate: '48000',
-                     timecode: nil, color_primaries: 'bt709', color_transfer: 'bt709', audio_streams: nil)
+                     timecode: nil, color_primaries: 'bt709', color_transfer: 'bt709', rotation: nil,
+                     audio_streams: nil)
     video_stream = {
       'codec_type' => 'video',
       'width' => width,
@@ -17,6 +18,9 @@ RSpec.describe ButterCut::FCPX do
       'color_transfer' => color_transfer
     }
     video_stream['tags'] = { 'timecode' => timecode } if timecode
+    if rotation
+      video_stream['side_data_list'] = [{ 'side_data_type' => 'Display Matrix', 'rotation' => rotation }]
+    end
 
     audio_streams ||= [{ 'codec_type' => 'audio', 'sample_rate' => sample_rate }]
 
@@ -779,6 +783,85 @@ RSpec.describe ButterCut::FCPX do
         xml = generator.to_xml
 
         expect(xml.scan(/<format /).length).to eq(1)
+      end
+    end
+
+    # Vertical phone footage is stored as a LANDSCAPE frame (e.g. 3840x2160)
+    # with a display-matrix rotation flag. Final Cut and Resolve rotate the
+    # pixels upright from that flag, but the <format> elements must declare
+    # DISPLAY dimensions — a raw landscape declaration squeezes the upright
+    # clip into a landscape sequence with a landscape-declared asset format.
+    describe 'rotated-portrait sources' do
+      let(:rotated_path)    { '/tmp/fcpx_rotated.mov' }
+      let(:cw_rotated_path) { '/tmp/fcpx_cw_rotated.mov' }
+      let(:upright_path)    { '/tmp/fcpx_upright.mov' }
+      let(:metadata_by_path) do
+        {
+          # Vertical footage stored landscape with a -90 display-matrix flag.
+          rotated_path => build_metadata(frame_rate: '30/1', duration_seconds: 4.0,
+                                         width: 3840, height: 2160, rotation: -90),
+          # The other quarter-turn: +90 normalizes to 270 clockwise.
+          cw_rotated_path => build_metadata(frame_rate: '30/1', duration_seconds: 4.0,
+                                            width: 3840, height: 2160, rotation: 90),
+          # Ordinary landscape footage of the same stored frame, no rotation.
+          upright_path => build_metadata(frame_rate: '30/1', duration_seconds: 3.0,
+                                         width: 3840, height: 2160)
+        }
+      end
+
+      before { stub_ffprobe(metadata_by_path) }
+
+      def doc_for(clips)
+        Nokogiri::XML(ButterCut::FCPX.new(clips).to_xml)
+      end
+
+      it 'declares a portrait timeline format when the first clip is a quarter turn' do
+        format = doc_for([{ path: rotated_path }]).at_xpath('//format[@id="r1"]')
+
+        expect(format['width']).to eq('2160')
+        expect(format['height']).to eq('3840')
+      end
+
+      it 'treats a +90 source the same as a -90 source' do
+        format = doc_for([{ path: cw_rotated_path }]).at_xpath('//format[@id="r1"]')
+
+        expect(format['width']).to eq('2160')
+        expect(format['height']).to eq('3840')
+      end
+
+      it 'keeps a lone quarter-turn clip on the timeline format' do
+        doc = doc_for([{ path: rotated_path }])
+
+        expect(doc.xpath('//format').length).to eq(1)
+        expect(doc.at_xpath('//asset')['format']).to eq('r1')
+      end
+
+      it 'declares display dimensions in a rotated asset format id and element' do
+        # Upright first clip -> landscape timeline; the rotated clip differs
+        # and gets its own format, declared portrait.
+        doc = doc_for([{ path: upright_path }, { path: rotated_path }])
+        format = doc.at_xpath('//format[@id="r_fmt_2160x3840_1_30_1-1-1"]')
+
+        expect(format).not_to be_nil
+        expect(format['width']).to eq('2160')
+        expect(format['height']).to eq('3840')
+      end
+
+      it 'keeps upright and quarter-turn variants of the same stored frame distinct' do
+        # Rotated first clip -> portrait timeline (r1); the upright clip of the
+        # same stored 3840x2160 must land on its own landscape format, not r1.
+        doc = doc_for([{ path: rotated_path }, { path: upright_path }])
+        formats = doc.xpath('//format').to_h { |f| [f['id'], [f['width'], f['height']]] }
+
+        expect(formats['r1']).to eq(%w[2160 3840])
+        expect(formats['r_fmt_3840x2160_1_30_1-1-1']).to eq(%w[3840 2160])
+      end
+
+      it 'leaves upright sources on raw landscape dimensions' do
+        format = doc_for([{ path: upright_path }]).at_xpath('//format[@id="r1"]')
+
+        expect(format['width']).to eq('3840')
+        expect(format['height']).to eq('2160')
       end
     end
   end

--- a/spec/buttercut/resolve_legacy_spec.rb
+++ b/spec/buttercut/resolve_legacy_spec.rb
@@ -42,4 +42,36 @@ RSpec.describe ButterCut::ResolveLegacy do
     expect(xml).to include('<effectid>audiolevels</effectid>')
     expect(xml).to match(%r{<parameterid>level</parameterid>\s*<name>Level</name>.*?<value>0</value>}m)
   end
+
+  # Resolve auto-corrects the pixels from the source rotation flag, but the
+  # sequence frame follows what the XML declares — a quarter-turn first clip
+  # needs a portrait sequence. No baked rotation filter: that's Premiere-only.
+  context 'with rotated-portrait footage stored as a landscape frame' do
+    let(:metadata) do
+      {
+        'streams' => [
+          { 'codec_type' => 'video', 'codec_name' => 'h264',
+            'width' => 3840, 'height' => 2160, 'r_frame_rate' => '30/1',
+            'color_space' => 'bt709', 'color_primaries' => 'bt709', 'color_transfer' => 'bt709',
+            'side_data_list' => [{ 'side_data_type' => 'Display Matrix', 'rotation' => -90 }] },
+          { 'codec_type' => 'audio', 'sample_rate' => '48000' }
+        ],
+        'format' => { 'duration' => '4.0', 'tags' => {} }
+      }
+    end
+
+    it 'swaps the sequence dimensions to portrait' do
+      xml = described_class.new([{ path: video_path }]).to_xml
+      format = xml[%r{<format>.*?</format>}m]
+
+      expect(format).to include('<width>2160</width>')
+      expect(format).to include('<height>3840</height>')
+    end
+
+    it 'does not bake a rotation filter into the clip' do
+      xml = described_class.new([{ path: video_path }]).to_xml
+
+      expect(xml).not_to include('<name>Basic Motion</name>')
+    end
+  end
 end

--- a/spec/buttercut/resolve_spec.rb
+++ b/spec/buttercut/resolve_spec.rb
@@ -44,6 +44,35 @@ RSpec.describe ButterCut::Resolve do
     expect(xml).not_to include('db"')
   end
 
+  # Resolve reads the source rotation flag to display the pixels upright, but
+  # it trusts the declared <format> dimensions — vertical phone footage stored
+  # landscape needs a portrait declaration or it lands in a landscape timeline.
+  context 'with rotated-portrait footage stored as a landscape frame' do
+    let(:rotated_path) { '/tmp/resolve_rotated.mov' }
+
+    let(:metadata) do
+      {
+        'streams' => [
+          { 'codec_type' => 'video', 'codec_name' => 'h264',
+            'width' => 3840, 'height' => 2160, 'r_frame_rate' => '30/1',
+            'color_space' => 'bt709', 'color_primaries' => 'bt709', 'color_transfer' => 'bt709',
+            'side_data_list' => [{ 'side_data_type' => 'Display Matrix', 'rotation' => -90 }] },
+          { 'codec_type' => 'audio', 'sample_rate' => '48000' }
+        ],
+        'format' => { 'duration' => '4.0', 'tags' => {} }
+      }
+    end
+
+    it 'declares portrait dimensions in the timeline and asset format' do
+      doc = Nokogiri::XML(described_class.new([{ path: rotated_path }]).to_xml)
+      format = doc.at_xpath('//format[@id="r1"]')
+
+      expect(format['width']).to eq('2160')
+      expect(format['height']).to eq('3840')
+      expect(doc.at_xpath('//asset')['format']).to eq('r1')
+    end
+  end
+
   # Sony XAVC hangs start timecode off an `rtmd` stream with no timecode track.
   # Final Cut can't read it and needs zero; Resolve reads it and needs the match.
   context 'with timecode on a Sony rtmd metadata stream and no timecode track' do


### PR DESCRIPTION
## Summary

Back-port of barefootford/buttercut-pro#77 (fixes barefootford/buttercut-pro#76).

Vertical phone footage is stored as a landscape frame (e.g. 1920x1080) with a display-matrix rotation flag. The FCPXML generators declared the stored dimensions, so Final Cut and Resolve laid the upright clip into a landscape sequence with a landscape-declared asset format — the clip imported sideways-framed instead of on a vertical timeline.

## Changes

- Declare display dimensions in FCPXML format elements: a quarter-turn (90/270) first clip infers a portrait timeline, and rotated assets get portrait per-asset format elements. An explicit `timeline:` block still wins.
- Add `quarter_turn?` and `display_dimensions` helpers to `EditorBase`; remove Premiere's private duplicate (its baked Basic Motion rotation/scale filters already handled orientation and are unchanged).
- Key per-asset format resources on display dimensions so upright and rotated sources of the same stored frame stay distinct formats.
- Add rotated-portrait specs for FCPX, Resolve, and ResolveLegacy.

Adapted to this repo's `video_format_key`/`video_format_id` format-resource scheme (the Pro patch didn't apply directly).

## Testing

- `bundle exec rspec` — 424 examples, 0 failures.
- Verified the Pro version of this change empirically in Final Cut Pro, DaVinci Resolve, and Premiere Pro with real iPhone rotated footage (portrait sequences import correctly; landscape-first mixed timelines keep the rotated clip upright and pillarboxed).