### PR TITLE
Handle silent and audio-less clips in transcription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Silent clips no longer break transcription.** Some WhisperX versions handle a clip with no dialogue — common for B-roll — by exiting cleanly without writing a transcript, which made processing stop with an error. ButterCut now recognizes that case and records the clip as having no dialogue, the same as it always has for other WhisperX versions.
 - Fixed an issue with some vertical footage not embedding correctly.
+- Improved how transcription handles footage with no audio stream or no spoken words, which now gets an empty transcript instead of an error.
+- Improved how transcription detects a WhisperX crash, which could previously be reported as a missing transcript.
 - **Transcription is sturdier.** ButterCut now runs the current WhisperX release (3.8.6, with pyannote-audio 4.0.7). This fixes the transcription failures some users hit on the old pinned version, and improves word-level timing accuracy so cuts land on cleaner points.
 
 ## [0.9.0] - 2026-08-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Silent clips no longer break transcription.** Some WhisperX versions handle a clip with no dialogue — common for B-roll — by exiting cleanly without writing a transcript, which made processing stop with an error. ButterCut now recognizes that case and records the clip as having no dialogue, the same as it always has for other WhisperX versions.
 - Fixed an issue with some vertical footage not embedding correctly.
 - **Transcription is sturdier.** ButterCut now runs the current WhisperX release (3.8.6, with pyannote-audio 4.0.7). This fixes the transcription failures some users hit on the old pinned version, and improves word-level timing accuracy so cuts land on cleaner points.
 

--- a/lib/buttercut/media_tools.rb
+++ b/lib/buttercut/media_tools.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require %q(open3)
+
 # Resolves the ffmpeg/ffprobe binaries ButterCut shells out to. Static builds
 # may be installed into the gitignored dependencies/ directory at the repo
 # root; when a binary is there it wins over PATH, so a ButterCut folder can be
@@ -16,6 +18,20 @@ module MediaTools
   def self.ffmpeg = resolve('ffmpeg')
   def self.ffprobe = resolve('ffprobe')
 
+  # The setup skill installs WhisperX into this venv and puts a wrapper script
+  # on PATH. Wrappers written before 2026-09 ended with `deactivate`, so the
+  # shell reported *its* exit status — 0 — no matter how whisperx died, and a
+  # crash looked like a clean run that wrote no transcript. Calling the venv
+  # binary directly sidesteps every wrapper ever installed; the bare name is
+  # the fallback for installs that keep whisperx somewhere else.
+  WHISPERX_VENV_BIN = File.expand_path('~/.buttercut/venv/bin/whisperx')
+
+  def self.whisperx
+    return WHISPERX_VENV_BIN if File.executable?(WHISPERX_VENV_BIN)
+
+    'whisperx'
+  end
+
   def self.resolve(name)
     local = File.join(DEPENDENCIES_DIR, name)
     return local if File.executable?(local)
@@ -29,5 +45,20 @@ module MediaTools
     ENV.fetch('PATH', '').split(File::PATH_SEPARATOR).any? do |dir|
       !dir.empty? && File.executable?(File.join(dir, name))
     end
+  end
+
+  # True when ffprobe finds at least one audio stream in the file. Picture-only
+  # recordings — many drone bodies, some action cams, screen captures — have
+  # none, and handing one to WhisperX only makes the ffmpeg decode inside it
+  # fail. If ffprobe itself can't read the file, answer true: the transcription
+  # step will then hit the real problem against the real tool and report that.
+  def self.audio_stream?(path)
+    output, status = Open3.capture2e(
+      ffprobe, '-v', 'error', '-select_streams', 'a',
+      '-show_entries', 'stream=codec_type', '-of', 'csv=p=0', path
+    )
+    return true unless status.success?
+
+    output.lines.any? { |line| line.strip == 'audio' }
   end
 end

--- a/lib/buttercut/transcribe_job.rb
+++ b/lib/buttercut/transcribe_job.rb
@@ -39,15 +39,33 @@ class TranscribeJob < Job
   private
 
   NO_SPEECH_MARKER = 'No active speech found in audio'
+  LOAD_AUDIO_MARKER = 'Failed to load audio'
   PYTHON_TRACEBACK_MARKER = 'Traceback (most recent call last)'
 
-  # Returns true if whisperx produced a transcript file, false if it rescued a
-  # silent clip by writing an empty one. Raises on any other failure.
-  # Silent clips (common for B-roll) vary by whisperx version: some exit
-  # non-zero, some exit 0 after writing a valid empty-segments JSON, and some
-  # exit 0 having written nothing at all — so the rescue keys on NO_SPEECH_MARKER
-  # plus a missing transcript, not on the exit status.
+  # The outcome is read from the evidence — the output file and whisperx's
+  # own messages — before the exit status. The wrapper script older installs
+  # run whisperx through reports 0 for everything (see MediaTools.whisperx),
+  # so a status of 0 proves nothing on its own.
+  #
+  # Returns true if whisperx produced a transcript with dialogue in it, false
+  # if the clip is silent and got the empty no-dialogue transcript instead.
+  # Raises on any other failure.
+  #
+  # Silence comes in two shapes, and both end up as the same file on disk:
+  #   * no audio stream at all — picture-only drone and action-cam bodies,
+  #     screen captures. Caught up front with ffprobe so whisperx never runs;
+  #     the ffmpeg decode inside it would only fail.
+  #   * an audio stream with no speech — B-roll, ambient, a drone with a mic.
+  #     whisperx 3.8+ logs NO_SPEECH_MARKER and exits 0 with an empty-segments
+  #     JSON; older versions logged it and exited non-zero without writing
+  #     anything. Both are rescued here.
   def run_whisperx
+    FileUtils.mkdir_p(@output_dir)
+    unless MediaTools.audio_stream?(@video_path)
+      rescue_silent_clip
+      return false
+    end
+
     # WhisperX decodes audio by running a bare `ffmpeg` from PATH (see
     # whisperx/audio.py load_audio), so the subprocess gets MediaTools'
     # dependencies-first precedence via PATH — without this, installs whose
@@ -58,7 +76,7 @@ class TranscribeJob < Job
     env = { 'PATH' => [MediaTools::DEPENDENCIES_DIR, ENV.fetch('PATH', '')].join(':') }
     output, status = Open3.capture2e(
       env,
-      'whisperx', @video_path,
+      MediaTools.whisperx, @video_path,
       '--language', @language_code,
       '--model', @whisper_model,
       '--compute_type', 'float32',
@@ -66,17 +84,61 @@ class TranscribeJob < Job
       '--output_format', 'json',
       '--output_dir', @output_dir
     )
-    return true if status.success? && File.exist?(transcript_path)
+
+    if status.success? && File.exist?(transcript_path)
+      if empty_transcript?(transcript_path)
+        rescue_silent_clip
+        return false
+      end
+
+      return true
+    end
 
     if output.include?(NO_SPEECH_MARKER)
       rescue_silent_clip
       return false
     end
 
+    raise undecodable_audio_message(output) if output.include?(LOAD_AUDIO_MARKER)
     raise stale_install_message(output, status) if output.include?(PYTHON_TRACEBACK_MARKER)
     raise "whisperx failed for #{clip} (exit #{status.exitstatus})" unless status.success?
 
-    raise "whisperx produced no transcript at #{transcript_path}"
+    raise no_output_message(output)
+  end
+
+  # whisperx 3.8+ answers a silent audio stream with {"segments": []}. Treat
+  # that as the rescue case so every silent clip carries the same no-dialogue
+  # note, whether or not its file had an audio stream to begin with.
+  def empty_transcript?(path)
+    Array(JSON.parse(File.read(path))['segments']).empty?
+  rescue JSON::ParserError
+    false
+  end
+
+  # ffprobe saw an audio stream but ffmpeg couldn't decode it (a codec it
+  # doesn't handle, a damaged track). That's the footage, not the install, so
+  # don't send the user off to reinstall WhisperX.
+  def undecodable_audio_message(output)
+    tail = output.lines.last(15).join
+    <<~MSG
+      whisperx couldn't decode the audio in #{clip} — ffmpeg can't read its audio stream. This is the footage, not the WhisperX install.
+      Fix: convert the clip with ffmpeg to a supported container and codec, add the converted file to the library, and remove the original entry (see unsupported_media in AGENTS.md for the detect-tell-convert-swap path).
+      Last output from ffmpeg:
+      #{tail}
+    MSG
+  end
+
+  # whisperx exited 0 without writing a transcript and without saying it found
+  # no speech. This has been reported from the field and not reproduced, so
+  # carry whisperx's own output along — it's the only diagnostic a bug report
+  # will have.
+  def no_output_message(output)
+    tail = output.lines.last(15).join
+    <<~MSG
+      whisperx exited 0 but produced no transcript at #{transcript_path} for #{clip}.
+      Last output from whisperx:
+      #{tail}
+    MSG
   end
 
   # A Python traceback means whisperx itself crashed rather than choking on the
@@ -88,8 +150,11 @@ class TranscribeJob < Job
   # update flows didn't sync the venv.
   def stale_install_message(output, status)
     tail = output.lines.last(15).join
+    # A wrapper script can report 0 for a crash (see MediaTools.whisperx), so
+    # only quote the exit status when it says something.
+    exit_note = status.success? ? '' : " (exit #{status.exitstatus})"
     <<~MSG
-      whisperx crashed with a Python error for #{clip} (exit #{status.exitstatus}). This usually means the WhisperX install is stale or broken, not that the footage is bad.
+      whisperx crashed with a Python error for #{clip}#{exit_note}. This usually means the WhisperX install is stale or broken, not that the footage is bad.
       Fix: from the ButterCut directory, sync the WhisperX packages to ButterCut's pinned versions:
         ~/.buttercut/venv/bin/pip install --only-binary :all: --no-binary antlr4-python3-runtime,docopt -r requirements.txt
       then retry this clip. If that doesn't fix it, run the setup skill.

--- a/lib/buttercut/transcribe_job.rb
+++ b/lib/buttercut/transcribe_job.rb
@@ -43,9 +43,10 @@ class TranscribeJob < Job
 
   # Returns true if whisperx produced a transcript file, false if it rescued a
   # silent clip by writing an empty one. Raises on any other failure.
-  # whisperx 3.8+ handles silent clips itself: it prints NO_SPEECH_MARKER but
-  # exits 0 with a valid empty-segments JSON, so the rescue below only fires on
-  # older whisperx versions that exit non-zero.
+  # Silent clips (common for B-roll) vary by whisperx version: some exit
+  # non-zero, some exit 0 after writing a valid empty-segments JSON, and some
+  # exit 0 having written nothing at all — so the rescue keys on NO_SPEECH_MARKER
+  # plus a missing transcript, not on the exit status.
   def run_whisperx
     # WhisperX decodes audio by running a bare `ffmpeg` from PATH (see
     # whisperx/audio.py load_audio), so the subprocess gets MediaTools'
@@ -65,7 +66,7 @@ class TranscribeJob < Job
       '--output_format', 'json',
       '--output_dir', @output_dir
     )
-    return true if status.success?
+    return true if status.success? && File.exist?(transcript_path)
 
     if output.include?(NO_SPEECH_MARKER)
       rescue_silent_clip
@@ -73,8 +74,9 @@ class TranscribeJob < Job
     end
 
     raise stale_install_message(output, status) if output.include?(PYTHON_TRACEBACK_MARKER)
+    raise "whisperx failed for #{clip} (exit #{status.exitstatus})" unless status.success?
 
-    raise "whisperx failed for #{clip} (exit #{status.exitstatus})"
+    raise "whisperx produced no transcript at #{transcript_path}"
   end
 
   # A Python traceback means whisperx itself crashed rather than choking on the
@@ -96,10 +98,13 @@ class TranscribeJob < Job
     MSG
   end
 
+  def transcript_path
+    File.join(@output_dir, "#{File.basename(@video_path, '.*')}.json")
+  end
+
   def rescue_silent_clip
-    path = File.join(@output_dir, "#{File.basename(@video_path, '.*')}.json")
     FileUtils.mkdir_p(@output_dir)
-    File.write(path, JSON.pretty_generate(
+    File.write(transcript_path, JSON.pretty_generate(
       '_note'        => 'no dialogue',
       'segments'     => [],
       'word_segments' => [],
@@ -108,10 +113,7 @@ class TranscribeJob < Job
   end
 
   def prepare_transcript
-    json = File.join(@output_dir, "#{File.basename(@video_path, '.*')}.json")
-    raise "whisperx produced no transcript at #{json}" unless File.exist?(json)
-
-    ok = system('ruby', PREPARE_SCRIPT, json, @video_path)
+    ok = system('ruby', PREPARE_SCRIPT, transcript_path, @video_path)
     raise "prepare_audio_script failed for #{clip}" unless ok
   end
 end

--- a/skills/setup/advanced-setup.md
+++ b/skills/setup/advanced-setup.md
@@ -113,9 +113,9 @@ deactivate
 # Create wrapper script
 cat > ~/.buttercut/whisperx << 'EOF'
 #!/bin/bash
-source ~/.buttercut/venv/bin/activate
-whisperx "$@"
-deactivate
+# exec so whisperx's own exit status is the wrapper's. ButterCut reads it to
+# tell a crash from a clean run — a trailing command here would hide crashes.
+exec "$HOME/.buttercut/venv/bin/whisperx" "$@"
 EOF
 chmod +x ~/.buttercut/whisperx
 

--- a/skills/setup/simple-setup.md
+++ b/skills/setup/simple-setup.md
@@ -212,9 +212,9 @@ Run the `pip install` from the buttercut directory so `requirements.txt` resolve
 ```bash
 cat > ~/.buttercut/whisperx << 'EOF'
 #!/bin/bash
-source ~/.buttercut/venv/bin/activate
-whisperx "$@"
-deactivate
+# exec so whisperx's own exit status is the wrapper's. ButterCut reads it to
+# tell a crash from a clean run — a trailing command here would hide crashes.
+exec "$HOME/.buttercut/venv/bin/whisperx" "$@"
 EOF
 chmod +x ~/.buttercut/whisperx
 ```
@@ -288,5 +288,5 @@ running ButterCut in:
 - **Mise not activating**: Open new terminal, run `mise doctor`
 - **Wrong Ruby/Python**: Run `mise trust && mise install` from buttercut directory
 - **WhisperX not found**: Ensure `~/.buttercut` is in PATH, open new terminal
-- **WhisperX import errors**: The wrapper script handles venv activation automatically; ensure you're using `~/.buttercut/whisperx` not calling whisperx directly
+- **WhisperX import errors**: `~/.buttercut/whisperx` runs the venv's own whisperx; if it's a wrapper from an older setup that ends in `deactivate`, rewrite it with Step 7 — that shape reported exit 0 even when whisperx crashed
 - **`torchcodec` / `libavutil` warning when WhisperX starts**: Harmless — torchcodec's native FFmpeg bindings may fail to load, but WhisperX decodes audio through the ffmpeg binary, so transcription still works. Ignore it.

--- a/skills/update-buttercut/SKILL.md
+++ b/skills/update-buttercut/SKILL.md
@@ -40,6 +40,12 @@ Also sync the WhisperX install to the repo's pinned versions — updates sometim
 ```
 This is fast and a no-op when the pins haven't changed. If `~/.buttercut/venv` doesn't exist, the install predates the standard venv layout — skip this command (that Mac's transcription setup lives wherever `.buttercut_env` points). If it fails because the network dropped, continue the update but tell the user transcription may misbehave until it's re-run.
 
+While you're there, if `~/.buttercut/whisperx` exists and contains the line `deactivate`, rewrite it — that older wrapper reported exit 0 even when whisperx crashed:
+
+```bash
+grep -q '^deactivate' ~/.buttercut/whisperx 2>/dev/null && printf '%s\n' '#!/bin/bash' 'exec "$HOME/.buttercut/venv/bin/whisperx" "$@"' > ~/.buttercut/whisperx
+```
+
 **5. Tell the user what they got — in their language:**
 ```bash
 git diff <sha-from-step-1>..HEAD -- CHANGELOG.md

--- a/spec/buttercut/media_tools_spec.rb
+++ b/spec/buttercut/media_tools_spec.rb
@@ -53,3 +53,51 @@ RSpec.describe MediaTools do
     expect(MediaTools.ffmpeg).to eq('ffmpeg')
   end
 end
+
+# Real ffprobe against real files: the fixture mov has an audio track, a lavfi
+# clip rendered with -an has none. Uses the ffmpeg/ffprobe MediaTools resolves for
+# the suite (dependencies/ or PATH), like the contact-sheet specs do.
+RSpec.describe MediaTools, '.audio_stream?' do
+  let(:tmp) { Dir.mktmpdir('bc-audio-stream') }
+  after { FileUtils.remove_entry(tmp) }
+
+  it 'is true for a file with an audio stream' do
+    expect(MediaTools.audio_stream?(File.join(__dir__, '../fixtures/media/MVI_0309_720p.mov'))).to be(true)
+  end
+
+  it 'is false for picture-only footage' do
+    clip = File.join(tmp, 'drone.mp4')
+    system(MediaTools.ffmpeg, '-y', '-loglevel', 'error', '-f', 'lavfi', '-i', 'testsrc=duration=1:size=64x64:rate=10',
+           '-an', '-c:v', 'libx264', '-pix_fmt', 'yuv420p', clip, exception: true)
+
+    expect(MediaTools.audio_stream?(clip)).to be(false)
+  end
+
+  # ffprobe can't read the file at all: don't guess "silent" and quietly skip
+  # transcription — let whisperx run and report the real failure.
+  it 'assumes audio when ffprobe cannot read the file' do
+    expect(MediaTools.audio_stream?(File.join(tmp, 'missing.mov'))).to be(true)
+  end
+end
+
+RSpec.describe MediaTools, '.whisperx' do
+  let(:tmp) { Dir.mktmpdir('bc-whisperx') }
+  after { FileUtils.remove_entry(tmp) }
+
+  # The venv binary is preferred over anything on PATH so the job never runs
+  # through a wrapper script — older ones reported exit 0 for every crash.
+  it 'prefers the venv binary when it exists' do
+    bin = File.join(tmp, 'whisperx')
+    File.write(bin, "#!/bin/sh\n")
+    File.chmod(0o755, bin)
+    stub_const('MediaTools::WHISPERX_VENV_BIN', bin)
+
+    expect(MediaTools.whisperx).to eq(bin)
+  end
+
+  it 'falls back to the bare name for installs without the standard venv' do
+    stub_const('MediaTools::WHISPERX_VENV_BIN', File.join(tmp, 'absent'))
+
+    expect(MediaTools.whisperx).to eq('whisperx')
+  end
+end

--- a/spec/buttercut/transcribe_job_spec.rb
+++ b/spec/buttercut/transcribe_job_spec.rb
@@ -1,13 +1,29 @@
 require 'spec_helper'
+require 'tmpdir'
 require_relative '../../lib/buttercut/transcribe_job'
 
 RSpec.describe TranscribeJob do
+  let(:output_dir) { Dir.mktmpdir }
+  after { FileUtils.remove_entry(output_dir) }
+
   let(:job) do
     described_class.new(
       library_name: 'test-lib', clip: 'clip.mov',
-      video_path: '/footage/clip.mov', output_dir: '/tmp/out',
+      video_path: '/footage/clip.mov', output_dir: output_dir,
       language_code: 'en', whisper_model: 'small'
     )
+  end
+
+  let(:transcript_path) { File.join(output_dir, 'clip.json') }
+
+  # Simulates one whisperx run: `writes_json` mirrors whether the real binary
+  # left a transcript behind, which varies independently of the exit status.
+  def stub_whisperx(output, success:, writes_json: false)
+    allow(MediaTools).to receive(:ffmpeg) # preflight only — keep the spec hermetic
+    allow(Open3).to receive(:capture2e) do
+      File.write(transcript_path, '{"segments": []}') if writes_json
+      [output, instance_double(Process::Status, success?: success, exitstatus: success ? 0 : 1)]
+    end
   end
 
   # WhisperX resolves a bare `ffmpeg` from PATH internally, so the subprocess
@@ -16,6 +32,7 @@ RSpec.describe TranscribeJob do
     captured_env = nil
     allow(Open3).to receive(:capture2e) do |env, *|
       captured_env = env
+      File.write(transcript_path, '{"segments": []}')
       ['', instance_double(Process::Status, success?: true)]
     end
     allow(job).to receive(:prepare_transcript)
@@ -26,18 +43,32 @@ RSpec.describe TranscribeJob do
     expect(captured_env['PATH']).to include(ENV.fetch('PATH'))
   end
 
-  def stub_whisperx_failure(output)
-    allow(MediaTools).to receive(:ffmpeg) # preflight only — keep the spec hermetic
-    allow(Open3).to receive(:capture2e).and_return(
-      [output, instance_double(Process::Status, success?: false, exitstatus: 1)]
-    )
+  # Silent-clip handling varies by whisperx version: some builds exit non-zero,
+  # some exit 0 without writing any JSON. Both must land on the same rescue —
+  # B-roll with no dialogue is normal footage, not an error.
+  ['exits 0 without writing a transcript', 'exits non-zero'].each do |variant|
+    it "rescues a silent clip when whisperx #{variant}" do
+      stub_whisperx("No active speech found in audio\n", success: variant.start_with?('exits 0'))
+      expect(job).not_to receive(:prepare_transcript)
+
+      job.perform
+
+      expect(JSON.parse(File.read(transcript_path)))
+        .to include('_note' => 'no dialogue', 'segments' => [], 'word_segments' => [])
+    end
+  end
+
+  it 'raises when whisperx exits 0 with no transcript and no no-speech notice' do
+    stub_whisperx("some unrelated noise\n", success: true)
+
+    expect { job.perform }.to raise_error("whisperx produced no transcript at #{transcript_path}")
   end
 
   # A Python traceback means whisperx itself is broken (a stale venv), not the
   # clip — the error must point at the requirements.txt resync so any session
   # can self-heal, even one updated by an older skill that didn't sync the venv.
   it 'points at the venv resync when whisperx dies with a Python traceback' do
-    stub_whisperx_failure(<<~OUTPUT)
+    stub_whisperx(<<~OUTPUT, success: false)
       Traceback (most recent call last):
         File "whisperx/asr.py", line 16, in <module>
       AttributeError: module 'torchaudio' has no attribute 'AudioMetaData'
@@ -50,7 +81,7 @@ RSpec.describe TranscribeJob do
   end
 
   it 'raises the plain failure message when whisperx fails without a traceback' do
-    stub_whisperx_failure("some ffmpeg decode noise\n")
+    stub_whisperx("some ffmpeg decode noise\n", success: false)
 
     expect { job.perform }.to raise_error('whisperx failed for clip.mov (exit 1)')
   end

--- a/spec/buttercut/transcribe_job_spec.rb
+++ b/spec/buttercut/transcribe_job_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe TranscribeJob do
   let(:output_dir) { Dir.mktmpdir }
   after { FileUtils.remove_entry(output_dir) }
 
+  # The clip's audio stream is probed with ffprobe before whisperx runs; the
+  # specs below fake footage paths, so answer "has audio" unless a spec says
+  # otherwise. The ffmpeg preflight is stubbed too, to keep the spec hermetic.
+  before do
+    allow(MediaTools).to receive(:audio_stream?).and_return(true)
+    allow(MediaTools).to receive(:ffmpeg)
+  end
+
   let(:job) do
     described_class.new(
       library_name: 'test-lib', clip: 'clip.mov',
@@ -14,61 +22,120 @@ RSpec.describe TranscribeJob do
     )
   end
 
-  let(:transcript_path) { File.join(output_dir, 'clip.json') }
+  SPOKEN = '{"segments": [{"start": 0.0, "end": 1.0, "text": "hello"}], "language": "en"}'.freeze
+  SILENT = '{"segments": [], "language": "en"}'.freeze
 
-  # Simulates one whisperx run: `writes_json` mirrors whether the real binary
-  # left a transcript behind, which varies independently of the exit status.
-  def stub_whisperx(output, success:, writes_json: false)
-    allow(MediaTools).to receive(:ffmpeg) # preflight only — keep the spec hermetic
-    allow(Open3).to receive(:capture2e) do
-      File.write(transcript_path, '{"segments": []}') if writes_json
-      [output, instance_double(Process::Status, success?: success, exitstatus: success ? 0 : 1)]
+  # The fake whisperx writes `<basename>.json` into whatever --output_dir it
+  # was given, exactly as the real binary does.
+  def stub_whisperx(json: SPOKEN, output: '')
+    allow(Open3).to receive(:capture2e) do |env, *cmd|
+      whisper_out = cmd[cmd.index('--output_dir') + 1]
+      File.write(File.join(whisper_out, 'clip.json'), json) if json
+      @captured_env = env
+      @captured_cmd = cmd
+      [output, instance_double(Process::Status, success?: true)]
     end
+  end
+
+  def stub_whisperx_failure(output)
+    allow(Open3).to receive(:capture2e).and_return(
+      [output, instance_double(Process::Status, success?: false, exitstatus: 1)]
+    )
+  end
+
+  def transcript = JSON.parse(File.read(File.join(output_dir, 'clip.json')))
+
+  def expect_no_dialogue_transcript
+    expect(transcript).to include('_note' => 'no dialogue', 'segments' => [], 'video_path' => '/footage/clip.mov')
   end
 
   # WhisperX resolves a bare `ffmpeg` from PATH internally, so the subprocess
   # must see dependencies/ first — the env equivalent of MediaTools' precedence.
   it 'runs whisperx with dependencies/ leading the subprocess PATH' do
-    captured_env = nil
-    allow(Open3).to receive(:capture2e) do |env, *|
-      captured_env = env
-      File.write(transcript_path, '{"segments": []}')
-      ['', instance_double(Process::Status, success?: true)]
-    end
+    stub_whisperx
     allow(job).to receive(:prepare_transcript)
 
     job.perform
 
-    expect(captured_env['PATH'].split(':').first).to eq(MediaTools::DEPENDENCIES_DIR)
-    expect(captured_env['PATH']).to include(ENV.fetch('PATH'))
+    expect(@captured_env['PATH'].split(':').first).to eq(MediaTools::DEPENDENCIES_DIR)
+    expect(@captured_env['PATH']).to include(ENV.fetch('PATH'))
   end
 
-  # Silent-clip handling varies by whisperx version: some builds exit non-zero,
-  # some exit 0 without writing any JSON. Both must land on the same rescue —
-  # B-roll with no dialogue is normal footage, not an error.
-  ['exits 0 without writing a transcript', 'exits non-zero'].each do |variant|
-    it "rescues a silent clip when whisperx #{variant}" do
-      stub_whisperx("No active speech found in audio\n", success: variant.start_with?('exits 0'))
-      expect(job).not_to receive(:prepare_transcript)
+  it 'runs the whisperx binary MediaTools resolves, not whatever is on PATH' do
+    allow(MediaTools).to receive(:whisperx).and_return('/venv/bin/whisperx')
+    stub_whisperx
+    allow(job).to receive(:prepare_transcript)
 
-      job.perform
+    job.perform
 
-      expect(JSON.parse(File.read(transcript_path)))
-        .to include('_note' => 'no dialogue', 'segments' => [], 'word_segments' => [])
+    expect(@captured_cmd.first).to eq('/venv/bin/whisperx')
+  end
+
+  it 'keeps a transcript with dialogue and hands it to prepare_transcript' do
+    stub_whisperx
+    expect(job).to receive(:prepare_transcript)
+
+    job.perform
+
+    expect(transcript['segments'].first['text']).to eq('hello')
+  end
+
+  # Picture-only cameras (drone bodies, action cams) have no audio stream at
+  # all. whisperx can't decode what isn't there, so the job doesn't ask it to.
+  it 'writes the no-dialogue transcript without running whisperx when the clip has no audio stream' do
+    allow(MediaTools).to receive(:audio_stream?).with('/footage/clip.mov').and_return(false)
+    expect(Open3).not_to receive(:capture2e)
+    expect(job).not_to receive(:prepare_transcript)
+
+    job.perform
+
+    expect_no_dialogue_transcript
+  end
+
+  # whisperx 3.8+ handles a silent audio stream itself: it logs the no-speech
+  # warning but exits 0 with {"segments": []}. That gets the same no-dialogue
+  # note as a clip with no audio stream, so silence looks the same on disk.
+  it 'normalizes an empty whisperx transcript to the no-dialogue transcript' do
+    stub_whisperx(json: SILENT, output: "WARNING - No active speech found in audio\n")
+    expect(job).not_to receive(:prepare_transcript)
+
+    job.perform
+
+    expect_no_dialogue_transcript
+  end
+
+  it 'rescues a no-speech clip when an older whisperx exits non-zero without writing anything' do
+    stub_whisperx_failure("WARNING - No active speech found in audio\n")
+
+    job.perform
+
+    expect_no_dialogue_transcript
+  end
+
+  it 'rescues a no-speech clip when whisperx exits 0 without writing anything' do
+    stub_whisperx(json: nil, output: "WARNING - No active speech found in audio\n")
+
+    job.perform
+
+    expect_no_dialogue_transcript
+  end
+
+  # Reported from the field and not reproduced: exit 0, no file, no no-speech
+  # warning. The message has to carry whisperx's output — it's all we'll get.
+  it 'raises with the whisperx output when it exits 0 with no transcript and no explanation' do
+    stub_whisperx(json: nil, output: "something odd happened\n")
+
+    expect { job.perform }.to raise_error do |error|
+      expect(error.message).to include('exited 0 but produced no transcript')
+      expect(error.message).to include('something odd happened')
     end
-  end
-
-  it 'raises when whisperx exits 0 with no transcript and no no-speech notice' do
-    stub_whisperx("some unrelated noise\n", success: true)
-
-    expect { job.perform }.to raise_error("whisperx produced no transcript at #{transcript_path}")
   end
 
   # A Python traceback means whisperx itself is broken (a stale venv), not the
   # clip — the error must point at the requirements.txt resync so any session
   # can self-heal, even one updated by an older skill that didn't sync the venv.
   it 'points at the venv resync when whisperx dies with a Python traceback' do
-    stub_whisperx(<<~OUTPUT, success: false)
+    stub_whisperx_failure(<<~OUTPUT)
       Traceback (most recent call last):
         File "whisperx/asr.py", line 16, in <module>
       AttributeError: module 'torchaudio' has no attribute 'AudioMetaData'
@@ -80,8 +147,40 @@ RSpec.describe TranscribeJob do
     end
   end
 
+  # whisperx's load_audio raises "Failed to load audio" — as a traceback — when
+  # ffmpeg can't decode the stream ffprobe reported. That's the footage, and
+  # the message must not send the user off to reinstall WhisperX.
+  it 'blames the footage, not the install, when whisperx cannot decode the audio' do
+    stub_whisperx_failure(<<~OUTPUT)
+      Traceback (most recent call last):
+        File "whisperx/audio.py", line 63, in load_audio
+      RuntimeError: Failed to load audio: Output file does not contain any stream
+    OUTPUT
+
+    expect { job.perform }.to raise_error do |error|
+      expect(error.message).to include("couldn't decode the audio in clip.mov")
+      expect(error.message).not_to include('pip install')
+      expect(error.message).to include('does not contain any stream')
+    end
+  end
+
+  # The wrapper script older installs run whisperx through ends in
+  # `deactivate`, so the shell reports 0 for every crash. Neither report
+  # below may depend on the exit status.
+  it 'still diagnoses a stale install when the traceback arrives with exit 0' do
+    stub_whisperx(json: nil, output: "Traceback (most recent call last):\nAttributeError: module 'torchaudio' has no attribute 'AudioMetaData'\n")
+
+    expect { job.perform }.to raise_error(/pip install .*-r requirements\.txt/)
+  end
+
+  it 'still blames the footage when the decode failure arrives with exit 0' do
+    stub_whisperx(json: nil, output: "Traceback (most recent call last):\nRuntimeError: Failed to load audio: Output file does not contain any stream\n")
+
+    expect { job.perform }.to raise_error(/couldn't decode the audio in clip.mov/)
+  end
+
   it 'raises the plain failure message when whisperx fails without a traceback' do
-    stub_whisperx("some ffmpeg decode noise\n", success: false)
+    stub_whisperx_failure("some ffmpeg decode noise\n")
 
     expect { job.perform }.to raise_error('whisperx failed for clip.mov (exit 1)')
   end


### PR DESCRIPTION
Brings two transcription fixes across from ButterCut Pro, where they shipped as `core:` commits, so core installs get the same behavior.

**Rescue silent clips when whisperx exits 0 without writing a transcript.** Some WhisperX builds handle a no-dialogue clip by printing the no-speech notice and exiting 0 with no output JSON. The rescue used to key on a non-zero exit, so those runs raised "produced no transcript" instead of recording the clip as silent.

**Handle B-roll that is silent or has no audio track.** Each clip is probed with ffprobe first; a clip with no audio stream gets the no-dialogue transcript without running whisperx. An empty-segments transcript from whisperx 3.8+ is normalized to the same no-dialogue file. The job now reads the outcome from the evidence (output file, no-speech marker, traceback) before trusting the exit status, because the old `~/.buttercut/whisperx` wrapper ended in `deactivate` and reported 0 for every crash. `MediaTools.whisperx` runs the venv binary directly when it exists; both setup docs now write an `exec` wrapper, and the update skill rewrites the old shape on existing installs. A "Failed to load audio" traceback now blames the footage rather than the install.

Differences from the Pro versions: core writes the transcript straight into the output dir (Pro moves it out of a per-job temp dir, which arrived with a Pro-only audio-clip change), and the ffprobe spec uses one of core's `.mov` fixtures instead of Pro's wav fixture. Core's `advanced-setup.md` wrapper is updated too, since it had the same `deactivate` shape.

Not addressed here: ButterCut report 9 (pyannote VAD dropping clear speech on WhisperX 3.8.6). With this change a clip pyannote misses entirely gets a no-dialogue transcript rather than an error, so that report still needs its own fix.

Full suite: 439 examples, 0 failures.